### PR TITLE
feat: jump stats

### DIFF
--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -82,6 +82,7 @@
 			<ChaosHudShowPos />
 			<ChaosHudBoneCounts />
 			<MomHudSpectate id="Spectator" />
+			<MomHudJumpStats />
 		</Panel>
 
 		<TrickList id="TrickList" />

--- a/layout/hud/jumpstats.xml
+++ b/layout/hud/jumpstats.xml
@@ -83,13 +83,13 @@
 				<Label text="{s:gain}" id="GainLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
-				id="StrafeRatioContainer"
-				class="jumpstats__label jumpstats__label--strafe-ratio"
-				convar="mom_hud_jstats_strafe_ratio_enable"
+				id="YawRatioContainer"
+				class="jumpstats__label jumpstats__label--yaw-ratio"
+				convar="mom_hud_jstats_yaw_ratio_enable"
 				togglevisibility="true"
 			>
-				<Label text="#JumpStats_Label_StrafeRatio" class="jumpstats__label--name" />
-				<Label text="{s:strafe_ratio}" id="StrafeRatioLabel" class="jumpstats__label--values" />
+				<Label text="#JumpStats_Label_YawRatio" class="jumpstats__label--name" />
+				<Label text="{s:yaw_ratio}" id="YawRatioLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
 				id="HeightDeltaContainer"

--- a/layout/hud/jumpstats.xml
+++ b/layout/hud/jumpstats.xml
@@ -25,7 +25,7 @@
 				convar="mom_hud_jstats_takeoff_speed_enable"
 				togglevisibility="true"
 			>
-				<Label text="Speed" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_Speed" class="jumpstats__label--name" />
 				<Label text="{s:speed}" id="SpeedLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -34,7 +34,7 @@
 				convar="mom_hud_jstats_speed_delta_enable"
 				togglevisibility="true"
 			>
-				<Label text="ΔS" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_DeltaSpeed" class="jumpstats__label--name" />
 				<Label text="{s:speed_delta}" id="SpeedDeltaLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -43,7 +43,7 @@
 				convar="mom_hud_jstats_takeoff_time_enable"
 				togglevisibility="true"
 			>
-				<Label text="Time" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_Time" class="jumpstats__label--name" />
 				<Label text="{s:time}" id="TimeLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -52,7 +52,7 @@
 				convar="mom_hud_jstats_time_delta_enable"
 				togglevisibility="true"
 			>
-				<Label text="ΔT" class="jumpstats__label--name" />
+				<Label text="JumpStats_Label_DeltaTime" class="jumpstats__label--name" />
 				<Label text="{s:time_delta}" id="TimeDeltaLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -61,7 +61,7 @@
 				convar="mom_hud_jstats_strafe_count_enable"
 				togglevisibility="true"
 			>
-				<Label text="Strafes" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_Strafes" class="jumpstats__label--name" />
 				<Label text="{s:strafes}" id="StrafesLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -70,7 +70,7 @@
 				convar="mom_hud_jstats_strafe_sync_enable"
 				togglevisibility="true"
 			>
-				<Label text="Sync" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_Sync" class="jumpstats__label--name" />
 				<Label text="{s:sync}" id="SyncLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -79,7 +79,7 @@
 				convar="mom_hud_jstats_speed_gain_enable"
 				togglevisibility="true"
 			>
-				<Label text="Gain" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_Gain" class="jumpstats__label--name" />
 				<Label text="{s:gain}" id="GainLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -88,16 +88,16 @@
 				convar="mom_hud_jstats_strafe_ratio_enable"
 				togglevisibility="true"
 			>
-				<Label text="SRatio" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_StrafeRatio" class="jumpstats__label--name" />
 				<Label text="{s:strafe_ratio}" id="StrafeRatioLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
-				id="HeightContainer"
+				id="HeightDeltaContainer"
 				class="jumpstats__label jumpstats__label--height-delta"
 				convar="mom_hud_jstats_height_delta_enable"
 				togglevisibility="true"
 			>
-				<Label text="ΔZ" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_HeightDelta" class="jumpstats__label--name" />
 				<Label text="{s:height_delta}" id="HeightDeltaLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -106,7 +106,7 @@
 				convar="mom_hud_jstats_distance_enable"
 				togglevisibility="true"
 			>
-				<Label text="Dist" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_Distance" class="jumpstats__label--name" />
 				<Label text="{s:distance}" id="DistanceLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 			<ConVarEnabler
@@ -115,7 +115,7 @@
 				convar="mom_hud_jstats_efficiency_enable"
 				togglevisibility="true"
 			>
-				<Label text="Eff" class="jumpstats__label--name" />
+				<Label text="#JumpStats_Label_Efficiency" class="jumpstats__label--name" />
 				<Label text="{s:efficiency}" id="EfficiencyLabel" class="jumpstats__label--values" />
 			</ConVarEnabler>
 		</ConVarEnabler>

