### PR TITLE
feat: adjust menus to scale better with aspect ratio

### DIFF
--- a/layout/mainmenu.xml
+++ b/layout/mainmenu.xml
@@ -45,14 +45,18 @@
 		<Panel id="MainMenuInput" class="mainmenu">
 			<!-- Topnav -->
 			<Panel id="MainMenuNavBar" class="topnav" style="z-index: 10;">
-
 				<RadioButton
 					id="HomeButton"
 					group="TopNavRadio"
 					class="topnav__home"
 					onactivate="MainMenuController.onHomeButtonPressed()"
 				>
-					<Image class="topnav__logo" src="file://{images}/momentumLogo.svg" textureheight="64" />
+					<Image
+						class="topnav__logo"
+						src="file://{images}/momentumLogo.svg"
+						textureheight="64"
+						scaling="stretch-to-fit-preserve-aspect"
+					/>
 				</RadioButton>
 
 				<Panel id="MainMenuTopButtons" class="full-height flow-right">

--- a/layout/mainmenu.xml
+++ b/layout/mainmenu.xml
@@ -220,16 +220,20 @@
 
 						<Panel id="HomeContent" class="mainmenu__home-container home MainMenuModeOnly">
 
-							<Frame id="NewsPanel" class="home__newspanel" src="file://{resources}/layout/mainmenu_news.xml" />
+							<Panel id="NewsModelWrapper" class="home__wrapper">
 
-							<ModelPanel
-								id="MainMenuModel"
-								class="home__modelpanel"
-								src="models/custom_props/hd_logo.mdl"
-								cubemap="cubemaps/cubemap_menu_model_bg.hdr"
-								antialias="true"
-								mouse_rotate="true"
-							/>
+								<Frame id="NewsPanel" class="home__newspanel" src="file://{resources}/layout/mainmenu_news.xml" />
+
+								<ModelPanel
+									id="MainMenuModel"
+									class="home__modelpanel"
+									src="models/custom_props/hd_logo.mdl"
+									cubemap="cubemaps/cubemap_menu_model_bg.hdr"
+									antialias="true"
+									mouse_rotate="true"
+								/>
+
+							</Panel>
 
 							<Panel class="home__bottombar bottombar">
 

--- a/layout/mainmenu/mapselector/selector.xml
+++ b/layout/mainmenu/mapselector/selector.xml
@@ -36,7 +36,7 @@
 								group="CategoryListNavBar"
 								onactivate='$("#CategoryContents").SetHasClass("mapselector__category-contents--playlists", true)'
 							>
-<Panel class="flow-right horizontal-align-center">
+						<Panel class="flow-right horizontal-align-center">
 							<Image class="mapselector-category-tabs__image" src="file://{images}/playlist-play.svg" textureheight="32" />
 							<Label class="text-h mapselector-category-tabs__text" text="#MapSelector_Playlists" />
 						</Panel>
@@ -76,77 +76,79 @@
 							</Panel>
 						</Panel>
 						<Panel id="MapFilters" class="mapselector-filters mapselector-filters--filters-retracted">
-							<Panel id="GamemodeFilters" class="mapselector-filters__row mapselector-filters__gamemodes">
-								<ToggleButton
-											id="SurfFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_Surf" />
-								</ToggleButton>
-								<ToggleButton
-											id="BhopFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_Bhop" />
-								</ToggleButton>
-								<ToggleButton
-											id="ClimbFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_Climb" />
-								</ToggleButton>
-								<ToggleButton
-											id="RJFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_RJ" />
-								</ToggleButton>
-								<ToggleButton
-											id="SJFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_SJ" />
-								</ToggleButton>
-								<ToggleButton
-											id="TricksurfFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_Tricksurf" />
-								</ToggleButton>
-								<ToggleButton
-											id="AhopFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_Ahop" />
-								</ToggleButton>
-								<ToggleButton
-											id="ParkourFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_Parkour" />
-								</ToggleButton>
-								<ToggleButton
-											id="ConcFilterButton"
-											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_Conc" />
-								</ToggleButton>
-								<ToggleButton
-											id="DefragFilterButton"
-											class="button togglebutton togglebutton--blue mapselector-filters__button"
-											selected="true"
-										>
-									<Label class="button__text mapselector-filters__text" text="#Gamemode_Defrag" />
-								</ToggleButton>
+							<Panel class="full-width">
+								<Panel id="GamemodeFilters" class="mapselector-filters__row mapselector-filters__gamemodes">
+									<ToggleButton
+												id="SurfFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_Surf" />
+									</ToggleButton>
+									<ToggleButton
+												id="BhopFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_Bhop" />
+									</ToggleButton>
+									<ToggleButton
+												id="ClimbFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_Climb" />
+									</ToggleButton>
+									<ToggleButton
+												id="RJFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_RJ" />
+									</ToggleButton>
+									<ToggleButton
+												id="SJFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_SJ" />
+									</ToggleButton>
+									<ToggleButton
+												id="TricksurfFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_Tricksurf" />
+									</ToggleButton>
+									<ToggleButton
+												id="AhopFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_Ahop" />
+									</ToggleButton>
+									<ToggleButton
+												id="ParkourFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_Parkour" />
+									</ToggleButton>
+									<ToggleButton
+												id="ConcFilterButton"
+												class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_Conc" />
+									</ToggleButton>
+									<ToggleButton
+												id="DefragFilterButton"
+												class="button togglebutton togglebutton--blue mapselector-filters__button"
+												selected="true"
+											>
+										<Label class="button__text mapselector-filters__text" text="#Gamemode_Defrag" />
+									</ToggleButton>
+								</Panel>
 							</Panel>
 
 							<Panel class="mapselector-filters__row">

--- a/layout/mainmenu/mapselector/selector.xml
+++ b/layout/mainmenu/mapselector/selector.xml
@@ -9,400 +9,394 @@
 
 	<MomentumMapSelect>
 		<Panel id="MapSelectorContents" class="mapselector">
-			<Panel id="MapSelectorLeft" class="mapselector__left">
-				<Panel class="mapselector__left-wrapper">
-					<Panel class="mapselector-category-tabs">
-						<RadioButton
-							id="CategoryListMaps"
-							class="mapselector-category-tabs__tab"
-							group="CategoryListNavBar"
-							selected="true"
-							onactivate='$("#CategoryContents").SetHasClass("mapselector__category-contents--playlists", false)'
-						>
-							<Panel class="flow-right horizontal-align-center">
+			<Panel id="MapSelectorLeftContainer" class="mapselector__left-container">
+				<Panel id="MapSelectorLeft" class="mapselector__left">
+					<Panel class="mapselector__left-wrapper">
+						<Panel class="mapselector-category-tabs">
+							<RadioButton
+								id="CategoryListMaps"
+								class="mapselector-category-tabs__tab"
+								group="CategoryListNavBar"
+								selected="true"
+								onactivate='$("#CategoryContents").SetHasClass("mapselector__category-contents--playlists", false)'
+							>
+<Panel class="flow-right horizontal-align-center">
 								<Image
-									class="mapselector-category-tabs__image"
-									src="file://{images}/panorama-variant.svg"
-									textureheight="32"
-									style="padding: 1px;"
-								/>
+										class="mapselector-category-tabs__image"
+										src="file://{images}/panorama-variant.svg"
+										textureheight="32"
+										style="padding: 1px;"
+									/>
 								<Label class="text-h mapselector-category-tabs__text" text="#MapSelector_Maps" />
 							</Panel>
 						</RadioButton>
 						<RadioButton
-							id="CategoryListPlaylists"
-							class="mapselector-category-tabs__tab"
-							group="CategoryListNavBar"
-							onactivate='$("#CategoryContents").SetHasClass("mapselector__category-contents--playlists", true)'
-						>
-							<Panel class="flow-right horizontal-align-center">
-								<Image class="mapselector-category-tabs__image" src="file://{images}/playlist-play.svg" textureheight="32" />
-								<Label class="text-h mapselector-category-tabs__text" text="#MapSelector_Playlists" />
-							</Panel>
-						</RadioButton>
-					</Panel>
+								id="CategoryListPlaylists"
+								class="mapselector-category-tabs__tab"
+								group="CategoryListNavBar"
+								onactivate='$("#CategoryContents").SetHasClass("mapselector__category-contents--playlists", true)'
+							>
+<Panel class="flow-right horizontal-align-center">
+							<Image class="mapselector-category-tabs__image" src="file://{images}/playlist-play.svg" textureheight="32" />
+							<Label class="text-h mapselector-category-tabs__text" text="#MapSelector_Playlists" />
+						</Panel>
+					</RadioButton>
+				</Panel>
 
