### PR TITLE
feat: Add Jump Sync defrag hud element

### DIFF
--- a/layout/hud/dfjump.xml
+++ b/layout/hud/dfjump.xml
@@ -1,0 +1,22 @@
+<root>
+	<styles>
+		<include src="file://{resources}/styles/main.scss" />
+	</styles>
+	<scripts>
+		<include src="file://{resources}/scripts/common/buttons.js" />
+		<include src="file://{resources}/scripts/hud/dfjump.js" />
+	</scripts>
+	<MomHudDFJump>
+		<ConVarEnabler id="DFJumpContainer" class="dfjump__container" convar="mom_df_hud_jump_enable" togglevisibility="true">
+			<Panel class="dfjump__bar-wrapper" alternateTicks="false">
+				<ProgressBar id="JumpPressBar" class="dfjump__press dfjump__press--ground" min="0" max="1" />
+				<ProgressBar id="JumpReleaseBar" class="dfjump__release" min="0" max="1" />
+			</Panel>
+			<ConVarEnabler convar="mom_df_hud_jump_text_enable" class="dfjump__text-wrapper" togglevisibility="true">
+				<Label id="JumpReleaseLabel" class="dfjump__text-wrapper--release" />
+				<Label id="JumpTotalLabel" class="dfjump__text-wrapper--total" />
+				<Label id="JumpPressLabel" class="dfjump__text-wrapper--press" />
+			</ConVarEnabler>
+		</ConVarEnabler>
+	</MomHudDFJump>
+</root>

--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -49,6 +49,7 @@
 
 		<!-- Anchored on lower-right corner, laid out from top to bottom -->
 		<Panel id="HudBottomRight" hittest="false" hittestchildren="false">
+			<MomHudDFJump />
 			<MomHudKeyPress />
 		</Panel>
 

--- a/layout/settings/settings_gameplay.xml
+++ b/layout/settings/settings_gameplay.xml
@@ -972,6 +972,39 @@
 
 				</Panel>
 
+				<Panel class="settings-group__combo">
+
+					<ChaosSettingsEnum
+						text="Display jump visualizer"
+						convar="mom_df_hud_jump_enable"
+						infomessage="Display jump visualizer. Draws an upward bar to show how long +jump was held after leaving the ground, and a downward bar to show how early/late +jump was pressed before jumping."
+					>
+						<RadioButton group="dfjumpenable" text="#SFUI_Off" value="0" />
+						<RadioButton group="dfjumpenable" text="#SFUI_On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ConVarEnabler convar="mom_df_hud_jump_enable" class="flow-down">
+						<ChaosSettingsSlider
+							text="Maximum delay time (ms)"
+							min="50"
+							max="1000"
+							convar="mom_df_hud_jump_max_delay"
+							displayprecision="0"
+							infomessage="Length of time (in milliseconds) corresponding to 100% full press or release bars"
+						/>
+
+						<ChaosSettingsEnum
+							text="Display time labels"
+							convar="mom_df_hud_jump_text_enable"
+							infomessage="Display times (in milliseconds) next to jump sync bars. At the top is late release time, at the bottom early/late press time, and in the middle is combined time for a single jump."
+						>
+							<RadioButton group="dfjumptextenable" text="#SFUI_Off" value="0" />
+							<RadioButton group="dfjumptextenable" text="#SFUI_On" value="1" />
+						</ChaosSettingsEnum>
+					</ConVarEnabler>
+
+				</Panel>
+
 			</Panel>
 		</Panel>
 	</Panel>