--- a/layout/hud/jumpstats.xml
+++ b/layout/hud/jumpstats.xml
@@ -1,0 +1,123 @@
+<root>
+	<styles>
+		<include src="file://{resources}/styles/main.scss" />
+	</styles>
+	<scripts>
+		<include src="file://{resources}/scripts/hud/jumpstats.js" />
+	</scripts>
+
+	<MomHudJumpStats class="jumpstats">
+		<ConVarEnabler
+			id="JumpStatsContainer"
+			class="jumpstats__container"
+			convar="mom_hud_jstats_enable"
+			togglevisibility="true"
+		>
+			<Label id="JumpStatsLabel" class="jumpstats__label" text="\n" />
+			<Label
+				text="{s:jump_count}"
+				id="CountLabel"
+				class="jumpstats__label jumpstats__label--count jumpstats__label--values"
+			/>
+			<ConVarEnabler
+				id="SpeedContainer"
+				class="jumpstats__label jumpstats__label--speed"
+				convar="mom_hud_jstats_takeoff_speed_enable"
+				togglevisibility="true"
+			>
+				<Label text="Speed" class="jumpstats__label--name" />
+				<Label text="{s:speed}" id="SpeedLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="SpeedDeltaContainer"
+				class="jumpstats__label jumpstats__label--speed-delta"
+				convar="mom_hud_jstats_speed_delta_enable"
+				togglevisibility="true"
+			>
+				<Label text="ΔS" class="jumpstats__label--name" />
+				<Label text="{s:speed_delta}" id="SpeedDeltaLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="TimeContainer"
+				class="jumpstats__label jumpstats__label--time"
+				convar="mom_hud_jstats_takeoff_time_enable"
+				togglevisibility="true"
+			>
+				<Label text="Time" class="jumpstats__label--name" />
+				<Label text="{s:time}" id="TimeLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="TimeDeltaContainer"
+				class="jumpstats__label jumpstats__label--time-delta"
+				convar="mom_hud_jstats_time_delta_enable"
+				togglevisibility="true"
+			>
+				<Label text="ΔT" class="jumpstats__label--name" />
+				<Label text="{s:time_delta}" id="TimeDeltaLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="StrafesContainer"
+				class="jumpstats__label jumpstats__label--strafes"
+				convar="mom_hud_jstats_strafe_count_enable"
+				togglevisibility="true"
+			>
+				<Label text="Strafes" class="jumpstats__label--name" />
+				<Label text="{s:strafes}" id="StrafesLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="SyncContainer"
+				class="jumpstats__label jumpstats__label--sync"
+				convar="mom_hud_jstats_strafe_sync_enable"
+				togglevisibility="true"
+			>
+				<Label text="Sync" class="jumpstats__label--name" />
+				<Label text="{s:sync}" id="SyncLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="GainContainer"
+				class="jumpstats__label jumpstats__label--gain"
+				convar="mom_hud_jstats_speed_gain_enable"
+				togglevisibility="true"
+			>
+				<Label text="Gain" class="jumpstats__label--name" />
+				<Label text="{s:gain}" id="GainLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="StrafeRatioContainer"
+				class="jumpstats__label jumpstats__label--strafe-ratio"
+				convar="mom_hud_jstats_strafe_ratio_enable"
+				togglevisibility="true"
+			>
+				<Label text="SRatio" class="jumpstats__label--name" />
+				<Label text="{s:strafe_ratio}" id="StrafeRatioLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="HeightContainer"
+				class="jumpstats__label jumpstats__label--height-delta"
+				convar="mom_hud_jstats_height_delta_enable"
+				togglevisibility="true"
+			>
+				<Label text="ΔZ" class="jumpstats__label--name" />
+				<Label text="{s:height_delta}" id="HeightDeltaLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="DistanceContainer"
+				class="jumpstats__label jumpstats__label--distance"
+				convar="mom_hud_jstats_distance_enable"
+				togglevisibility="true"
+			>
+				<Label text="Dist" class="jumpstats__label--name" />
+				<Label text="{s:distance}" id="DistanceLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+			<ConVarEnabler
+				id="EfficiencyContainer"
+				class="jumpstats__label jumpstats__label--efficiency"
+				convar="mom_hud_jstats_efficiency_enable"
+				togglevisibility="true"
+			>
+				<Label text="Eff" class="jumpstats__label--name" />
+				<Label text="{s:efficiency}" id="EfficiencyLabel" class="jumpstats__label--values" />
+			</ConVarEnabler>
+		</ConVarEnabler>
+	</MomHudJumpStats>
+</root>

--- a/layout/hud/synchronizer.xml
+++ b/layout/hud/synchronizer.xml
@@ -8,15 +8,21 @@
 		<include src="file://{resources}/scripts/hud/synchronizer.js" />
 	</scripts>
 	<MomHudSynchronizer class="synchronizer" alternateTicks="false">
-		<ConVarEnabler class="synchronizer__background" convar="mom_hud_synchronizer_mode" togglevisibility="true">
-			<Panel id="Container" class="synchronizer__container">
-				<Panel id="Segment0" class="synchronizer__segment" />
-				<Panel id="Segment1" class="synchronizer__segment" />
-				<Panel id="Segment2" class="synchronizer__segment" />
-				<Panel id="Segment3" class="synchronizer__segment" />
-				<Panel id="Segment4" class="synchronizer__segment" />
-			</Panel>
-			<Panel id="Needle" class="synchronizer__needle" />
+		<Panel id="BarWrapper" class="synchronizer__bar-wrapper">
+			<ConVarEnabler class="synchronizer__background" convar="mom_hud_synchro_mode" togglevisibility="true">
+				<Panel id="Container" class="synchronizer__container">
+					<Panel id="Segment0" class="synchronizer__segment" />
+					<Panel id="Segment1" class="synchronizer__segment" />
+					<Panel id="Segment2" class="synchronizer__segment" />
+					<Panel id="Segment3" class="synchronizer__segment" />
+					<Panel id="Segment4" class="synchronizer__segment" />
+				</Panel>
+				<Panel id="Needle" class="synchronizer__needle" />
+			</ConVarEnabler>
+		</Panel>
+		<ConVarEnabler class="synchronizer__stats" convar="mom_hud_synchro_stat_mode" togglevisibility="true">
+			<Label id="StatsUpper" class="synchronizer__stats--upper" />
+			<Label id="StatsLower" class="synchronizer__stats--lower" />
 		</ConVarEnabler>
 	</MomHudSynchronizer>
 </root>

--- a/layout/mainmenu_settings.xml
+++ b/layout/mainmenu_settings.xml
@@ -395,7 +395,7 @@
 									group="SettingsSubNav"
 									onactivate="MainMenuSettings.navigateToSubsection('InterfaceSettings', 'JumpStatsSubSection')"
 								>
-									<Label class="settings-nav__subitem-label" text="Jump Stats" />
+									<Label class="settings-nav__subitem-label" text="#Settings_JumpStats_Title" />
 								</RadioButton>
 
 								<RadioButton

--- a/layout/mainmenu_settings.xml
+++ b/layout/mainmenu_settings.xml
@@ -324,7 +324,7 @@
 
 							<Label class="settings-nav__item-label" text="#Settings_Interface" />
 
-							<Panel class="settings-nav__subsection settings-nav__subsection--10 settings-nav__subsection--hidden">
+							<Panel class="settings-nav__subsection settings-nav__subsection--11 settings-nav__subsection--hidden">
 
 								<RadioButton
 									id="UIRadio"
@@ -387,6 +387,15 @@
 									onactivate="MainMenuSettings.navigateToSubsection('InterfaceSettings', 'WeaponSelSubSection')"
 								>
 									<Label class="settings-nav__subitem-label" text="#Settings_WeaponSelection_Title" />
+								</RadioButton>
+								
+								<RadioButton
+									id="JumpStatsRadio"
+									class="settings-nav__subitem"
+									group="SettingsSubNav"
+									onactivate="MainMenuSettings.navigateToSubsection('InterfaceSettings', 'JumpStatsSubSection')"
+								>
+									<Label class="settings-nav__subitem-label" text="Jump Stats" />
 								</RadioButton>
 
 								<RadioButton

--- a/layout/settings/settings_interface.xml
+++ b/layout/settings/settings_interface.xml
@@ -872,6 +872,16 @@
 
 
 				<ConVarEnabler convar="mom_hud_synchro_mode" class="flow-down">