-					<Panel id="CategoryContents" class="mapselector__category-contents">
-						<Panel id="MapSelector" class="mapselector__maps">
-							<Panel class="mapselector-header">
-								<Panel class="search mapselector-header__search">
-									<Image class="search__icon" src="file://{images}/search.svg" textureheight="32" />
-									<TextEntry id="MapSearchTextEntry" class="search__textentry" maxchars="30" placeholder="Search Maps" />
-									<Button
-										id="MapSearchClear"
-										class="search__clearbutton search__clearbutton--hidden"
-										onactivate="MapSelection.clearSearch()"
-									>
-										<Image class="search__clearicon" src="file://{images}/close.svg" textureheight="32" />
-									</Button>
-								</Panel>
-								<Panel class="mapselector-header__filters">
-									<Button class="button button--green ml-2" onactivate="MapSelection.requestMapUpdate()">
-										<Label class="button__text" text="#Common_Update" />
-									</Button>
-									<ToggleButton
-										id="FilterToggle"
-										class="ml-2 button togglebutton togglebutton--blue"
-										selected="false"
-										onactivate="MapSelection.toggleFilterCollapse()"
-									>
-										<Label class="button__text button__text--left" text="#MapSelector_Filters" />
-										<Image class="button__icon button__icon--right" src="file://{images}/filter-menu.svg" textureheight="32" />
-									</ToggleButton>
-									<TooltipPanel tooltip="#MapSelector_Filters_Reset">
-										<Button id="FilterErase" class="ml-2 button button--red" onactivate="MapSelection.clearFilters()">
-											<Image class="button__icon" src="file://{images}/filter-remove.svg" textureheight="32" />
-										</Button>
-									</TooltipPanel>
-								</Panel>
+				<Panel id="CategoryContents" class="mapselector__category-contents">
+					<Panel id="MapSelector" class="mapselector__maps">
+						<Panel class="mapselector-header">
+							<Panel class="search mapselector-header__search">
+								<Image class="search__icon" src="file://{images}/search.svg" textureheight="32" />
+								<TextEntry id="MapSearchTextEntry" class="search__textentry" maxchars="30" placeholder="#MapSelector_SearchMaps" />
+								<Button
+											id="MapSearchClear"
+											class="search__clearbutton search__clearbutton--hidden"
+											onactivate="MapSelection.clearSearch()"
+										>
+									<Image class="search__clearicon" src="file://{images}/close.svg" textureheight="32" />
+								</Button>
 							</Panel>
-							<Panel id="MapFilters" class="mapselector-filters mapselector-filters--filters-retracted">
-								<Panel id="GamemodeFilters" class="mapselector-filters__row mapselector-filters__gamemodes">
-									<ToggleButton
-										id="SurfFilterButton"
-										class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-										selected="true"
-									>
-										<Label class="button__text mapselector-filters__text" text="#Gamemode_Surf" />
-									</ToggleButton>
-									<ToggleButton
-										id="BhopFilterButton"
-										class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-										selected="true"
-									>
-										<Label class="button__text mapselector-filters__text" text="#Gamemode_Bhop" />
-									</ToggleButton>
-									<TooltipPanel tooltip="#Common_ComingAfterRelease">
-										<ToggleButton
+							<Panel class="mapselector-header__filters">
+								<Button class="button button--green ml-2" onactivate="MapSelection.requestMapUpdate()">
+									<Label class="button__text" text="#Common_Update" />
+								</Button>
+								<ToggleButton
+											id="FilterToggle"
+											class="ml-2 button togglebutton togglebutton--blue"
+											selected="false"
+											onactivate="MapSelection.toggleFilterCollapse()"
+										>
+									<Label class="button__text button__text--left" text="#MapSelector_Filters" />
+									<Image class="button__icon button__icon--right" src="file://{images}/filter-menu.svg" textureheight="32" />
+								</ToggleButton>
+								<Button id="FilterErase" class="ml-2 button button--red" onactivate="MapSelection.clearFilters()">
+									<Image class="button__icon" src="file://{images}/filter-remove.svg" textureheight="32" />
+								</Button>
+							</Panel>
+						</Panel>
+						<Panel id="MapFilters" class="mapselector-filters mapselector-filters--filters-retracted">
+							<Panel id="GamemodeFilters" class="mapselector-filters__row mapselector-filters__gamemodes">
+								<ToggleButton
+											id="SurfFilterButton"
+											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+											selected="true"
+										>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_Surf" />
+								</ToggleButton>
+								<ToggleButton
+											id="BhopFilterButton"
+											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+											selected="true"
+										>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_Bhop" />
+								</ToggleButton>
+								<ToggleButton
 											id="ClimbFilterButton"
 											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
 											selected="true"
 										>
-											<Label class="button__text mapselector-filters__text" text="#Gamemode_Climb" />
-										</ToggleButton>
-									</TooltipPanel>
-									<ToggleButton
-										id="RJFilterButton"
-										class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-										selected="true"
-									>
-										<Label class="button__text mapselector-filters__text" text="#Gamemode_RJ" />
-									</ToggleButton>
-									<ToggleButton
-										id="SJFilterButton"
-										class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-										selected="true"
-									>
-										<Label class="button__text mapselector-filters__text" text="#Gamemode_SJ" />
-									</ToggleButton>
-									<ToggleButton
-										id="TricksurfFilterButton"
-										class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-										selected="true"
-									>
-										<Label class="button__text mapselector-filters__text" text="#Gamemode_Tricksurf" />
-									</ToggleButton>
-									<ToggleButton
-										id="AhopFilterButton"
-										class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-										selected="true"
-									>
-										<Label class="button__text mapselector-filters__text" text="#Gamemode_Ahop" />
-									</ToggleButton>
-									<TooltipPanel tooltip="#Common_ComingAfterRelease">
-										<ToggleButton
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_Climb" />
+								</ToggleButton>
+								<ToggleButton
+											id="RJFilterButton"
+											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+											selected="true"
+										>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_RJ" />
+								</ToggleButton>
+								<ToggleButton
+											id="SJFilterButton"
+											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+											selected="true"
+										>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_SJ" />
+								</ToggleButton>
+								<ToggleButton
+											id="TricksurfFilterButton"
+											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+											selected="true"
+										>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_Tricksurf" />
+								</ToggleButton>
+								<ToggleButton
+											id="AhopFilterButton"
+											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+											selected="true"
+										>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_Ahop" />
+								</ToggleButton>
+								<ToggleButton
 											id="ParkourFilterButton"
 											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
 											selected="true"
 										>
-											<Label class="button__text mapselector-filters__text" text="#Gamemode_Parkour" />
-										</ToggleButton>
-									</TooltipPanel>
-									<ToggleButton
-										id="ConcFilterButton"
-										class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
-										selected="true"
-									>
-										<Label class="button__text mapselector-filters__text" text="#Gamemode_Conc" />
-									</ToggleButton>
-									<ToggleButton
-										id="DefragFilterButton"
-										class="button togglebutton togglebutton--blue mapselector-filters__button"
-										selected="true"
-									>
-										<Label class="button__text mapselector-filters__text" text="#Gamemode_Defrag" />
-									</ToggleButton>
-								</Panel>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_Parkour" />
+								</ToggleButton>
+								<ToggleButton
+											id="ConcFilterButton"
+											class="mr-1 button togglebutton togglebutton--blue mapselector-filters__button"
+											selected="true"
+										>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_Conc" />
+								</ToggleButton>
+								<ToggleButton
+											id="DefragFilterButton"
+											class="button togglebutton togglebutton--blue mapselector-filters__button"
+											selected="true"
+										>
+									<Label class="button__text mapselector-filters__text" text="#Gamemode_Defrag" />
+								</ToggleButton>
+							</Panel>
 