--- a/scripts/common/buttons.js
+++ b/scripts/common/buttons.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const BUTTONS = {
+	ATTACK: 1 << 0,
+	JUMP: 1 << 1,
+	DUCK: 1 << 2,
+	FORWARD: 1 << 3,
+	BACK: 1 << 4,
+	USE: 1 << 5,
+	CANCEL: 1 << 6,
+	LEFT: 1 << 7,
+	RIGHT: 1 << 8,
+	MOVELEFT: 1 << 9,
+	MOVERIGHT: 1 << 10,
+	ATTACK2: 1 << 11,
+	SCORE: 1 << 16,
+	SPEED: 1 << 17,
+	WALK: 1 << 18,
+	ZOOM: 1 << 19,
+	LOOKSPIN: 1 << 25,
+	BHOPDISABLED: 1 << 29,
+	PAINT: 1 << 30,
+	STRAFE: 1 << 31
+};

--- a/scripts/common/panelregistration.js
+++ b/scripts/common/panelregistration.js
@@ -29,6 +29,7 @@
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudMapInfo', 'file://{resources}/layout/hud/mapinfo.xml');
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudWeaponSelection', 'file://{resources}/layout/hud/weaponselection.xml');
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudCgaz', 'file://{resources}/layout/hud/cgaz.xml');
+	UiToolkitAPI.RegisterHUDPanel2d('MomHudDFJump', 'file://{resources}/layout/hud/dfjump.xml');
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudSpecInfo', 'file://{resources}/layout/hud/specinfo.xml');
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudSynchronizer', 'file://{resources}/layout/hud/synchronizer.xml');
 

--- a/scripts/hud/dfjump.js
+++ b/scripts/hud/dfjump.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const COLOR_CLASS = {
+	AIR: 'dfjump__press--air',
+	GROUND: 'dfjump__press--ground'
+};
+
+const DEFAULT_DELAY = 360;
+
+class DFJump {
+	/** @type {Panel} @static */
+	static container = $('#DFJumpContainer');
+	/** @type {ProgressBar} @static */
+	static releaseBar = $('#JumpReleaseBar');
+	/** @type {ProgressBar} @static */
+	static pressBar = $('#JumpPressBar');
+	/** @type {Label} @static */
+	static releaseLabel = $('#JumpReleaseLabel');
+	/** @type {Label} @static */
+	static pressLabel = $('#JumpPressLabel');
+	/** @type {Label} @static */
+	static totalLabel = $('#JumpTotalLabel');
+
+	static onLoad() {
+		this.initializeSettings();
+		this.colorClass = COLOR_CLASS.GROUND;
+	}
+
+	static onDFJumpUpdate(releaseDelay, pressDelay, totalDelay) {
+		const releaseRatio = releaseDelay * this.inverseMaxDelay;
+		const pressRatio = Math.abs(pressDelay) * this.inverseMaxDelay;
+		const newPressColorClass = pressDelay < 0 ? COLOR_CLASS.GROUND : COLOR_CLASS.AIR;
+
+		this.releaseBar.value = releaseRatio;
+		this.pressBar.value = pressRatio;
+		this.pressBar.RemoveClass(this.colorClass);
+		this.pressBar.AddClass(newPressColorClass);
+		this.colorClass = newPressColorClass;
+
+		this.releaseLabel.text = releaseDelay.toFixed();
+		this.pressLabel.text = pressDelay.toFixed();
+		this.totalLabel.text = totalDelay.toFixed();
+	}
+
+	static setMaxDelay(newDelay) {
+		this.inverseMaxDelay = 1.0 / (newDelay ?? DEFAULT_DELAY);
+	}
+
+	static initializeSettings() {
+		this.setMaxDelay(GameInterfaceAPI.GetSettingInt('mom_df_hud_jump_max_delay'));
+	}
+
+	static {
+		$.RegisterEventHandler('DFJumpDataUpdate', this.container, this.onDFJumpUpdate.bind(this));
+
+		$.RegisterForUnhandledEvent('ChaosLevelInitPostEntity', this.onLoad.bind(this));
+		$.RegisterForUnhandledEvent('DFJumpMaxDelayChanged', this.setMaxDelay.bind(this));
+	}
+}

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -662,6 +662,19 @@ $speedometer-color-increase: $blue !default;
 $speedometer-color-decrease: $red !default;
 
 // ================