+					<ChaosSettingsEnumDropDown
+						text="#Settings_Synchronizer_Stats_Mode"
+						convar="mom_hud_synchro_stat_mode"
+						infomessage="#Settings_Synchronizer_Stats_Mode_Info"
+					>
+						<Label id="mode0" text="#Settings_Synchronizer_StatsMode_Mode0" value="0" />
+						<Label id="mode1" text="#Settings_Synchronizer_StatsMode_Mode1" value="1" />
+						<Label id="mode2" text="#Settings_Synchronizer_StatsMode_Mode2" value="2" />
+					</ChaosSettingsEnumDropDown>
+				
 					<ChaosSettingsEnum
 						text="#Settings_Synchronizer_Color"
 						convar="mom_hud_synchro_color_enable"

--- a/layout/settings/settings_interface.xml
+++ b/layout/settings/settings_interface.xml
@@ -893,6 +893,15 @@
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
+						text="Settings_Synchronizer_Dynamic_Mode"
+						convar="mom_hud_synchro_dynamic_enable"
+						infomessage="#Settings_Synchronizer_Dynamic_Mode_Info"
+					>
+						<RadioButton group="synchrodynamic" text="#Common_Off" value="0" />
+						<RadioButton group="synchrodynamic" text="#Common_On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
 						text="#Settings_Synchronizer_Direction"
 						convar="mom_hud_synchro_flip_enable"
 						infomessage="#Settings_Synchronizer_Direction_Info"

--- a/layout/settings/settings_interface.xml
+++ b/layout/settings/settings_interface.xml
@@ -623,15 +623,15 @@
 
 				<Panel class="settings-group__header">
 
-					<Label class="settings-group__title" text="Jump Stats" />
+					<Label class="settings-group__title" text="#Settings_JumpStats_Title" />
 
 					<Panel class="flow-right horizontal-align-right">
 
 						<Button class="button mr-3" onactivate="SettingsShared.showImportExportDialogue('Jump Stats', 'JumpStatsSubSection')">
-							<Label class="button__text" text="Import/Export" />
+							<Label class="button__text" text="#Settings_ImportExport_ImportExport" />
 						</Button>
 
-						<TooltipPanel class="settings-group__reset" tooltip="Reset">
+						<TooltipPanel class="settings-group__reset" tooltip="#Settings_General_Reset">
 							<Button class="button" onactivate="SettingsShared.resetSettings('JumpStatsSubSection');">
 								<Image class="button__icon" src="file://{images}/reset.svg" />
 							</Button>
@@ -641,125 +641,143 @@
 
 				</Panel>
 
-					<ChaosSettingsEnum text="Show jump stats" convar="mom_hud_jstats_enable" infomessage="When enabled, the .">
-						<RadioButton group="jumpstatsenable" text="Off" value="0" />
-						<RadioButton group="jumpstatsenable" text="On" value="1" />
+					<ChaosSettingsEnum
+					text="#Settings_JumpStats_Enable"
+					convar="mom_hud_jstats_enable"
+					infomessage="#Settings_JumpStats_Enable_Info"
+				>
+						<RadioButton group="jumpstatsenable" text="#Common_Off" value="0" />
+						<RadioButton group="jumpstatsenable" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 				<ConVarEnabler convar="mom_hud_jstats_enable" class="flow-down">
 					<ChaosSettingsSlider
-						text="First"
+						text="#Settings_JumpStats_First"
 						min="0"
 						max="10"
 						convar="mom_hud_jstats_first"
 						displayprecision="0"
-						infomessage="First jump to print jump stats."
+						infomessage="#Settings_JumpStats_First_Info"
 						hasdocspage="false"
 					/>
 				
 					<ChaosSettingsSlider
-						text="Interval"
+						text="#Settings_JumpStats_Interval"
 						min="1"
 						max="10"
 						convar="mom_hud_jstats_interval"
 						displayprecision="0"
-						infomessage="Number of jumps between jump stat messages. Setting -1 prevents printing recurring jump stats (only first data is displayed)."
+						infomessage="#Settings_JumpStats_Interval_Info"
+						hasdocspage="false"
+					/>
+				
+					<ChaosSettingsSlider
+						text="#Settings_JumpStats_Log"
+						min="1"
+						max="10"
+						convar="mom_hud_jstats_log"
+						displayprecision="0"
+						infomessage="#Settings_JumpStats_Log_Info"
 						hasdocspage="false"
 					/>
 				
 					<ChaosSettingsEnum
-						text="Takeoff speed"
+						text="#Settings_JumpStats_TakeoffSpeed"
 						convar="mom_hud_jstats_takeoff_speed_enable"
-						infomessage="Show jump takeoff speed in jump stats."
+						infomessage="#Settings_JumpStats_TakeoffSpeed_Info"
 					>
-						<RadioButton group="takeoffspeed" text="Off" value="0" />
-						<RadioButton group="takeoffspeed" text="On" value="1" />
+						<RadioButton group="takeoffspeed" text="#Common_Off" value="0" />
+						<RadioButton group="takeoffspeed" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Speed Delta"
+						text="#Settings_JumpStats_SpeedDelta"
 						convar="mom_hud_jstats_speed_delta_enable"
-						infomessage="Show jump speed delta in jump stats."
+						infomessage="#Settings_JumpStats_SpeedDelta_Info"
 					>
-						<RadioButton group="deltaspeed" text="Off" value="0" />
-						<RadioButton group="deltaspeed" text="On" value="1" />
+						<RadioButton group="deltaspeed" text="#Common_Off" value="0" />
+						<RadioButton group="deltaspeed" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Takeoff time"
+						text="#Settings_JumpStats_TakeoffTime"
 						convar="mom_hud_jstats_takeoff_time_enable"
-						infomessage="Show jump takeoff time in jump stats."
+						infomessage="#Settings_JumpStats_TakeoffTime_Info"
 					>
-						<RadioButton group="jumptime" text="Off" value="0" />
-						<RadioButton group="jumptime" text="On" value="1" />
+						<RadioButton group="jumptime" text="#Common_Off" value="0" />
+						<RadioButton group="jumptime" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Jump time delta"
+						text="#Settings_JumpStats_TimeDelta"
 						convar="mom_hud_jstats_time_delta_enable"
-						infomessage="Show jump time delta in jump stats."
+						infomessage="#Settings_JumpStats_TimeDelta_Info"
 					>
-						<RadioButton group="jumptimedelta" text="Off" value="0" />
-						<RadioButton group="jumptimedelta" text="On" value="1" />
+						<RadioButton group="jumptimedelta" text="#Common_Off" value="0" />
+						<RadioButton group="jumptimedelta" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Strafe sync"
+						text="#Settings_JumpStats_StrafeSync"
 						convar="mom_hud_jstats_strafe_sync_enable"
-						infomessage="Show ratio of speed gain ticks to jump ticks in jump stats."
+						infomessage="#Settings_JumpStats_StrafeSync_Info"
 					>
-						<RadioButton group="syncratio" text="Off" value="0" />
-						<RadioButton group="syncratio" text="On" value="1" />
+						<RadioButton group="syncratio" text="#Common_Off" value="0" />
+						<RadioButton group="syncratio" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Strafe count"
+						text="#Settings_JumpStats_StrafeCount"
 						convar="mom_hud_jstats_strafe_count_enable"