-								<Panel class="mapselector-filters__row">
-									<Panel class="mapselector-filters__tiers">
-										<Label class="text-h5 mr-2 vertical-align-center" text="#MapSelector_Filters_Tier" />
-										<Panel class="mapselector-tier-slider">
-											<Panel class="mapselector-tier-slider__numbers">
-												<Label class="mapselector-tier-slider__number" text="1" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number" text="2" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number" text="3" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number" text="4" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number" text="5" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number" text="6" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number" text="7" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number" text="8" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number" text="9" />
-												<Panel class="mapselector-tier-slider__gap" />
-												<Label class="mapselector-tier-slider__number mapselector-tier-slider__number--double-digit" text="10" />
-											</Panel>
-											<DualSlider
-												id="TierSlider"
-												class="slider slider--horizontal mapselector-tier-slider__slider"
-												snaptoincrement="true"
-												direction="horizontal"
-												min="1"
-												max="10"
-												increment="1"
-												default="1"
-												default2="10"
-												value="1"
-												value2="10"
-											/>
+							<Panel class="mapselector-filters__row">
+								<Panel class="mapselector-filters__tiers">
+									<Label class="text-h5 mr-2 vertical-align-center" text="Tiers" />
+									<Panel class="mapselector-tier-slider">
+										<Panel class="mapselector-tier-slider__numbers">
+											<Label class="mapselector-tier-slider__number" text="1" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number" text="2" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number" text="3" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number" text="4" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number" text="5" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number" text="6" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number" text="7" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number" text="8" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number" text="9" />
+											<Panel class="mapselector-tier-slider__gap" />
+											<Label class="mapselector-tier-slider__number mapselector-tier-slider__number--double-digit" text="10" />
 										</Panel>
-									</Panel>
-									<Panel class="horizontal-align-right flow-right">
-										<TooltipPanel tooltip="#MapSelector_Filters_ByCompleted">
-											<NStateButton id="MapCompletedFilterButton" class="button nstatebutton mapselector-filters__nstatebutton mr-2">
-												<Image class="button__icon" src="file://{images}/flag.svg" textureheight="32" />
-											</NStateButton>
-										</TooltipPanel>
-										<TooltipPanel tooltip="#MapSelector_Filters_ByFavorited">
-											<NStateButton id="MapFavoritedFilterButton" class="button nstatebutton mapselector-filters__nstatebutton mr-2">
-												<Image class="button__icon" src="file://{images}/star.svg" textureheight="32" />
-											</NStateButton>
-										</TooltipPanel>
-										<TooltipPanel tooltip="#MapSelector_Filters_ByDownloaded">
-											<NStateButton id="MapDownloadedFilterButton" class="button nstatebutton mapselector-filters__nstatebutton">
-												<Image class="button__icon" src="file://{images}/download.svg" textureheight="32" />
-											</NStateButton>
-										</TooltipPanel>
+										<DualSlider
+													id="TierSlider"
+													class="slider slider--horizontal mapselector-tier-slider__slider"
+													snaptoincrement="true"
+													direction="horizontal"
+													min="1"
+													max="10"
+													increment="1"
+													default="1"
+													default2="10"
+													value="1"
+													value2="10"
+												/>
 									</Panel>
 								</Panel>
-							</Panel>
-
-							<Panel id="TabsAndSortBy" class="mapselector-sorting">
-								<Panel class="tabs mapselector-sorting__tabs">
-									<RadioButton id="MapListRanked" class="tabs__tab mapselector-sorting__tab" group="MapListNavBar" selected="true">
-										<Label class="tabs__text" text="#MapSelector_Tabs_Ranked" />
-									</RadioButton>
-									<Panel class="tabs__gap" />
-									<RadioButton id="MapListUnranked" class="tabs__tab mapselector-sorting__tab" group="MapListNavBar">
-										<Label class="tabs__text" text="#MapSelector_Tabs_Unranked" />
-									</RadioButton>
-									<Panel class="tabs__gap" />
-									<RadioButton id="MapListBeta" class="tabs__tab mapselector-sorting__tab" group="MapListNavBar">
-										<Label class="tabs__text" text="#MapSelector_Tabs_Beta" />
-									</RadioButton>
-								</Panel>
-								<Panel id="SortBy" class="mapselector-sorting__sort">
-									<DropDown id="SortByDropdown" class="dropdown sorting__dropdown" menuclass="dropdown-menu">
-										<Label text="#MapSelector_Sorting_DateReleased_Asc" id="dateRelAsc" value="6" />
-										<Label text="#MapSelector_Sorting_DateReleased_Desc" id="dateRelDesc" value="7" />
-										<Label text="#MapSelector_Sorting_Alphabetical_Asc" id="alphaAsc" value="0" />
-										<Label text="#MapSelector_Sorting_Alphabetical_Desc" id="alphaDesc" value="1" />
-										<Label text="#MapSelector_Sorting_Tier_Asc" id="tierAsc" value="2" />
-										<Label text="#MapSelector_Sorting_Tier_Desc" id="tierDesc" value="3" />
-										<Label text="#MapSelector_Sorting_LastPlayed_Asc" id="lastPlayAsc" value="4" />
-										<Label text="#MapSelector_Sorting_LastPlayed_Desc" id="lastPlayDesc" value="5" />
-										<Label text="#MapSelector_Sorting_DateCreated_Asc" id="dateCreatedAsc" value="8" />
-										<Label text="#MapSelector_Sorting_DateCreated_Desc" id="dateCreatedDesc" value="9" />
-									</DropDown>
-								</Panel>
-							</Panel>
-
-							<Panel class="full-width">
-								<DelayLoadList
-									id="MapListContainer"
-									class="mapselector__list"
-									itemheight="54px"
-									itemwidth="100%"
-									spacersize="3px"
-									spacerperiod="1"
-								>
-									<!-- Populated via MapEntry snippets in code -->
-								</DelayLoadList>
-								<Panel id="MapListEmptyContainer" class="mapselector__emptywarning mapselector__emptywarning--hidden">
-									<Label class="text-h2 horizontal-align-center mb-4" text="#MapSelector_Error_NoMapsFound" />
-									<Label class="horizontal-align-center text-align-center full-height" text="#MapSelector_Error_NoMapsFound_Long" />
+								<Panel class="horizontal-align-right flow-right">
+									<TooltipPanel tooltip="&lt;b&gt;Filter by&lt;/b&gt;: Completed">
+										<NStateButton id="MapCompletedFilterButton" class="button nstatebutton mapselector-filters__nstatebutton mr-2">
+											<Image class="button__icon" src="file://{images}/flag.svg" textureheight="32" />
+										</NStateButton>
+									</TooltipPanel>
+									<TooltipPanel tooltip="&lt;b&gt;Filter by&lt;/b&gt;: Favorited">
+										<NStateButton id="MapFavoritedFilterButton" class="button nstatebutton mapselector-filters__nstatebutton mr-2">
+											<Image class="button__icon" src="file://{images}/star.svg" textureheight="32" />
+										</NStateButton>
+									</TooltipPanel>
+									<TooltipPanel tooltip="&lt;b&gt;Filter by&lt;/b&gt;: Downloaded">
+										<NStateButton id="MapDownloadedFilterButton" class="button nstatebutton mapselector-filters__nstatebutton">
+											<Image class="button__icon" src="file://{images}/download.svg" textureheight="32" />
+										</NStateButton>
+									</TooltipPanel>
 								</Panel>
 							</Panel>
 						</Panel>
 
