### PR TITLE
Add scripts to get js types file

### DIFF
--- a/tools/get_latest_js_types.bat
+++ b/tools/get_latest_js_types.bat
@@ -1,0 +1,11 @@
+@echo off
+:: Get latest types file and plop it in scripts
+
+powershell Invoke-WebRequest https://github.com/panorama-languages-support/panorama-jsdoc-gen/releases/latest/download/types_momentum.zip -OutFile types.zip
+
+tar -xf types.zip -C ./
+DEL types.zip
+
+MOVE .\__types_momentum.js ..\scripts\
+
+PAUSE

--- a/tools/get_latest_js_types.sh
+++ b/tools/get_latest_js_types.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Get latest types file and cram it into scripts
+
+wget "https://github.com/panorama-languages-support/panorama-jsdoc-gen/releases/latest/download/types_momentum.zip"
+
+tar -xvf types_momentum.zip
+
+rm -v types_momentum.zip
+
+mv -v __types_momentum.js ../scripts/
+
+exit


### PR DESCRIPTION
Forgot to move this over to the public repo. Also re-ran on a new dumps files so will have a lot more types! (https://github.com/panorama-languages-support/panorama-jsdoc-gen/releases/tag/0.2.1)
