### PR TITLE
Feat: defrag compass (pitch & yaw)

### DIFF
--- a/layout/hud/cgaz.xml
+++ b/layout/hud/cgaz.xml
@@ -42,21 +42,32 @@
 				<Panel id="SnapSplitZone" />
 			</ConVarEnabler>
 		</Panel>
-    <Panel id="VelocityArrow">
-      <ConVarEnabler class="full-height" convar="mom_df_hud_velocity_enable" togglevisibility="true">
-        <Image id="VelocityArrowIcon" class="arrow__up" src="file://{images}/hud/cgaz-arrow.svg" textureheight="48" />
-      </ConVarEnabler>
-    </Panel>
+		<Panel id="CompassArrow">
+			<ConVarEnabler class="full-height" convar="mom_df_hud_compass_mode" togglevisibility="true">
+				<Image id="CompassArrowIcon" class="arrow__up" src="file://{images}/hud/cgaz-arrow.svg" textureheight="48" />
+			</ConVarEnabler>
+		</Panel>
+		<Panel id="PitchLine" class="cgaz-line" />
+		<ConVarEnabler class="full-height" convar="mom_df_hud_compass_stat_mode" togglevisibility="true">
+			<Panel id="StatsBox" class="cgaz-stats__container">
+				<Label id="PitchStat" class="cgaz-stats cgaz-stats__pitch" />
+				<Label id="YawStat" class="cgaz-stats cgaz-stats__yaw" />
+			</Panel>
+		</ConVarEnabler>
+		<Panel id="CompassTicks" class="cgaz__container">
+				<Panel id="FullTick" class="cgaz-tick cgaz-tick__full" />
+				<Panel id="HalfTick" class="cgaz-tick cgaz-tick__half" />
+		</Panel>
 		<Panel id="WindicatorArrow">
-      <ConVarEnabler class="full-height" convar="mom_df_hud_windicator_enable" togglevisibility="true">
-        <Image
+      		<ConVarEnabler class="full-height" convar="mom_df_hud_windicator_enable" togglevisibility="true">
+        		<Image
 					id="WindicatorArrowIcon"
 					class="arrow__down"
 					src="file://{images}/hud/cgaz-arrow.svg"
 					textureheight="48"
 				/>
-      </ConVarEnabler>
-    </Panel>
+      		</ConVarEnabler>
+    	</Panel>
 	</MomHudCgaz>
 
 </root>

--- a/layout/settings/settings_gameplay.xml
+++ b/layout/settings/settings_gameplay.xml
@@ -889,7 +889,6 @@
 
 				</Panel>
 
-
 				<ChaosSettingsEnumDropDown
 					text="#Settings_Defrag_ProjectionMode"
 					convar="mom_df_hud_projection"
@@ -926,31 +925,76 @@
 
 				<Panel class="settings-group__combo">
 
-					<ChaosSettingsEnum
-						text="#Settings_Defrag_Velocity"
-						convar="mom_df_hud_velocity_enable"
-						infomessage="#Settings_Defrag_Velocity_Info"
-					>
-						<RadioButton group="velocityenable" text="#Common_Off" value="0" />
-						<RadioButton group="velocityenable" text="#Common_On" value="1" />
-					</ChaosSettingsEnum>
+					<Label class="settings-group__combo-header" text="#Settings_Defrag_Compass_Title" />
 
-					<ConVarEnabler convar="mom_df_hud_velocity_enable" class="flow-down">
+					<ChaosSettingsEnumDropDown
+						text="#Settings_Defrag_Compass"
+						convar="mom_df_hud_compass_mode"
+						infomessage="#Settings_Defrag_Compass_Info"
+					>
+						<Label id="compass0" text="#Settings_Defrag_CompassMode_Type0" value="0" />
+						<Label id="compass1" text="#Settings_Defrag_CompassMode_Type1" value="1" />
+						<Label id="compass2" text="#Settings_Defrag_CompassMode_Type2" value="2" />
+						<Label id="compass3" text="#Settings_Defrag_CompassMode_Type3" value="3" />
+					</ChaosSettingsEnumDropDown>
+
+					<ConVarEnabler convar="mom_df_hud_compass_mode" class="flow-down">
 						<ChaosSettingsSlider
-							text="#Settings_Defrag_VelocityArrowSize"
+							text="#Settings_Defrag_CompassSize"
 							min="0"
 							max="25"
-							convar="mom_df_hud_velocity_size"
+							convar="mom_df_hud_compass_size"
 							displayprecision="0"