-						<!-- Playlist Selector -->
-						<Panel id="PlaylistSelector" class="mapselector__playlists">
-							<Panel class="full-height full-width">
-								<Label class="text-h1 text-align-center horizontal-align-center mt-5" text="#Common_ComingSoon" />
+						<Panel id="TabsAndSortBy" class="mapselector-sorting">
+							<Panel class="tabs mapselector-sorting__tabs">
+								<RadioButton id="MapListRanked" class="tabs__tab mapselector-sorting__tab" group="MapListNavBar" selected="true">
+									<Label class="tabs__text" text="#MapSelector_Tabs_Ranked" />
+								</RadioButton>
+								<Panel class="tabs__gap" />
+								<RadioButton id="MapListUnranked" class="tabs__tab mapselector-sorting__tab" group="MapListNavBar">
+									<Label class="tabs__text" text="#MapSelector_Tabs_Unranked" />
+								</RadioButton>
+								<Panel class="tabs__gap" />
+								<RadioButton id="MapListBeta" class="tabs__tab mapselector-sorting__tab" group="MapListNavBar">
+									<Label class="tabs__text" text="#MapSelector_Tabs_Beta" />
+								</RadioButton>
 							</Panel>
+							<Panel id="SortBy" class="mapselector-sorting__sort">
+								<DropDown id="SortByDropdown" class="dropdown sorting__dropdown" menuclass="dropdown-menu">
+									<Label text="#MapSelector_Sorting_DateReleased_Asc" id="dateRelAsc" value="6" />
+									<Label text="#MapSelector_Sorting_DateReleased_Desc" id="dateRelDesc" value="7" />
+									<Label text="#MapSelector_Sorting_Alphabetical_Asc" id="alphaAsc" value="0" />
+									<Label text="#MapSelector_Sorting_Alphabetical_Desc" id="alphaDesc" value="1" />
+									<Label text="#MapSelector_Sorting_Tier_Asc" id="tierAsc" value="2" />
+									<Label text="#MapSelector_Sorting_Tier_Desc" id="tierDesc" value="3" />
+									<Label text="#MapSelector_Sorting_LastPlayed_Asc" id="lastPlayAsc" value="4" />
+									<Label text="#MapSelector_Sorting_LastPlayed_Desc" id="lastPlayDesc" value="5" />
+									<Label text="#MapSelector_Sorting_DateCreated_Asc" id="dateCreatedAsc" value="8" />
+									<Label text="#MapSelector_Sorting_DateCreated_Desc" id="dateCreatedDesc" value="9" />
+								</DropDown>
+							</Panel>
+						</Panel>
+
+						<Panel class="full-width">
+							<DelayLoadList
+										id="MapListContainer"
+										class="mapselector__list"
+										itemheight="54px"
+										itemwidth="100%"
+										spacersize="3px"
+										spacerperiod="1"
+									>
+								<!-- Populated via MapEntry snippets in code -->
+							</DelayLoadList>
+							<Panel id="MapListEmptyContainer" class="mapselector__emptywarning mapselector__emptywarning--hidden">
+								<Label class="text-h2 horizontal-align-center mb-4" text="#MapSelector_Error_NoMapsFound" />
+								<Label class="horizontal-align-center text-align-center full-height" text="#MapSelector_Error_NoMapsFound_Long" />
+							</Panel>
+						</Panel>
+					</Panel>
+
+					<!-- Playlist Selector -->
+					<Panel id="PlaylistSelector" class="mapselector__playlists">
+						<Panel class="full-height full-width">
+							<Label class="text-h1 text-align-center horizontal-align-center mt-5" text="#Common_ComingSoon" />
 						</Panel>
 					</Panel>
 				</Panel>
 			</Panel>
+		</Panel>
+	</Panel>
 
-			<Panel class="mapselector__right">
-				<Panel id="MapTimes" class="mapselector-map-times">
-					<Panel class="mapselector-map-times__list-wrapper">
-						<Leaderboards id="Leaderboards" class="mapselector-map-times__list mapselector-map-times__list--hidden" />
+	<Panel class="mapselector__right">
+		<Panel id="MapTimes" class="mapselector-map-times">
+			<Panel class="mapselector-map-times__list-wrapper">
+				<Leaderboards id="Leaderboards" class="mapselector-map-times__list mapselector-map-times__list--hidden" />
+			</Panel>
+		</Panel>
+		<Panel id="MapInfo" class="mapselector-map-info">
+			<!-- Stacked labels to give double layers of shadow. I don't like it, but I'll have to go along with it. -->
+			<Panel>
+				<Label class="text-h1 text-shadow-outline" text="{s:name}" />
+				<Label class="text-h1 text-shadow-black color-transparent" text="{s:name}" />
+			</Panel>
+			<Panel class="mapselector-map-info__block">
+				<Panel class="mapselector-map-info__block-left">
+					<!-- TODO: This is a hack to get a stronger font shadow. Remove when doing sRGB styling! -->
+					<Label class="text-h4 text-shadow-outline" text="#MapSelector_Info_Stats" />
+					<Label class="text-h4 text-shadow-bold color-transparent" text="#MapSelector_Info_Stats" />
+				</Panel>
+				<Panel class="flow-right mapselector-map-info__block-right">
+					<Panel class="mapselector-map-info__action">
+						<Button id="MapInfoAction" class="button mapselector-action-button">
+							<Panel class="mapselector-action-button__typecontainer action-play">
+								<Image class="button__icon mapselector-action-button__icon" src="file://{images}/play-circle.svg" textureheight="40" />
+								<Label class="button__text mapselector-action-button__text" text="#MapSelector_Button_Play" />
+							</Panel>
+							<Panel class="mapselector-action-button__typecontainer action-download">
+								<Image class="button__icon mapselector-action-button__icon" src="file://{images}/download.svg" textureheight="40" />
+								<Label class="button__text mapselector-action-button__text" text="#MapSelector_Button_Download" />
+							</Panel>
+						</Button>
+						<MapDownloadStatus id="MapInfoDownloadStatus" class="map-download-status" />
 					</Panel>
 				</Panel>
-				<Panel id="MapInfo" class="mapselector-map-info">
-					<!-- Stacked labels to give double layers of shadow. I don't like it, but I'll have to go along with it. -->
-					<Panel>
-						<Label class="text-h1 text-shadow-outline" text="{s:name}" />
-						<Label class="text-h1 text-shadow-black color-transparent" text="{s:name}" />
-					</Panel>
-					<Panel class="mapselector-map-info__block">
-						<Panel class="mapselector-map-info__block-left">
-							<!-- TODO: This is a hack to get a stronger font shadow. Remove when doing sRGB styling! -->
-							<Label class="text-h4 text-shadow-outline" text="#MapSelector_Info_Stats" />
-							<Label class="text-h4 text-shadow-bold color-transparent" text="#MapSelector_Info_Stats" />
-						</Panel>
-						<Panel class="flow-right mapselector-map-info__block-right">
-							<Panel class="mapselector-map-info__action">
-								<Button id="MapInfoAction" class="button mapselector-action-button">
-									<Panel class="mapselector-action-button__typecontainer action-play">
-										<Image class="button__icon mapselector-action-button__icon" src="file://{images}/play-circle.svg" textureheight="40" />
-										<Label class="button__text mapselector-action-button__text" text="#MapSelector_Button_Play" />
-									</Panel>
-									<Panel class="mapselector-action-button__typecontainer action-download">
-										<Image class="button__icon mapselector-action-button__icon" src="file://{images}/download.svg" textureheight="40" />
-										<Label class="button__text mapselector-action-button__text" text="#MapSelector_Button_Download" />
-									</Panel>
-								</Button>
-								<MapDownloadStatus id="MapInfoDownloadStatus" class="map-download-status" />
-							</Panel>
-						</Panel>
-					</Panel>
-					<!-- <Panel class="map-info-gallery_container">
+			</Panel>
+			<!-- <Panel class="map-info-gallery_container">
 						<Panel class="map-info-gallery" />
 					</Panel> -->