-						infomessage="Show number of strafes in jump stats."
+						infomessage="#Settings_JumpStats_StrafeCount_Info"
 					>
-						<RadioButton group="jumpstrafes" text="Off" value="0" />
-						<RadioButton group="jumpstrafes" text="On" value="1" />
+						<RadioButton group="jumpstrafes" text="#Common_Off" value="0" />
+						<RadioButton group="jumpstrafes" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Speed Gain"
+						text="#Settings_JumpStats_SpeedGain"
 						convar="mom_hud_jstats_speed_gain_enable"
-						infomessage="Show speed gain ratio in jump stats. Speed gain is calculated as the ratio of actual speed gained from strafing to ideal maximum speed gain."
+						infomessage="#Settings_JumpStats_SpeedGain_Info"
 					>
-						<RadioButton group="speedgain" text="Off" value="0" />
-						<RadioButton group="speedgain" text="On" value="1" />
+						<RadioButton group="speedgain" text="#Common_Off" value="0" />
+						<RadioButton group="speedgain" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Strafe ratio (JSS)"
+						text="#Settings_JumpStats_StrafeRatio"
 						convar="mom_hud_jstats_strafe_ratio_enable"
-						infomessage="Strafe ratio is calculated as the ratio of actual strafe angle to ideal strafe angle."
+						infomessage="#Settings_JumpStats_StrafeRatio_Info"
 					>
-						<RadioButton group="straferatio" text="Off" value="0" />
-						<RadioButton group="straferatio" text="On" value="1" />
+						<RadioButton group="yawratio" text="#Common_Off" value="0" />
+						<RadioButton group="yawratio" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Height delta"
+						text="#Settings_JumpStats_HeightDelta"
 						convar="mom_hud_jstats_height_delta_enable"
-						infomessage="Show height delta in jump stats."
+						infomessage="#Settings_JumpStats_HeightDelta_Info"
 					>
-						<RadioButton group="heightdelta" text="Off" value="0" />
-						<RadioButton group="heightdelta" text="On" value="1" />
-					</ChaosSettingsEnum>
-
-					<ChaosSettingsEnum text="Distance" convar="mom_hud_jstats_distance_enable" infomessage="Show traveled jump distance.">
-						<RadioButton group="distance" text="Off" value="0" />
-						<RadioButton group="distance" text="On" value="1" />
+						<RadioButton group="heightdelta" text="#Common_Off" value="0" />
+						<RadioButton group="heightdelta" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="Jump efficiency"
-						convar="mom_hud_jstats_efficiency_enable"
-						infomessage="Show jump efficiency in jump stats. Jump efficiency is calculated as the ratio of displacement to distance travelled."
+						text="#Settings_JumpStats_Distance"
+						convar="mom_hud_jstats_distance_enable"
+						infomessage="#Settings_JumpStats_Distance_Info"
 					>
-						<RadioButton group="efficiency" text="Off" value="0" />
-						<RadioButton group="efficiency" text="On" value="1" />
+						<RadioButton group="distance" text="#Common_Off" value="0" />
+						<RadioButton group="distance" text="#Common_On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="#Settings_JumpStats_Efficiency"
+						convar="mom_hud_jstats_efficiency_enable"
+						infomessage="#Settings_JumpStats_Efficiency"
+					>
+						<RadioButton group="efficiency" text="#Common_Off" value="0" />
+						<RadioButton group="efficiency" text="#Common_On" value="1" />
 					</ChaosSettingsEnum>
 				</ConVarEnabler>
 
@@ -877,7 +895,7 @@
 						convar="mom_hud_synchro_stat_mode"
 						infomessage="#Settings_Synchronizer_Stats_Mode_Info"
 					>
-						<Label id="mode0" text="#Settings_Synchronizer_StatsMode_Mode0" value="0" />
+						<Label id="mode0" text="#Common_Off" value="0" />
 						<Label id="mode1" text="#Settings_Synchronizer_StatsMode_Mode1" value="1" />
 						<Label id="mode2" text="#Settings_Synchronizer_StatsMode_Mode2" value="2" />
 					</ChaosSettingsEnumDropDown>

--- a/layout/settings/settings_interface.xml
+++ b/layout/settings/settings_interface.xml
@@ -618,7 +618,155 @@
 			</Panel>
 
 			<Panel class="settings-page__spacer" />
+			
+			<Panel id="JumpStatsSubSection" class="settings-group">
 