-							infomessage="#Settings_Defrag_VelocityArrowSize_Info"
+							infomessage="#Settings_Defrag_CompassSize_Info"
 						/>
 
-						<ConVarColorDisplay
-							text="#Settings_Defrag_VelocityArrowColor"
-							convar="mom_df_hud_velocity_color"
-							infomessage="#Settings_Defrag_VelocityArrowColor_Info"
-						/>
+						<!-- Stats Enable -->
 					</ConVarEnabler>
+
+					<ChaosSettingsEnum
+						text="#Settings_Defrag_Pitch"
+						convar="mom_df_hud_pitch_enable"
+						infomessage="#Settings_Defrag_Pitch_Info"
+					>
+						<RadioButton group="pitchenable" text="#Common_Off" value="0" />
+						<RadioButton group="pitchenable" text="#Common_On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ConVarEnabler convar="mom_df_hud_pitch_enable" class="flow-down">
+						<ChaosSettingsSlider
+							text="#Settings_Defrag_PitchTarget"
+							min="-90"
+							max="90"
+							convar="mom_df_hud_pitch_target"
+							displayprecision="1"
+							infomessage="#Settings_Defrag_PitchTarget_Info"
+						/>
+
+						<!-- Stats Enable -->
+					</ConVarEnabler>
+
+					<ChaosSettingsEnumDropDown
+						text="#Settings_Defrag_Compass_Stat_Mode"
+						convar="mom_df_hud_compass_stat_mode"
+						infomessage="#Settings_Defrag_Compass_Stat_Mode_Info"
+					>
+						<Label id="stat0" text="#Settings_Defrag_Compass_StatMode_Type0" value="0" />
+						<Label id="stat1" text="#Settings_Defrag_Compass_StatMode_Type1" value="1" />
+						<Label id="stat2" text="#Settings_Defrag_Compass_StatMode_Type2" value="2" />
+						<Label id="stat3" text="#Settings_Defrag_Compass_StatMode_Type3" value="3" />
+					</ChaosSettingsEnumDropDown>
+
+					<ConVarColorDisplay
+						text="#Settings_Defrag_CompassColor"
+						convar="mom_df_hud_compass_color"
+						infomessage="#Settings_Defrag_CompassColor_Info"
+					/>
+
+					<ConVarColorDisplay
+						text="#Settings_Defrag_Compass_Highlight_Color"
+						convar="mom_df_hud_compass_hl_color"
+						infomessage="#Settings_Defrag_Compass_Highlight_Color_Info"
+					/>
 
 				</Panel>
 

--- a/styles/hud/cgaz.scss
+++ b/styles/hud/cgaz.scss
@@ -6,6 +6,7 @@
 	&__container {
 		width: 100%;
 		horizontal-align: left;
+		overflow: noclip noclip;
 	}
 }
 
@@ -16,5 +17,56 @@
 
 	&__down {
 		transform: rotatez(180deg);
+	}
+}
+
+.cgaz-line {
+	width: 100px;
+	margin-top: -1px;
+	border-top: 2px solid;
+	horizontal-align: center;
+	vertical-align: bottom;
+	overflow: noclip noclip;
+}
+
+.cgaz-tick {
+	border-left: 2px solid black;
+	border-right: 2px solid black;
+	//margin-left set in js for positioning
+	margin-right: -1px;
+	vertical-align: top;
+	overflow: noclip noclip;
+
+	&__full {
+		height: 6px;
+	}
+
+	&__half {
+		height: 3px;
+	}
+}
+
+.cgaz-stats {
+	width: 50px;
+	height: 24px;
+	font-size: 20px;
+	text-align: right;
+
+	&__container {
+		width: 200px;
+		height: 100px;
+		horizontal-align: center;
+		vertical-align: center;
+		overflow: noclip;
+	}
+
+	&__pitch {
+		horizontal-align: left;
+		transform: translatex(-40px);
+	}
+
+	&__yaw {
+		horizontal-align: left;
+		transform: translatex(175px);
 	}
 }


### PR DESCRIPTION
This PR adds settings and functionality for compass hud elements in defrag:

- compass mode - off, show arrow, show ticks, show both
- compass size - compass tick length and arrow half-height
- pitch enable - show/hide pitch target
- pitch target - pitch line offset in degrees (71.8 default for plasma climb)
- compass stat mode - off, show pitch, show yaw, show both
- compass color - normal color for compass elements
- compass highlight color - pitch line & text set to this color when aiming at the pitch target, compass & yaw stat set to this color when velocity is along Pi/4 directions

Requires changes on red to function (cvars and events)