-					<Panel class="mapselector-map-info__content">
-						<Panel id="MapDescription" class="mapselector-map-info__block-left mapselector-map-info__description">
-							<Panel class="mapselector-map-info__wrapper mapselector-map-info__wrapper--unpadded">
-								<Panel class="mapselector-map-info__description-scroll">
-									<Panel class="mapselector-map-info__description-main-elements">
-										<Panel id="MapDescriptionContainer" class="flow-down">
-											<Label class="text-h5 mb-1" text="#MapSelector_Info_Description" />
-											<Label class="mapselector-map-info__paragraph" text="{s:description}" />
-										</Panel>
-										<Panel id="MapCreditsContainer" class="flow-down mt-4">
-											<Label class="text-h5 mb-1" text="#MapSelector_Info_Authors" />
-											<Panel id="MapCredits" class="mapselector-credits">
-												<!-- Populated by JS -->
-											</Panel>
-										</Panel>
-										<Panel id="MapDatesContainer" class="flow-down mt-4">
-											<Label class="text-h5 mb-1" text="#MapSelector_Info_DateCreated" />
-											<Label class="mapselector-map-info__paragraph" text="{s:date}" />
-										</Panel>
-										<!-- <Label class="text-h5 mt-4 mb-1" text="#MapSelector_Info_Tags" />
-										<Label id="MapTags" class="mapselector-map-info__paragraph" />-->
-									</Panel>
-									<Button id="MapInfoWebsiteButton" class="mapselector-map-info__webbutton">
-										<Label class="mapselector-map-info__webbutton-text" text="#Action_ViewOnWebsite" />
-									</Button>
+			<Panel class="mapselector-map-info__content">
+				<Panel id="MapDescription" class="mapselector-map-info__block-left mapselector-map-info__description">
+					<Panel class="mapselector-map-info__wrapper mapselector-map-info__wrapper--unpadded">
+						<Panel class="mapselector-map-info__description-scroll">
+							<Panel class="mapselector-map-info__description-main-elements">
+								<Panel id="MapDescriptionContainer" class="flow-down full-width">
+									<Label class="text-h5 mb-1" text="#MapSelector_Info_Description" />
+									<Label class="mapselector-map-info__paragraph" text="{s:description}" />
 								</Panel>
+								<Panel id="MapCreditsContainer" class="flow-down mt-4">
+									<Label class="text-h5 mb-1" text="#MapSelector_Info_Authors" />
+									<Panel id="MapCredits" class="mapselector-credits">
+										<!-- Populated by JS -->
+									</Panel>
+								</Panel>
+								<Panel id="MapDatesContainer" class="flow-down mt-4">
+									<Label class="text-h5 mb-1" text="#MapSelector_Info_DateCreated" />
+									<Label class="mapselector-map-info__paragraph" text="{s:date}" />
+								</Panel>
+								<!-- <Label class="text-h5 mt-4 mb-1" text="#MapSelector_Info_Tags" />
+										<Label id="MapTags" class="mapselector-map-info__paragraph" />-->
 							</Panel>
+							<Button id="MapInfoWebsiteButton" class="mapselector-map-info__webbutton">
+								<Label class="mapselector-map-info__webbutton-text" text="#Action_ViewOnWebsite" />
+							</Button>
 						</Panel>
+					</Panel>
+				</Panel>
 
-						<Panel class="flow-down mapselector-map-info__block-right">
-							<Panel class="flow-right full-width pb-3">
-								<ToggleButton
+				<Panel class="flow-down mapselector-map-info__block-right">
+					<Panel class="flow-right full-width pb-3">
+						<ToggleButton
 									id="LeaderboardsBtn"
 									class="button togglebutton togglebutton--blue mapselector-map-info__leaderboard-button"
 									onactivate="MapSelection.toggleLeaderboards()"
 								>
-									<Panel class="flow-right  full-height horizontal-align-center">
-										<Image class="button__icon button__icon--left" src="file://{images}/chart-timeline.svg" textureheight="40" />
-										<Label class="button__text button__icon--right mr-3" text="#MapSelector_Button_Leaderboards" />
-									</Panel>
-								</ToggleButton>
-								<TooltipPanel tooltip="#MapSelector_Button_Favorite">
-									<ToggleButton id="MapInfoFavorite" class="button togglebutton togglebutton--yellow mapselector-map-info__square-button">
-										<Image class="button__icon" src="file://{images}/star.svg" textureheight="40" />
-									</ToggleButton>
-								</TooltipPanel>
-								<TooltipPanel tooltip="#MapSelector_Button_Gallery">
-									<Button id="MapInfoGallery" class="button mapselector-map-info__square-button">
-										<Image class="button__icon" src="file://{images}/fullscreen.svg" textureheight="40" />
-									</Button>
-								</TooltipPanel>
+							<Panel class="flow-right  full-height horizontal-align-center">
+								<Image class="button__icon button__icon--left" src="file://{images}/chart-timeline.svg" textureheight="40" />
+								<Label class="button__text button__icon--right mr-3" text="#MapSelector_Button_Leaderboards" />
 							</Panel>
-							<Panel id="MapInfoStats" class="mapselector-stats">
-								<Panel class="mapselector-map-info__wrapper">
-									<Label class="text-h5" text="#MapSelector_Stats" />
-									<Panel class="mapselector-stats__container">
-										<Panel class="mapselector-stats__column">
-											<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_PlaylistInstances">
-												<Image class="mapselector-stat__icon" src="file://{images}/playlist-plus.svg" textureheight="48" />
-												<Label class="mapselector-stat__text" text="{d:completesUnique}" />
-											</TooltipPanel>
-											<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_Favorites">
-												<Image class="mapselector-stat__icon" src="file://{images}/star.svg" textureheight="48" />
-												<Label class="mapselector-stat__text" text="{d:favorites}" />
-											</TooltipPanel>
-											<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_Downloads">
-												<Image class="mapselector-stat__icon" src="file://{images}/download.svg" textureheight="48" />
-												<Label class="mapselector-stat__text" text="{d:downloads}" />
-											</TooltipPanel>
-											<TooltipPanel class="mapselector-stat" tooltip="#Common_PersonalBest">
-												<Image class="mapselector-stat__icon" src="file://{images}/ranks/pb.svg" textureheight="48" />
-												<Label class="mapselector-stat__text" text="{s:pb}" />
-											</TooltipPanel>
-										</Panel>
-										<Panel class="vertical-separator mt-3" />
-										<Panel class="mapselector-stats__column mapselector-stats__column--right">
-											<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_Downloads">
-												<Image class="mapselector-stat__icon" src="file://{images}/play.svg" textureheight="48" />
-												<Label class="mapselector-stat__text" text="{d:plays}" />
-											</TooltipPanel>
-											<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_Completions">
-												<Image class="mapselector-stat__icon" src="file://{images}/flag.svg" textureheight="48" />
-												<Label class="mapselector-stat__text" text="{d:completes}" />
-											</TooltipPanel>
-											<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_PercentCompletion">
-												<Image class="mapselector-stat__icon" src="file://{images}/percent.svg" textureheight="48" />
-												<Label class="mapselector-stat__text" text="{s:avgTime}" />
-											</TooltipPanel>
-											<TooltipPanel class="mapselector-stat" tooltip="#Common_WorldRecord">
-												<Image class="mapselector-stat__icon" src="file://{images}/ranks/wr.svg" textureheight="48" />
-												<Label class="mapselector-stat__text" text="{s:wr}" />
-											</TooltipPanel>
-										</Panel>
-									</Panel>
+						</ToggleButton>
+						<TooltipPanel tooltip="#MapSelector_Button_Favorite">
+							<ToggleButton id="MapInfoFavorite" class="button togglebutton togglebutton--yellow mapselector-map-info__square-button">
+								<Image class="button__icon" src="file://{images}/star.svg" textureheight="40" />
+							</ToggleButton>
+						</TooltipPanel>
+						<TooltipPanel tooltip="#MapSelector_Button_Gallery">
+							<Button id="MapInfoGallery" class="button mapselector-map-info__square-button">
+								<Image class="button__icon" src="file://{images}/fullscreen.svg" textureheight="40" />
+							</Button>
+						</TooltipPanel>
+					</Panel>
+					<Panel id="MapInfoStats" class="mapselector-stats">
+						<Panel class="mapselector-map-info__wrapper">
+							<Label class="text-h5" text="#MapSelector_Stats" />
+							<Panel class="mapselector-stats__container">
+								<Panel class="mapselector-stats__column">
+									<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_PlaylistInstances">
+										<Image class="mapselector-stat__icon" src="file://{images}/playlist-plus.svg" textureheight="48" />
+										<Label class="mapselector-stat__text" text="{d:completesUnique}" />
+									</TooltipPanel>
+									<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_Favorites">
+										<Image class="mapselector-stat__icon" src="file://{images}/star.svg" textureheight="48" />
+										<Label class="mapselector-stat__text" text="{d:favorites}" />
+									</TooltipPanel>
+									<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_Downloads">
+										<Image class="mapselector-stat__icon" src="file://{images}/download.svg" textureheight="48" />
+										<Label class="mapselector-stat__text" text="{d:downloads}" />
+									</TooltipPanel>
+									<TooltipPanel class="mapselector-stat" tooltip="#Common_PersonalBest">
+										<Image class="mapselector-stat__icon" src="file://{images}/ranks/pb.svg" textureheight="48" />
+										<Label class="mapselector-stat__text" text="{s:pb}" />
+									</TooltipPanel>
+								</Panel>
+								<Panel class="vertical-separator mt-3" />
+								<Panel class="mapselector-stats__column mapselector-stats__column--right">
+									<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_Downloads">
+										<Image class="mapselector-stat__icon" src="file://{images}/play.svg" textureheight="48" />
+										<Label class="mapselector-stat__text" text="{d:plays}" />
+									</TooltipPanel>
+									<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_Completions">
+										<Image class="mapselector-stat__icon" src="file://{images}/flag.svg" textureheight="48" />
+										<Label class="mapselector-stat__text" text="{d:completes}" />
+									</TooltipPanel>
+									<TooltipPanel class="mapselector-stat" tooltip="#MapSelector_Stats_PercentCompletion">
+										<Image class="mapselector-stat__icon" src="file://{images}/percent.svg" textureheight="48" />
+										<Label class="mapselector-stat__text" text="{s:avgTime}" />
+									</TooltipPanel>
+									<TooltipPanel class="mapselector-stat" tooltip="#Common_WorldRecord">
+										<Image class="mapselector-stat__icon" src="file://{images}/ranks/wr.svg" textureheight="48" />
+										<Label class="mapselector-stat__text" text="{s:wr}" />
+									</TooltipPanel>
 								</Panel>
 							</Panel>
 						</Panel>