+				<Panel class="settings-group__header">
+
+					<Label class="settings-group__title" text="Jump Stats" />
+
+					<Panel class="flow-right horizontal-align-right">
+
+						<Button class="button mr-3" onactivate="SettingsShared.showImportExportDialogue('Jump Stats', 'JumpStatsSubSection')">
+							<Label class="button__text" text="Import/Export" />
+						</Button>
+
+						<TooltipPanel class="settings-group__reset" tooltip="Reset">
+							<Button class="button" onactivate="SettingsShared.resetSettings('JumpStatsSubSection');">
+								<Image class="button__icon" src="file://{images}/reset.svg" />
+							</Button>
+						</TooltipPanel>
+
+					</Panel>
+
+				</Panel>
+
+					<ChaosSettingsEnum text="Show jump stats" convar="mom_hud_jstats_enable" infomessage="When enabled, the .">
+						<RadioButton group="jumpstatsenable" text="Off" value="0" />
+						<RadioButton group="jumpstatsenable" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+				<ConVarEnabler convar="mom_hud_jstats_enable" class="flow-down">
+					<ChaosSettingsSlider
+						text="First"
+						min="0"
+						max="10"
+						convar="mom_hud_jstats_first"
+						displayprecision="0"
+						infomessage="First jump to print jump stats."
+						hasdocspage="false"
+					/>
+				
+					<ChaosSettingsSlider
+						text="Interval"
+						min="1"
+						max="10"
+						convar="mom_hud_jstats_interval"
+						displayprecision="0"
+						infomessage="Number of jumps between jump stat messages. Setting -1 prevents printing recurring jump stats (only first data is displayed)."
+						hasdocspage="false"
+					/>
+				
+					<ChaosSettingsEnum
+						text="Takeoff speed"
+						convar="mom_hud_jstats_takeoff_speed_enable"
+						infomessage="Show jump takeoff speed in jump stats."
+					>
+						<RadioButton group="takeoffspeed" text="Off" value="0" />
+						<RadioButton group="takeoffspeed" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Speed Delta"
+						convar="mom_hud_jstats_speed_delta_enable"
+						infomessage="Show jump speed delta in jump stats."
+					>
+						<RadioButton group="deltaspeed" text="Off" value="0" />
+						<RadioButton group="deltaspeed" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Takeoff time"
+						convar="mom_hud_jstats_takeoff_time_enable"
+						infomessage="Show jump takeoff time in jump stats."
+					>
+						<RadioButton group="jumptime" text="Off" value="0" />
+						<RadioButton group="jumptime" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Jump time delta"
+						convar="mom_hud_jstats_time_delta_enable"
+						infomessage="Show jump time delta in jump stats."
+					>
+						<RadioButton group="jumptimedelta" text="Off" value="0" />
+						<RadioButton group="jumptimedelta" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Strafe sync"
+						convar="mom_hud_jstats_strafe_sync_enable"
+						infomessage="Show ratio of speed gain ticks to jump ticks in jump stats."
+					>
+						<RadioButton group="syncratio" text="Off" value="0" />
+						<RadioButton group="syncratio" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Strafe count"
+						convar="mom_hud_jstats_strafe_count_enable"
+						infomessage="Show number of strafes in jump stats."
+					>
+						<RadioButton group="jumpstrafes" text="Off" value="0" />
+						<RadioButton group="jumpstrafes" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Speed Gain"
+						convar="mom_hud_jstats_speed_gain_enable"
+						infomessage="Show speed gain ratio in jump stats. Speed gain is calculated as the ratio of actual speed gained from strafing to ideal maximum speed gain."
+					>
+						<RadioButton group="speedgain" text="Off" value="0" />
+						<RadioButton group="speedgain" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Strafe ratio (JSS)"
+						convar="mom_hud_jstats_strafe_ratio_enable"
+						infomessage="Strafe ratio is calculated as the ratio of actual strafe angle to ideal strafe angle."
+					>
+						<RadioButton group="straferatio" text="Off" value="0" />
+						<RadioButton group="straferatio" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Height delta"
+						convar="mom_hud_jstats_height_delta_enable"
+						infomessage="Show height delta in jump stats."
+					>
+						<RadioButton group="heightdelta" text="Off" value="0" />
+						<RadioButton group="heightdelta" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum text="Distance" convar="mom_hud_jstats_distance_enable" infomessage="Show traveled jump distance.">
+						<RadioButton group="distance" text="Off" value="0" />
+						<RadioButton group="distance" text="On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ChaosSettingsEnum
+						text="Jump efficiency"
+						convar="mom_hud_jstats_efficiency_enable"
+						infomessage="Show jump efficiency in jump stats. Jump efficiency is calculated as the ratio of displacement to distance travelled."
+					>
+						<RadioButton group="efficiency" text="Off" value="0" />
+						<RadioButton group="efficiency" text="On" value="1" />
+					</ChaosSettingsEnum>
+				</ConVarEnabler>
+
+			</Panel>
+
+			<Panel class="settings-page__spacer" />
+			
 			<Panel id="StrafeSyncSubSection" class="settings-group">
 
 				<Panel class="settings-group__header">

--- a/layout/settings/settings_interface.xml
+++ b/layout/settings/settings_interface.xml
@@ -745,9 +745,9 @@
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnum
-						text="#Settings_JumpStats_StrafeRatio"
-						convar="mom_hud_jstats_strafe_ratio_enable"
-						infomessage="#Settings_JumpStats_StrafeRatio_Info"
+						text="#Settings_JumpStats_YawRatio"
+						convar="mom_hud_jstats_yaw_ratio_enable"
+						infomessage="#Settings_JumpStats_YawRatio_Info"
 					>
 						<RadioButton group="yawratio" text="#Common_Off" value="0" />
 						<RadioButton group="yawratio" text="#Common_On" value="1" />

--- a/scripts/common/panelregistration.js
+++ b/scripts/common/panelregistration.js
@@ -30,6 +30,7 @@
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudWeaponSelection', 'file://{resources}/layout/hud/weaponselection.xml');
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudCgaz', 'file://{resources}/layout/hud/cgaz.xml');
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudDFJump', 'file://{resources}/layout/hud/dfjump.xml');
+	UiToolkitAPI.RegisterHUDPanel2d('MomHudJumpStats', 'file://{resources}/layout/hud/jumpstats.xml');
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudSpecInfo', 'file://{resources}/layout/hud/specinfo.xml');
 	UiToolkitAPI.RegisterHUDPanel2d('MomHudSynchronizer', 'file://{resources}/layout/hud/synchronizer.xml');
 

