### PR TITLE
Draft: Defrag project drawdelay setting

### DIFF
--- a/layout/settings/settings_gameplay.xml
+++ b/layout/settings/settings_gameplay.xml
@@ -468,7 +468,7 @@
 					text="#Settings_RJ_RocketDrawDelayEntry"
 					min="0"
 					max="1"
-					displayprecision="1"
+					displayprecision="2"
 					convar="mom_rj_rocket_drawdelay"
 					infomessage="#Settings_RJ_RocketDrawDelayEntry_Info"
 				/>
@@ -626,7 +626,7 @@
 					text="#Settings_SJ_DrawDelayEntry"
 					min="0"
 					max="1"
-					displayprecision="1"
+					displayprecision="2"
 					convar="mom_sj_stickybomb_drawdelay"
 					infomessage="#Settings_SJ_DrawDelayEntry_Info"
 					tags="delay"


### PR DESCRIPTION
Leaving as a draft til Lumia confirms if there's any other defrag weapon stuff we could add here.

Once in, add to POEditor
```
"Settings_Defrag_Projectile_DrawDelay": "Projectile render delay",
"Settings_Defrag_Projectile_DrawDelay_Info": "The delay in seconds before all defrag projectiles are rendered on-screen."
```