@@ -410,5 +404,7 @@
 				</Panel>
 			</Panel>
 		</Panel>
-	</MomentumMapSelect>
+	</Panel>
+</Panel>
+</MomentumMapSelect>
 </root>

--- a/styles/components/mapentry.scss
+++ b/styles/components/mapentry.scss
@@ -75,7 +75,7 @@ $transition: 0.125s ease-out 0s;
 			vertical-align: middle;
 			horizontal-align: right;
 			height: 100%;
-			width: 55%;
+			width: fit-children;
 		}
 	}
 

--- a/styles/components/playercard.scss
+++ b/styles/components/playercard.scss
@@ -2,13 +2,16 @@
 
 .playercard {
 	$root: &;
+	$card-width: 400px;
+	$card-margin: 6px;
+	$icon-size: 12px;
 
 	flow-children: none;
 
 	&__main {
 		flow-children: right;
 		height: 100%;
-		width: 500px;
+		width: $card-width;
 	}
 
 	&__background-image {
@@ -24,10 +27,10 @@
 	}
 
 	&__player-avatar {
-		margin: 8px;
+		margin: $card-margin;
 		height: 100%;
 		width: height-percentage(100%);
-		box-shadow: 0 0 4px rgb(0, 0, 0);
+		box-shadow: 0 0 3px rgb(0, 0, 0);
 		border-radius: 1px;
 		transition: brightness 0.15s ease-in-out 0s;
 
@@ -38,14 +41,15 @@
 	}
 
 	&__details-panel {
-		width: 500px;
+		width: $card-width;
 		flow-children: down;
-		margin: 8px 8px 8px 0px;
+		margin: $card-margin;
+		margin-left: 0px;
 	}
 
 	&__player-name {
-		font-size: 24px;
-		max-height: 32px;
+		font-size: 19px;
+		max-height: 25px;
 	}
 
 	&__units {
@@ -53,14 +57,14 @@
 	}
 
 	&__units-label {
-		font-size: 18px;
+		font-size: 14px;
 		vertical-align: middle;
 	}
 
 	&__units-icon {
-		margin-right: 4px;
-		width: 16px;
-		height: 16px;
+		margin-right: 3px;
+		width: $icon-size;
+		height: $icon-size;
 		wash-color: $units;
 		vertical-align: middle;
 	}
@@ -79,11 +83,11 @@
 	}
 
 	&__xp-progress-bar {
-		margin-top: 5px;
-		margin-right: 8px;
-		height: 10px;
+		margin-top: 4px;
+		margin-right: $card-margin;
+		height: 8px;
 		width: 100%;
-		box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+		box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
 	}
 
 	&__xp {
@@ -93,6 +97,6 @@
 	&__levelindicator {
 		horizontal-align: right;
 		vertical-align: bottom;
-		box-shadow: 0 0 4px rgba(0, 0, 0, 1);
+		box-shadow: 0 0 3px rgba(0, 0, 0, 1);
 	}
 }

--- a/styles/pages/learn.scss
+++ b/styles/pages/learn.scss
@@ -162,16 +162,17 @@
 
 .learn-info {
 	flow-children: right;
+	width: 100%;
 
 	&__left {
 		flow-children: down;
-		width: fill-parent-flow(1);
+		width: 50%;
 		margin-right: 4px;
 	}
 
 	&__right {
 		flow-children: down;
-		width: fit-children;
+		width: 50%;
 		margin-left: 4px;
 	}
 
@@ -198,9 +199,10 @@
 		width: 400px;
 	}
 
+	// This adds a bunch of extra height for no reason. Leaving it in because this page is WIP anyway and I wanna debug it C++ -Tom
 	&__image {
-		height: 280px;
-		width: height-percentage(133.333%);
+		width: 100%;
+		height: width-percentage(56.25%);
 		background-color: rgba(202, 202, 202, 0.04);
 		margin-bottom: 8px;
 	}

--- a/styles/pages/mainmenu.scss
+++ b/styles/pages/mainmenu.scss
@@ -34,8 +34,7 @@ $page-transition-timing-func: ease-in-out;
 	visibility: visible;
 }
 
-$topnav-height: 100px;
-$topnav-margin: 80px; // margin to use for other panels
+$topnav-height: 80px;
 $rightnav-width: 50px;
 $drawer-width: 768px;
 
@@ -84,7 +83,7 @@ $drawer-width: 768px;
 	&__content {
 		width: fill-parent-flow(1);
 		height: fill-parent-flow(1);
-		margin-top: $topnav-margin;
+		margin-top: $topnav-height;
 		margin-right: $rightnav-width;
 	}
 
@@ -135,7 +134,6 @@ $drawer-width: 768px;
 	width: 100%;
 	background-color: function.gradient-vertical(rgba(51, 51, 51, 0.3), rgba(20, 20, 20, 0.3));
 	z-index: 1;
-	ui-scale: 80%;
 
 	&__home {
 		height: 100%;
@@ -157,7 +155,7 @@ $drawer-width: 768px;
 	}
 
 	&__logo {
-		margin: 0 24px;
+		margin: 0 19px;
 		vertical-align: middle;
 	}
 
@@ -165,7 +163,7 @@ $drawer-width: 768px;
 		height: 100%;
 		width: height-percentage(100%);
 		vertical-align: middle;
-		padding: 24px;
+		padding: 19px;
 		background-color: function.gradient-radial-button(rgba(128, 128, 128, 0), rgba(128, 128, 128, 0));
 		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
 
@@ -193,7 +191,7 @@ $drawer-width: 768px;
 
 		&:selected {
 			background-color: function.gradient-radial-button(rgba(88, 88, 88, 0.7), rgba(20, 20, 20, 0.7));
-			box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.3);
+			box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.3);
 
 			#{$this}__icon {
 				opacity: 1;
@@ -211,7 +209,7 @@ $drawer-width: 768px;
 		vertical-align: middle;
 		color: white;
 		opacity: 0.85;