--- a/scripts/common/settings.js
+++ b/scripts/common/settings.js
@@ -59,6 +59,7 @@ const SettingsTabs = {
 			TimerSubSection: 'TimerRadio',
 			PlayerStatusSubSection: 'PlayerStatusRadio',
 			KeypressSubSection: 'KeypressRadio',
+			JumpStatsSubSection: 'JumpStatsRadio',
 			WeaponSelSubSection: 'WeaponSelRadio',
 			StrafeSyncSubSection: 'StrafeSyncRadio',
 			SynchronizerSubSection: 'SynchronizerRadio',

--- a/scripts/hud/jumpstats.js
+++ b/scripts/hud/jumpstats.js
@@ -1,0 +1,107 @@
+'use strict';
+
+class JumpStats {
+	/** @type {Label} @static */
+	static label = $('#JumpStatsLabel');
+	/** @type {Panel} @static */
+	static container = $('#JumpStatsContainer');
+	/** @type {Panel} @static */
+	static panel = $.GetContextPanel();
+
+	static bufferLength = 10;
+
+	static onJumpEnded() {
+		const lastJumpStats = MomentumMovementAPI.GetLastJumpStats();
+		if (lastJumpStats.jumpCount < this.jumpStatsConfig.statsFirstPrint) {
+			return;
+		}
+
+		if (
+			(lastJumpStats.jumpCount - this.jumpStatsConfig.statsFirstPrint) % this.jumpStatsConfig.statsInterval !==
+			0
+		) {
+			return;
+		}
+
+		this.addToBuffer(this.countBuffer, lastJumpStats.jumpCount + ':');
+		this.addToBuffer(this.takeoffSpeedBuffer, lastJumpStats.takeoffSpeed.toFixed());
+		this.addToBuffer(this.speedDeltaBuffer, lastJumpStats.jumpSpeedDelta.toFixed());
+		this.addToBuffer(this.takeoffTimeBuffer, this.makeTime(lastJumpStats.takeoffTime.toFixed(3)));
+		this.addToBuffer(this.timeDeltaBuffer, lastJumpStats.timeDelta.toFixed(3));
+		this.addToBuffer(this.strafesBuffer, lastJumpStats.strafeCount);
+		this.addToBuffer(this.syncBuffer, lastJumpStats.strafeSync.toFixed(2));
+		this.addToBuffer(this.gainBuffer, lastJumpStats.speedGain.toFixed(2));
+		this.addToBuffer(this.strafeRatioBuffer, lastJumpStats.strafeRatio.toFixed(2));
+		this.addToBuffer(this.heightDeltaBuffer, lastJumpStats.heightDelta.toFixed(1));
+		this.addToBuffer(this.distanceBuffer, lastJumpStats.distance.toFixed(1));
+		this.addToBuffer(this.efficiencyBuffer, lastJumpStats.efficiency.toFixed(2));
+
+		this.setText();
+	}
+
+	static initializeBuffer(size) {
+		return Array(size).fill('');
+	}
+
+	static addToBuffer(buffer, value) {
+		buffer[buffer.length - 1] += '\n';
+		buffer.push(value);
+
+		if (buffer.length > this.bufferLength) buffer.shift();
+	}
+
+	static getBufferedSum(history) {
+		return history.reduce((sum, element) => sum + element);
+	}
+
+	static onConfigChange() {
+		this.jumpStatsConfig = this.panel.jumpStatsCFG;
+	}
+
+	static onLoad() {
+		this.onConfigChange();
+		this.countBuffer = this.initializeBuffer(this.bufferLength);
+		this.takeoffSpeedBuffer = this.initializeBuffer(this.bufferLength);
+		this.speedDeltaBuffer = this.initializeBuffer(this.bufferLength);
+		this.takeoffTimeBuffer = this.initializeBuffer(this.bufferLength);
+		this.timeDeltaBuffer = this.initializeBuffer(this.bufferLength);
+		this.strafesBuffer = this.initializeBuffer(this.bufferLength);
+		this.syncBuffer = this.initializeBuffer(this.bufferLength);
+		this.gainBuffer = this.initializeBuffer(this.bufferLength);
+		this.strafeRatioBuffer = this.initializeBuffer(this.bufferLength);
+		this.heightDeltaBuffer = this.initializeBuffer(this.bufferLength);
+		this.distanceBuffer = this.initializeBuffer(this.bufferLength);
+		this.efficiencyBuffer = this.initializeBuffer(this.bufferLength);
+
+		this.setText();
+	}
+
+	static setText() {
+		this.panel.SetDialogVariable('jump_count', this.getBufferedSum(this.countBuffer));
+		this.panel.SetDialogVariable('speed', this.getBufferedSum(this.takeoffSpeedBuffer));
+		this.panel.SetDialogVariable('speed_delta', this.getBufferedSum(this.speedDeltaBuffer));
+		this.panel.SetDialogVariable('time', this.getBufferedSum(this.takeoffTimeBuffer));
+		this.panel.SetDialogVariable('time_delta', this.getBufferedSum(this.timeDeltaBuffer));
+		this.panel.SetDialogVariable('strafes', this.getBufferedSum(this.strafesBuffer));
+		this.panel.SetDialogVariable('sync', this.getBufferedSum(this.syncBuffer));
+		this.panel.SetDialogVariable('gain', this.getBufferedSum(this.gainBuffer));
+		this.panel.SetDialogVariable('strafe_ratio', this.getBufferedSum(this.strafeRatioBuffer));
+		this.panel.SetDialogVariable('height_delta', this.getBufferedSum(this.heightDeltaBuffer));
+		this.panel.SetDialogVariable('distance', this.getBufferedSum(this.distanceBuffer));
+		this.panel.SetDialogVariable('efficiency', this.getBufferedSum(this.efficiencyBuffer));
+	}
+
+	static makeTime(value) {
+		const hours = (value / 3600).toFixed().padStart(2, '0');
+		const minutes = (Math.floor(value / 60) % 60).toFixed().padStart(2, '0');
+		const seconds = (value % 60).toFixed(3).padStart(6, '0');
+		return `${hours}:${minutes}:${seconds}`;
+	}
+
+	static {
+		$.RegisterEventHandler('OnJumpEnded', this.container, this.onJumpEnded.bind(this));
+
+		$.RegisterForUnhandledEvent('ChaosLevelInitPostEntity', this.onLoad.bind(this));
+		$.RegisterForUnhandledEvent('OnJumpStatsCFGChange', this.onConfigChange.bind(this));
+	}
+}

--- a/scripts/hud/jumpstats.js
+++ b/scripts/hud/jumpstats.js
@@ -31,8 +31,11 @@ class JumpStats {
 		this.addToBuffer(this.strafesBuffer, lastJumpStats.strafeCount);
 		this.addToBuffer(this.syncBuffer, lastJumpStats.strafeSync.toFixed(2));
 		this.addToBuffer(this.gainBuffer, lastJumpStats.speedGain.toFixed(2));
-		this.addToBuffer(this.strafeRatioBuffer, lastJumpStats.strafeRatio.toFixed(2));
-		this.addToBuffer(this.heightDeltaBuffer, lastJumpStats.heightDelta.toFixed(1));
+		this.addToBuffer(this.yawRatioBuffer, lastJumpStats.yawRatio.toFixed(2));
+		this.addToBuffer(
+			this.heightDeltaBuffer,
+			(Math.abs(lastJumpStats.heightDelta) < 0.1 ? 0 : lastJumpStats.heightDelta).toFixed(1)
+		);
 		this.addToBuffer(this.distanceBuffer, lastJumpStats.distance.toFixed(1));
 		this.addToBuffer(this.efficiencyBuffer, lastJumpStats.efficiency.toFixed(2));
 
@@ -79,7 +82,7 @@ class JumpStats {
 		this.strafesBuffer = this.initializeBuffer(this.bufferLength);
 		this.syncBuffer = this.initializeBuffer(this.bufferLength);
 		this.gainBuffer = this.initializeBuffer(this.bufferLength);
-		this.strafeRatioBuffer = this.initializeBuffer(this.bufferLength);
+		this.yawRatioBuffer = this.initializeBuffer(this.bufferLength);
 		this.heightDeltaBuffer = this.initializeBuffer(this.bufferLength);
 		this.distanceBuffer = this.initializeBuffer(this.bufferLength);
 		this.efficiencyBuffer = this.initializeBuffer(this.bufferLength);
@@ -94,7 +97,7 @@ class JumpStats {
 		this.panel.SetDialogVariable('strafes', this.getBufferedSum(this.strafesBuffer));
 		this.panel.SetDialogVariable('sync', this.getBufferedSum(this.syncBuffer));
 		this.panel.SetDialogVariable('gain', this.getBufferedSum(this.gainBuffer));
-		this.panel.SetDialogVariable('strafe_ratio', this.getBufferedSum(this.strafeRatioBuffer));
+		this.panel.SetDialogVariable('yaw_ratio', this.getBufferedSum(this.yawRatioBuffer));
 		this.panel.SetDialogVariable('height_delta', this.getBufferedSum(this.heightDeltaBuffer));
 		this.panel.SetDialogVariable('distance', this.getBufferedSum(this.distanceBuffer));
 		this.panel.SetDialogVariable('efficiency', this.getBufferedSum(this.efficiencyBuffer));

--- a/scripts/hud/jumpstats.js
+++ b/scripts/hud/jumpstats.js
@@ -8,15 +8,15 @@ class JumpStats {
 	/** @type {Panel} @static */
 	static panel = $.GetContextPanel();
 
-	static bufferLength = 10;
-
 	static onJumpEnded() {
 		const lastJumpStats = MomentumMovementAPI.GetLastJumpStats();
 		if (lastJumpStats.jumpCount < this.jumpStatsConfig.statsFirstPrint) {
 			return;
 		}
 
-		if (
+		if (this.jumpStatsConfig.statsInterval === 0) {
+			if (lastJumpStats.jumpCount !== this.jumpStatsConfig.statsFirstPrint) return;
+		} else if (
 			(lastJumpStats.jumpCount - this.jumpStatsConfig.statsFirstPrint) % this.jumpStatsConfig.statsInterval !==
 			0
 		) {
@@ -40,7 +40,9 @@ class JumpStats {
 	}
 
 	static initializeBuffer(size) {
-		return Array(size).fill('');
+		let buffer = Array(size).fill('\n');
+		buffer[buffer.length - 1] = '';
+		return buffer;
 	}
 
 	static addToBuffer(buffer, value) {
@@ -56,10 +58,19 @@ class JumpStats {
 
 	static onConfigChange() {
 		this.jumpStatsConfig = this.panel.jumpStatsCFG;
+		if (this.jumpStatsConfig.statsLog !== this.bufferLength) {
+			this.bufferLength = this.jumpStatsConfig.statsLog;
+			this.initializeStats();
+		}
 	}
 
 	static onLoad() {
 		this.onConfigChange();
+		this.initializeStats();
+		this.setText();
+	}
+
+	static initializeStats() {
 		this.countBuffer = this.initializeBuffer(this.bufferLength);
 		this.takeoffSpeedBuffer = this.initializeBuffer(this.bufferLength);
 		this.speedDeltaBuffer = this.initializeBuffer(this.bufferLength);
@@ -72,8 +83,6 @@ class JumpStats {
 		this.heightDeltaBuffer = this.initializeBuffer(this.bufferLength);
 		this.distanceBuffer = this.initializeBuffer(this.bufferLength);
 		this.efficiencyBuffer = this.initializeBuffer(this.bufferLength);
-
-		this.setText();
 	}
 
 	static setText() {

--- a/scripts/hud/synchronizer.js
+++ b/scripts/hud/synchronizer.js
@@ -55,12 +55,12 @@ class Synchronizer {
 		);
 		const gainRatio = this.getBufferedSum(this.gainRatioHistory);
 
-		const ratio = this.mom_hud_synchro_mode > 2 ? 1 - lastTickStats.strafeRatio : lastTickStats.strafeRatio;
-		this.addToBuffer(this.strafeRatioHistory, this.sampleWeight * this.NaNCheck(ratio, 0));
-		const strafeRatio = this.getBufferedSum(this.strafeRatioHistory);
+		const ratio = this.mom_hud_synchro_mode > 2 ? 1 - lastTickStats.yawRatio : lastTickStats.yawRatio;
+		this.addToBuffer(this.yawRatioHistory, this.sampleWeight * this.NaNCheck(ratio, 0));
+		const yawRatio = this.getBufferedSum(this.yawRatioHistory);
 
 		const colorTuple = this.mom_hud_synchro_color_enable
-			? this.getColorTuple(gainRatio, false) //strafeRight * strafeRatio > 1)
+			? this.getColorTuple(gainRatio, false) //strafeRight * yawRatio > 1)
 			: COLORS.NEUTRAL;
 		const color = `gradient(linear, 0% 0%, 0% 100%, from(${colorTuple[0]}), to(${colorTuple[1]}))`;
 		let flow;
@@ -70,11 +70,11 @@ class Synchronizer {
 				flow = direction * flip;
 				this.panels.container.style.flowChildren = flow < 0 ? 'left' : 'right';
 				this.panels.segments[0].style.backgroundColor = color;
-				this.panels.segments[0].style.width = (strafeRatio * 50).toFixed(3) + '%';
+				this.panels.segments[0].style.width = (yawRatio * 50).toFixed(3) + '%';
 				break;
 			case 2: // "Full-width throttle"
 				const absRatio = Math.abs(gainRatio);
-				flow = direction * (strafeRatio > 1 ? -1 : 1) * flip;
+				flow = direction * (yawRatio > 1 ? -1 : 1) * flip;
 				this.panels.container.style.flowChildren = flow < 0 ? 'left' : 'right';
 				this.panels.segments[0].style.backgroundColor = color;
 				this.panels.segments[0].style.width = (absRatio * 100).toFixed(3) + '%';
@@ -82,13 +82,13 @@ class Synchronizer {
 			case 3: // "Strafe indicator"
 				this.panels.container.style.flowChildren = flip < 0 ? 'left' : 'right';
 				//const offset = Math.min(Math.max(0.5 - (0.5 * direction * syncDelta) / idealDelta, 0), 1);
-				const offset = Math.min(Math.max(0.5 - 0.5 * direction * strafeRatio, 0), 1);
+				const offset = Math.min(Math.max(0.5 - 0.5 * direction * yawRatio, 0), 1);
 				this.panels.segments[0].style.width = (offset * this.indicatorPercentage).toFixed(3) + '%';
 				this.panels.segments[1].style.backgroundColor = color;
 				break;
 			case 4: // "Synchronizer"
 				this.panels.container.style.flowChildren = flip < 0 ? 'left' : 'right';
-				this.firstPanelWidth += this.syncGain * direction * strafeRatio * lastTickStats.idealGain;
+				this.firstPanelWidth += this.syncGain * direction * yawRatio * lastTickStats.idealGain;
 				this.firstPanelWidth = this.wrapValueToRange(this.firstPanelWidth, 0, this.maxSegmentWidth, true);
 				this.panels.segments[0].style.width =
 					this.NaNCheck(this.firstPanelWidth.toFixed(3), this.maxSegmentWidth) + '%';
@@ -105,11 +105,11 @@ class Synchronizer {
 		this.panels.stats[0].text =
 			`${lastJumpStats.jumpCount}: `.padStart(6, ' ') +
 			`${lastJumpStats.takeoffSpeed.toFixed()} `.padStart(6, ' ') +
-			`(${(lastJumpStats.strafeRatio * 100).toFixed(2)}%)`.padStart(10, ' ');
+			`(${(lastJumpStats.yawRatio * 100).toFixed(2)}%)`.padStart(10, ' ');
 		this.panels.stats[1].text = (lastJumpStats.speedGain * 100).toFixed(2);
 		/*
 		const colorTuple = this.mom_hud_synchro_color_enable
-			? this.getColorTuple(lastJumpStats.speedGain, lastJumpStats.strafeRatio > 0)
+			? this.getColorTuple(lastJumpStats.speedGain, lastJumpStats.yawRatio > 0)
 			: COLORS.NEUTRAL;
 		const color = `gradient(linear, 0% 0%, 0% 100%, from(${colorTuple[0]}), to(${colorTuple[1]}))`;
 		this.panels.stats.forEach((stat) => (stat.style.color = color));
@@ -273,7 +273,7 @@ class Synchronizer {
 		this.sampleWeight = 1 / this.interpFrames;
 
 		this.gainRatioHistory = this.initializeBuffer(this.interpFrames);
-		this.strafeRatioHistory = this.initializeBuffer(this.interpFrames);
+		this.yawRatioHistory = this.initializeBuffer(this.interpFrames);
 	}
 
 	static setSynchroStatMode(newStatMode) {

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -687,6 +687,16 @@ $strafesync-color-increase: $blue !default;
 $strafesync-color-decrease: $red !default;
 
 // ================
+// JUMP STATS
+// ================
+$jump-stats-width: 600px !default;
+$jump-stats-height: 200px !default;
+$jump-stats-font-size: 16px !default;
+$jump-stats-color-default: $white !default;
+$jump-stats-color-increase: $blue !default;
+$jump-stats-color-decrease: $red !default;
+
+// ================
 // TIMER
 // ================
 $timer-font-weight: black !default;

--- a/styles/hud/_index.scss
+++ b/styles/hud/_index.scss
@@ -14,6 +14,7 @@
 @use 'hudchat';
 @use 'hudhinttext';
 @use 'hudreticle';
+@use 'jumpstats';
 @use 'keypress';
 @use 'mapinfo';
 @use 'replaycontrols';

--- a/styles/hud/jumpstats.scss
+++ b/styles/hud/jumpstats.scss
@@ -73,7 +73,7 @@
 			width: 60px;
 		}
 
-		&--strafe-ratio {
+		&--yaw-ratio {
 			width: 80px;
 		}
 

--- a/styles/hud/jumpstats.scss
+++ b/styles/hud/jumpstats.scss
@@ -1,0 +1,92 @@
+@use '../config' as *;
+@use '../abstract/mixin';
+
+.jumpstats {
+	align: center top;
+
+	&__container {
+		width: fit-children; //$jump-stats-width;
+		height: fit-children; //$jump-stats-height;
+		flow-children: right;
+		padding: 5px;
+		background-color: rgba(0, 0, 0, 0.3);
+	}
+
+	&__label {
+		@include mixin.font-styles($use-header: false);
+		align: center bottom;
+		margin: 5px;
+		flow-children: up;
+		vertical-align: top;
+		color: $jump-stats-color-default;
+
+		&--name {
+			width: 100%;
+			font-size: $jump-stats-font-size;
+			text-align: center;
+			border-top: 1px solid white;
+		}
+
+		&--values {
+			horizontal-align: center;
+			font-size: $jump-stats-font-size;
+			text-align: right;
+		}
+
+		&--increase {
+			color: $jump-stats-color-increase;
+		}
+
+		&--decrease {
+			color: $jump-stats-color-decrease;
+		}
+
+		&--count {
+			max-width: 60px;
+		}
+
+		&--speed {
+			width: 60px;
+		}
+
+		&--speed-delta {
+			width: 60px;
+		}
+
+		&--time {
+			width: 100px;
+		}
+
+		&--time-delta {
+			width: 60px;
+		}
+
+		&--strafes {
+			width: 60px;
+		}
+
+		&--sync {
+			width: 60px;
+		}
+
+		&--gain {
+			width: 60px;
+		}
+
+		&--strafe-ratio {
+			width: 80px;
+		}
+
+		&--height-delta {
+			width: 80px;
+		}
+
+		&--distance {
+			width: 80px;
+		}
+
+		&--efficiency {
+			width: 60px;
+		}
+	}
+}

--- a/styles/hud/synchronizer.scss
+++ b/styles/hud/synchronizer.scss
@@ -5,14 +5,19 @@
 $border-color: rgba(255, 255, 255, 0.3);
 
 .synchronizer {
+	height: 80px;
 	horizontal-align: center;
-	margin-bottom: 32px;
+	overflow: noclip;
+
+	&__bar-wrapper {
+		margin-bottom: 32px;
+		transform: translateY(32px);
+	}
 
 	&__background {
 		height: 16px;
 		width: 300px;
 		background-color: color.scale(rgba($progressbar-background, 1), $lightness: 2%);
-		box-shadow: fill 0px 1px 3px 1px rgba(0, 0, 0, 0.9);
 		border-radius: 8px;
 	}
 
@@ -33,5 +38,25 @@ $border-color: rgba(255, 255, 255, 0.3);
 		width: 2px;
 		horizontal-align: center;
 		background-color: rgba(0, 0, 0, 1);
+	}
+
+	&__stats {
+		height: 100%;
+		width: 300px;
+		padding: 2px;
+		vertical-align: center;
+		horizontal-align: center;
+
+		&--upper {
+			align: center top;
+			font-size: 20px;
+			font-weight: bold;
+		}
+
+		&--lower {
+			align: center bottom;
+			font-size: 20px;
+			font-weight: bold;
+		}
 	}
 }


### PR DESCRIPTION
This PR introduces a panel to implement jump stats like the SSJ plugin popular in CS:S. The ability to show jump stats on the strafe synchronizer is also introduced in this PR.

Jump stat settings:
- `mom_hud_jstats_enable` display bhop jump stats
- `mom_hud_jstats_first` first jump to log stats on jump stats panel
- `mom_hud_jstats_interval` log stats every X jumps after first log
- `mom_hud_jstats_takeoff_speed_enable` show takeoff speed on jump stats panel
- `mom_hud_jstats_speed_delta_enable` show speed delta on jump stats panel
- `mom_hud_jstats_takeoff_time_enable` show takeoff time on jump stats panel
- `mom_hud_jstats_time_delta_enable` show time delta on jump stats panel
- `mom_hud_jstats_strafe_sync_enable` show sync on jump stats panel
- `mom_hud_jstats_strafe_count_enable` show strafe count on jump stats panel
- `mom_hud_jstats_speed_gain_enable` show speed gain on jump stats panel
- `mom_hud_jstats_strafe_ratio_enable` show strafe ratio on jump stats panel
- `mom_hud_jstats_height_delta_enable` show height delta on jump stats panel
- `mom_hud_jstats_efficiency_enable` show jump efficiency on jump stats panel

New synchronizer settings:
- `mom_hud_synchro_stat_mode` show jump stats on strafe synchronizer. 0 = OFF, 1 = Show stats, 2 = Hide bar
- `mom_hud_synchro_dynamic_enable` enable bar direction to change with movement inputs (default ON). Turning this setting off causes the bar to fill from one side no matter the current input direction



Requires red and green changes.