+// DFJUMP
+// ================
+$dfjump-width: 20px !default;
+$dfjump-height: 300px !default;
+$dfjump-opacity: 0.7 !default;
+$dfjump-color-release: gradient(linear, 30% 0%, 100% 0%, from(#ff5757), to(#d31818)) !default;
+$dfjump-color-press-air: gradient(linear, 30% 0%, 100% 0%, from(#1896d3), to(#3f4aca)) !default;
+$dfjump-color-press-ground: gradient(linear, 30% 0%, 100% 0%, from(#7aee7a), to(#159856)) !default;
+$dfjump-color-background: gradient(linear, 0% 0%, 100% 0%, from(#5f5f5f80), to(#c8c8c880)) !default;
+$dfjump-font-size: 22px !default;
+$dfjump-padding: 6px !default;
+
+// ================
 // STRAFESYNC
 // ================
 $strafesync-color-default: $white !default;

--- a/styles/hud/_index.scss
+++ b/styles/hud/_index.scss
@@ -4,6 +4,7 @@
 @use 'consolenotify';
 @use 'crosshair';
 @use 'damageindicator';
+@use 'dfjump';
 @use 'ghostentities';
 @use 'hud';
 @use 'hud_comparisons';

--- a/styles/hud/dfjump.scss
+++ b/styles/hud/dfjump.scss
@@ -1,0 +1,82 @@
+@use '../config' as *;
+
+.dfjump {
+	align: center center;
+
+	&__container {
+		width: fit-children;
+		height: $dfjump-height;
+		flow-children: right;
+	}
+
+	&__bar-wrapper {
+		width: $dfjump-width;
+		height: $dfjump-height;
+		border: 1px solid $white;
+		border-radius: 3px;
+		opacity: $dfjump-opacity;
+	}
+
+	&__release {
+		width: 100%;
+		height: 50%;
+		horizontal-align: center;
+		vertical-align: top;
+		flow-children: up;
+		border-radius: 0px;
+		background-color: rgba(0, 0, 0, 0); //$progressbar-background;
+
+		.ProgressBarLeft {
+			background-color: $dfjump-color-release;
+		}
+
+		.ProgressBarRight {
+			background-color: $dfjump-color-background;
+		}
+	}
+
+	&__press {
+		width: 100%;
+		height: 50%;
+		horizontal-align: center;
+		vertical-align: bottom;
+		flow-children: down;
+		border-radius: 0px;
+		background-color: rgba(0, 0, 0, 0); //$progressbar-background;
+
+		&--air {
+			.ProgressBarLeft {
+				background-color: $dfjump-color-press-air;
+			}
+		}
+
+		&--ground {
+			.ProgressBarLeft {
+				background-color: $dfjump-color-press-ground;
+			}
+		}
+
+		.ProgressBarRight {
+			background-color: $dfjump-color-background;
+		}
+	}
+
+	&__text-wrapper {
+		width: fit-children;
+		height: $dfjump-height;
+		font-size: $dfjump-font-size;
+		padding-left: $dfjump-padding;
+
+		&--release {
+			vertical-align: top;
+		}
+
+		&--press {
+			vertical-align: bottom;
+		}
+
+		&--total {
+			vertical-align: middle;
+		}
+	}
+}


### PR DESCRIPTION
This pull request adds a HUD element to aid jump timing in defrag.

- `mom_hud_jump_sync_enable` to draw jump sync bars - upward for late release, downward for early/late press.

- `mom_hud_jump_sync_max_delay` to set the max value for tracking jump presses. This is the value corresponding to 100% on either bar.

- `mom_hud_jump_sync_text_enable` to show time (ms) next to bars.

Requires Red changes to merge. Closes [#1793](https://github.com/momentum-mod/game/issues/1793)