-		img-shadow: 0px 0px 5px 0 rgba(0, 0, 0, 0.4);
+		img-shadow: 0px 0px 4px 0 rgba(0, 0, 0, 0.4);
 		transition-property: opacity;
 		transition-duration: 0.1s;
 		transition-timing-function: ease-in;
@@ -229,9 +227,9 @@ $drawer-width: 768px;
 
 	&__shadow {
 		z-index: 1;
-		margin-top: $topnav-margin;
+		margin-top: $topnav-height;
 		width: 100%;
-		height: 24px;
+		height: 19px;
 		opacity: 0.8;
 		border-top: 1px solid rgba(0, 0, 0, 0.5);
 		background-color: gradient(
@@ -369,7 +367,7 @@ $drawer-width: 768px;
 	flow-children: right;
 	horizontal-align: right;
 	height: 100%;
-	margin-top: $topnav-margin;
+	margin-top: $topnav-height;
 
 	transform: translateX($drawer-width);
 	transition: transform 0.35s $easeOutQuart 0s;

--- a/styles/pages/mainmenu.scss
+++ b/styles/pages/mainmenu.scss
@@ -35,6 +35,7 @@ $page-transition-timing-func: ease-in-out;
 }
 
 $topnav-height: 100px;
+$topnav-margin: 80px; // margin to use for other panels
 $rightnav-width: 50px;
 $drawer-width: 768px;
 
@@ -43,8 +44,8 @@ $drawer-width: 768px;
 	height: 100%;
 
 	&__container {
-		width: 1920px;
-		height: 1080px;
+		width: 91%; // counteract blur 110% size
+		height: 91%; // counteract blur 110% size
 	}
 
 	&__background {
@@ -74,33 +75,16 @@ $drawer-width: 768px;
 	}
 
 	&__movie {
-		width: 1920px;
 		height: 1080px;
+		width: 100%;
+		min-width: 1920px;
 		overflow: noclip;
-
-		.AspectRatio4x3,
-		.AspectRatio5x4 {
-			transform: translateX(-17%);
-			overflow: noclip;
-		}
-
-		.AspectRatio16x10 {
-			transform: translateX(-10%);
-			overflow: noclip;
-		}
-
-		.AspectRatio21x9 {
-			width: 2580px;
-			height: 1080px;
-			transform: scaleY(1.3) translateY(-15%);
-			overflow: noclip;
-		}
 	}
 
 	&__content {
 		width: fill-parent-flow(1);
 		height: fill-parent-flow(1);
-		margin-top: $topnav-height;
+		margin-top: $topnav-margin;
 		margin-right: $rightnav-width;
 	}
 
@@ -134,8 +118,10 @@ $drawer-width: 768px;
 	&__page {
 		flow-children: down;
 		width: 100%;
+		max-width: 2560px;
 		height: 100%;
 		padding: 30px;
+		horizontal-align: middle;
 
 		transition-property: opacity;
 		transition-duration: 0s;
@@ -149,9 +135,11 @@ $drawer-width: 768px;
 	width: 100%;
 	background-color: function.gradient-vertical(rgba(51, 51, 51, 0.3), rgba(20, 20, 20, 0.3));
 	z-index: 1;
+	ui-scale: 80%;
 
 	&__home {
 		height: 100%;
+		vertical-align: middle;
 		background-color: rgba(255, 255, 255, 0);
 		transition: background-color 0.2s ease-in-out 0s;
 		transition-property: opacity, background-color;
@@ -175,6 +163,7 @@ $drawer-width: 768px;
 
 	&__button {
 		height: 100%;
+		width: height-percentage(100%);
 		vertical-align: middle;
 		padding: 24px;
 		background-color: function.gradient-radial-button(rgba(128, 128, 128, 0), rgba(128, 128, 128, 0));
@@ -240,7 +229,7 @@ $drawer-width: 768px;
 
 	&__shadow {
 		z-index: 1;
-		margin-top: $topnav-height;
+		margin-top: $topnav-margin;
 		width: 100%;
 		height: 24px;
 		opacity: 0.8;
@@ -380,7 +369,7 @@ $drawer-width: 768px;
 	flow-children: right;
 	horizontal-align: right;
 	height: 100%;
-	margin-top: $topnav-height;
+	margin-top: $topnav-margin;
 
 	transform: translateX($drawer-width);
 	transition: transform 0.35s $easeOutQuart 0s;
@@ -443,16 +432,24 @@ $drawer-width: 768px;
 }
 
 .home {
+	&__wrapper {
+		width: 100%;
+		max-width: 2560px;
+		height: 100%;
+		horizontal-align: middle;
+		flow-children: right;
+	}
+
 	&__newspanel {
 		margin: 24px;
 		background-color: rgba(0, 0, 0, 0.6);
 	}
 
 	&__modelpanel {
-		width: 700px;
+		width: fill-parent-flow(1);
+		max-width: 700px;
 		height: 100%;
-		margin-right: 200px;
-		horizontal-align: right;
+		horizontal-align: middle;
 		vertical-align: middle;
 
 		opacity: 1;
@@ -668,8 +665,11 @@ $drawer-width: 768px;
 }
 
 .mapselector__background {
-	width: 1920px;
-	height: 1080px;
+	height: 100%;
+	width: 100%;
+	min-width: 1920px;
+	max-width: 2560px;
+	horizontal-align: middle;
 	transition-property: opacity;
 	transition-duration: $page-transition-duration;
 	transition-timing-function: $page-transition-timing-func;

--- a/styles/pages/mainmenu.scss
+++ b/styles/pages/mainmenu.scss
@@ -43,8 +43,8 @@ $drawer-width: 768px;
 	height: 100%;
 
 	&__container {
-		width: 91%; // counteract blur 110% size
-		height: 91%; // counteract blur 110% size
+		width: 80%; // counteract blur 125% size
+		height: 80%; // counteract blur 125% size
 	}
 
 	&__background {
@@ -61,8 +61,8 @@ $drawer-width: 768px;
 	&__content-blur {
 		// Let this panel clip outside the page so the blur applies all the way to the edges
 		// mainmenu__container will constrain all children to 1920x1080
-		width: 110%;
-		height: 110%;
+		width: 125%;
+		height: 125%;
 		overflow: noclip;
 		blur: fastgaussian(8, 8, 5);
 	}
@@ -155,7 +155,8 @@ $drawer-width: 768px;
 	}
 
 	&__logo {
-		margin: 0 19px;
+		height: 56px;
+		margin: 0px 16px;
 		vertical-align: middle;
 	}
 
@@ -163,7 +164,7 @@ $drawer-width: 768px;
 		height: 100%;
 		width: height-percentage(100%);
 		vertical-align: middle;
-		padding: 19px;
+		padding: 18px;
 		background-color: function.gradient-radial-button(rgba(128, 128, 128, 0), rgba(128, 128, 128, 0));
 		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
 
@@ -229,7 +230,7 @@ $drawer-width: 768px;
 		z-index: 1;
 		margin-top: $topnav-height;
 		width: 100%;
-		height: 19px;
+		height: 20px;
 		opacity: 0.8;
 		border-top: 1px solid rgba(0, 0, 0, 0.5);
 		background-color: gradient(

--- a/styles/pages/mapselector.scss
+++ b/styles/pages/mapselector.scss
@@ -12,12 +12,14 @@
 
 	&__left {
 		horizontal-align: middle;
+		width: 100%;
 		height: 100%;
 		background-color: rgba(0, 0, 0, 0.3);
 
 		&-wrapper {
 			flow-children: down;
 			height: 100%;
+			width: 100%;
 			box-shadow: 0 0 16px 0 rgba(0, 0, 0, 0.5);
 		}
 
@@ -46,6 +48,7 @@
 	&__maps {
 		visibility: visible;
 		padding-right: 8px;
+		width: 100%;
 	}
 
 	&__playlists {
@@ -54,6 +57,8 @@
 	}
 
 	&__category-contents {
+		width: 100%;
+
 		&--playlists {
 			#{$root}__maps {
 				visibility: collapse;
@@ -139,13 +144,15 @@
 	$this: &;
 
 	flow-children: down;
+	width: 100%;
 	height: 0px;
 	padding-right: 8px;
 
 	transition: height 0.2s ease-in-out 0s;
+	overflow: clip;
 
 	&--filters-extended {
-		height: 84px; // Hardcoded value so height can transition
+		height: 88px; // Hardcoded value so height can transition
 
 		#{$this}__text {
 			vertical-align: middle;
@@ -171,9 +178,14 @@
 
 	&__gamemodes {
 		width: fit-children;
-		padding-bottom: 7px;
-		margin-bottom: -7px;
-		overflow: scroll squish;
+		overflow: scroll noclip;
+
+		& > #HorizontalScrollBar {
+			height: 2px;
+			& > #ScrollThumb {
+				opacity: 1;
+			}
+		}
 	}
 
 	&__tiers {

--- a/styles/pages/mapselector.scss
+++ b/styles/pages/mapselector.scss
@@ -22,6 +22,13 @@ $left-width: 808px;
 			height: 100%;
 			box-shadow: 0 0 16px 0 rgba(0, 0, 0, 0.5);
 		}
+
+		&-container {
+			horizontal-align: left;
+			width: 50%;
+			height: 100%;
+			margin-right: 8px;
+		}
 	}
 
 	&__right {

--- a/styles/pages/mapselector.scss
+++ b/styles/pages/mapselector.scss
@@ -148,6 +148,7 @@
 		height: 84px; // Hardcoded value so height can transition
 
 		#{$this}__text {
+			vertical-align: middle;
 			overflow: squish;
 			text-overflow: shrink;
 		}
@@ -176,7 +177,7 @@
 	}
 
 	&__tiers {
-		// width: fill-parent-flow(1);
+		width: fill-parent-flow(1);
 		flow-children: right;
 		margin-right: 24px;
 	}
@@ -189,16 +190,16 @@
 
 // Be careful with widths here to ensure the numbers align exactly. The SliderThumb must be the same width as the numbers, and the
 // whole panel must be allowed to fit all its children, so make sure some space is left on the right side. Always test on multiple resolutions!
-$notch-width: 12px;
-$notch-gap: 30px;
+$notch-width: 16px;
 .mapselector-tier-slider {
 	flow-children: none;
+	width: 100%;
 	height: 34px;
 	margin-top: 2px;
 
 	&__numbers {
 		flow-children: right;
-		width: fit-children;
+		width: 100%;
 		padding-top: 0px;
 	}
 
@@ -211,13 +212,12 @@ $notch-gap: 30px;
 
 		&--double-digit {
 			width: $notch-width + 4px;
-			margin-right: -4px;
-			transform: translateX(-4px);
+			horizontal-align: right;
 		}
 	}
 
 	&__gap {
-		width: $notch-gap;
+		width: fill-parent-flow(1);
 		height: 100%;
 	}
 

--- a/styles/pages/mapselector.scss
+++ b/styles/pages/mapselector.scss
@@ -3,8 +3,6 @@
 @use 'sass:map';
 @use 'sass:color';
 
-$left-width: 808px;
-
 .mapselector {
 	width: 100%;
 	height: 100%;
@@ -13,7 +11,7 @@ $left-width: 808px;
 	$root: &;
 
 	&__left {
-		min-width: $left-width;
+		horizontal-align: middle;
 		height: 100%;
 		background-color: rgba(0, 0, 0, 0.3);
 
@@ -36,6 +34,7 @@ $left-width: 808px;
 		horizontal-align: right;
 		width: 50%;
 		height: 100%;
+		margin-left: 8px;
 	}
 
 	&__maps,
@@ -50,7 +49,6 @@ $left-width: 808px;
 	}
 
 	&__playlists {
-		min-width: $left-width;
 		height: fill-parent-flow(1);
 		visibility: collapse;
 	}
@@ -156,7 +154,7 @@ $left-width: 808px;
 	}
 
 	&__button {
-		max-width: 112px;
+		width: fit-children;
 	}
 
 	&__text {
@@ -172,6 +170,9 @@ $left-width: 808px;
 
 	&__gamemodes {
 		width: fit-children;
+		padding-bottom: 7px;
+		margin-bottom: -7px;
+		overflow: scroll squish;
 	}
 
 	&__tiers {
@@ -242,7 +243,7 @@ $notch-gap: 30px;
 .mapselector-sorting {
 	flow-children: right;
 	width: 100%;
-	margin-top: 8px;
+	margin-top: 10px;
 	padding-right: 8px;
 
 	&__tabs {
@@ -304,12 +305,15 @@ $notch-gap: 30px;
 		width: 100%;
 
 		&-left {
-			width: 600px;
+			width: fill-parent-flow(1);
+			min-width: 450px;
+			margin-right: 8px;
 		}
 
 		&-right {
-			margin-left: 8px;
-			width: 290px;
+			width: fill-parent-flow(0.5);
+			max-width: 290px;
+			horizontal-align: left;
 		}
 	}
 
@@ -361,7 +365,6 @@ $notch-gap: 30px;
 		overflow: squish scroll;
 		padding: 12px;
 		width: 100%;
-		height: 100%;
 
 		& > VerticalScrollBar {
 			width: 4px;
@@ -373,6 +376,8 @@ $notch-gap: 30px;
 		flow-children: down;
 		// For some reason (maybe a bug?) when a panel has overflow: scroll its children
 		// can't be positioned with align. This is a hack to force the See More button to the bottom.
+		width: 100%;
+		height: fit-children;
 		min-height: 210px;
 	}
 
@@ -411,6 +416,7 @@ $notch-gap: 30px;
 	}
 
 	&__paragraph {
+		width: 100%;
 		font-size: 17px;
 		text-shadow: 1px 1px 2px 1 rgba(0, 0, 0, 0.8);
 	}
@@ -494,6 +500,7 @@ $notch-gap: 30px;
 		vertical-align: center;
 		@include mixin.font-styles($use-header: true, $light-header: true);
 		font-size: 22px;
+		text-overflow: shrink;
 		text-shadow: 0px 1px 3px 2 rgba(0, 0, 0, 0.8);
 	}
 }

--- a/styles/pages/settings.scss
+++ b/styles/pages/settings.scss
@@ -12,7 +12,8 @@ $page-width: 1920px - $rightnav-width;
 
 	&__left {
 		flow-children: down;
-		width: 350px;
+		width: fill-parent-flow(0.3);
+		min-width: 210px;
 
 		height: 100%;
 		padding-right: 16px;
@@ -27,7 +28,7 @@ $page-width: 1920px - $rightnav-width;
 		width: 400px;
 
 		height: 100%;
-		padding: 16px;
+		padding: 16px 0px 16px 32px;
 	}
 
 	&__search {

--- a/styles/pages/settings.scss
+++ b/styles/pages/settings.scss
@@ -10,6 +10,8 @@ $page-width: 1920px - $rightnav-width;
 	width: 100%;
 	height: 100%;
 
+	max-width: 1920px;
+
 	&__left {
 		flow-children: down;
 		width: fill-parent-flow(0.3);
@@ -25,7 +27,7 @@ $page-width: 1920px - $rightnav-width;
 	}
 
 	&__info {
-		width: 400px;
+		width: fill-parent-flow(0.4);
 
 		height: 100%;
 		padding: 16px 0px 16px 32px;
@@ -212,11 +214,14 @@ $page-width: 1920px - $rightnav-width;
 
 	&__item-label {
 		width: 100%;
-		padding-left: 16px;
+		padding: 0 16px;
 
 		@include mixin.font-styles($use-header: true, $light-header: false);
 		font-size: 38px;
 		opacity: 0.85;
+		max-height: 50px;
+		overflow: squish;
+		text-overflow: shrink;
 
 		transition: opacity 0.1s ease-in-out 0s;
 		&:hover {


### PR DESCRIPTION
This change addresses issues https://github.com/momentum-mod/game/issues/1761 and https://github.com/momentum-mod/game/issues/1669, without the need to explicitly define aspect ratios. The menus scale for arbitrary aspect ratios between 1:1 and 21:9. For ratios larger than 21:9, the menu is displayed at 21:9 and centered on the screen - this has no effect for any display 21:9 or narrower.