### PR TITLE
fix: Main menu background switcher

### DIFF
--- a/scripts/mainmenu.js
+++ b/scripts/mainmenu.js
@@ -294,7 +294,7 @@ class MainMenuController {
 	static toggleBackgroundLightDark() {
 		$.persistentStorage.setItem(
 			'settings.mainMenuBackground',
-			!$.persistentStorage.getItem('settings.mainMenuBackground')
+			$.persistentStorage.getItem('settings.mainMenuBackground') === 0 ? 1 : 0
 		);
 
 		this.setMainMenuBackground();


### PR DESCRIPTION
Stupid mistake, I was treating settings.mainMenuBackground as a bool here, but we store it as an int for if we want to add additional backgrounds in the future.