### PR TITLE
Spelling Fixes

### DIFF
--- a/scripts/common/eventdefinition.js
+++ b/scripts/common/eventdefinition.js
@@ -4,8 +4,8 @@
 // Purpose: Common place to define new events with panorama. This file is only include by
 //          layout/mainmenu.xml ensuring that new events are only registered once with panorama
 //
-// Usage:   $.DefineEvent( eventName, NumArguments, [optional] ArgumentsDescripton, [optional] Description )
-//          $.DefinePanelEvent( eventName, NumArguments, [optional] ArgumentsDescripton, [optional] Description )
+// Usage:   $.DefineEvent( eventName, NumArguments, [optional] ArgumentsDescription, [optional] Description )
+//          $.DefinePanelEvent( eventName, NumArguments, [optional] ArgumentsDescription, [optional] Description )
 //
 // Example: $.DefineEvent( 'MyCustomEvent', 2, 'args1, args2', 'Event defined in javascript' )
 //

--- a/scripts/common/run.js
+++ b/scripts/common/run.js
@@ -47,7 +47,7 @@ const RunStatusIcons = {
 };
 
 /**
- * Friendly JavaScript represention of a C++ Run object.
+ * Friendly JavaScript representation of a C++ Run object.
  * @property {string} mapName - Name of the map
  * @property {string} mapHash - Alphanumeric hash unique to the map
  * @property {string} playerName - Steam name of the local player

--- a/scripts/components/endofrun.js
+++ b/scripts/components/endofrun.js
@@ -151,7 +151,7 @@ class EndOfRun {
 	}
 	/**
 	 * Reset and determine how to generate the end of run panel.
-	 * The comparision run can be null, in which case we don't show splits or the graph.
+	 * The comparison run can be null, in which case we don't show splits or the graph.
 	 * Fired when either when the local player's run ends, a replay run ends,
 	 * you go back to a last EoR from leaderboards, or in the future when the player compares two runs.
 	 * @param {EorShowReason} showReason - Why the end of run panel is being shown. See EorShowReason for reasons.
@@ -202,7 +202,7 @@ class EndOfRun {
 		this.panels.cp.SetDialogVariable('run_diff_prefix', '');
 		this.panels.cp.SetDialogVariableFloat('run_diff', 0);
 
-		// Give the styling for a first/no comparsion set run
+		// Give the styling for a first/no comparison set run
 		this.panels.cp.AddClass('endofrun--first');
 
 		// Loop through each zone in the run and create a neutral Split panel with no diff/delta
@@ -226,7 +226,7 @@ class EndOfRun {
 	}
 
 	/**
-	 * Generate the end of run panel comparisions from the two active runs.
+	 * Generate the end of run panel comparisons from the two active runs.
 	 */
 	static setComparisionStats() {
 		if (!this.baseRun || !this.comparisonRun) return;
@@ -423,7 +423,7 @@ class EndOfRun {
 					`${$.Localize('#Run_Comparison_Diff')}: <b class='${diffStyle}'>${diffSign(data.diff)}{g:time:time_diff}</b>\n` +
 					`${$.Localize('#Run_Comparison_Delta')}: <b class='${deltaStyle}'>${diffSign(data.delta)}{g:time:time_delta}</b>`;
 			} else {
-				// Using string instead of float here, floats add a shitton of floating point imprecision e.g. 90.00000000128381273
+				// Using string instead of float here, floats add a shit ton of floating point imprecision e.g. 90.00000000128381273
 				tooltipString =
 					`{s:name}: <b>{s:base_value}</b>\n` +
 					`${$.Localize('#Run_Comparison')}: <b>{s:compare_value}</b>\n` +

--- a/scripts/components/endofrun_xp.js
+++ b/scripts/components/endofrun_xp.js
@@ -128,7 +128,7 @@ class EndOfRunXP {
 					chain = chain.then(() => {
 						// Smallest fraction of BASE_LEVELUP_TIME a level up duration can be
 						const phi = 5;
-						// Quatratic passing 0 and leveldiff at BASE_LEVELUP_TIME, phi adjusts curviness
+						// Quadratic passing 0 and leveldiff at BASE_LEVELUP_TIME, phi adjusts curviness
 						// Doesn't work great but hard to get right without a bunch more maths or being able to time all the levels in one
 						// animation, maybe that's possible with some very creative CSS?
 						const duration =

--- a/scripts/components/graphs/linegraph.js
+++ b/scripts/components/graphs/linegraph.js
@@ -102,7 +102,7 @@ class LineGraph {
 				// String to pass to Panorama styling
 				const offset = 'position: ' + (isX ? `${dist}px 0px 0px;` : `0px ${dist}px 0px;`);
 
-				// Linear interpolate to determine marker text, backwards for Y. Then round to precison and cast back to Number.
+				// Linear interpolate to determine marker text, backwards for Y. Then round to precision and cast back to Number.
 				const markerValue = +(isX ? lineMin + j : lineMax + lineMin - j).toFixed(precision);
 
 				// Create the marker label

--- a/scripts/hud/ghostentities.js
+++ b/scripts/hud/ghostentities.js
@@ -6,7 +6,7 @@ class GhostEntities {
 		const namePanel = entPanel.FindChildTraverse('NamePanel');
 		namePanel.SetHasClass('ghost-ent-namepanel--hidden', !nameEnabled);
 
-		// Always keep centered even when name isnt visible
+		// Always keep centered even when name isn't visible
 		if (nameEnabled) {
 			entPanel.style.transform = 'translatex(0)';
 			entPanel.style.zIndex = 1;

--- a/scripts/hud/hud_leaderboards.js
+++ b/scripts/hud/hud_leaderboards.js
@@ -81,7 +81,7 @@ class HudLeaderboards {
 				namePanel.AddClass('hud-leaderboards-map-info__credits-name--no-steam');
 			}
 
-			// hoped this would make contextmenu work but it dont
+			// hoped this would make contextmenu work but it doesn't
 			if (authorCredits.indexOf(credit) < authorCredits.length - 1) {
 				let commaPanel = $.CreatePanel('Label', this.panels.credits, '');
 				commaPanel.AddClass('hud-leaderboards-map-info__credits-other-text');

--- a/scripts/hud/speedometer.js
+++ b/scripts/hud/speedometer.js
@@ -192,7 +192,7 @@ class Speedometer {
 			return;
 		}
 
-		if (timerState === 0) return; // timer isnt running
+		if (timerState === 0) return; // timer isn't running
 
 		// return on current or previous zone, on a linear map
 		if (curZone <= this.lastZone && linear) return;

--- a/scripts/mainmenu.js
+++ b/scripts/mainmenu.js
@@ -340,7 +340,7 @@ class MainMenuController {
 	 * @param {boolean} toDesktop
 	 */
 	static onQuitPrompt(toDesktop = true) {
-		if (!toDesktop) return; // currently dont handle disconnect prompts
+		if (!toDesktop) return; // currently don't handle disconnect prompts
 
 		$.DispatchEvent('ChaosMainMenuPauseGame'); // make sure game is paused so we can see the popup if hit from a keybind in-game
 

--- a/scripts/mainmenu_settings.js
+++ b/scripts/mainmenu_settings.js
@@ -193,7 +193,7 @@ class MainMenuSettings {
 		const proportionScrolled = scrollOffset / (containerHeight - containerScreenHeight);
 
 		// Loop through each group until we find the one that scroll proportion fits within. If scrollOffset is 0 break in the first case
-		// Think of it of partitioning [0, 1] into sections based on each section's height and seeing which partion bounds the scroll proportion
+		// Think of it of partitioning [0, 1] into sections based on each section's height and seeing which partition bounds the scroll proportion
 		for (let child of panel.FindChildrenWithClassTraverse('settings-group')) {
 			if (
 				(child.actualyoffset / containerHeight <= proportionScrolled &&
@@ -244,7 +244,7 @@ class MainMenuSettings {
 	}
 
 	static initPanelsRecursive(panel) {
-		// Initalise info panel event handlers
+		// Initialise info panel event handlers
 		if (this.isSettingsPanel(panel) || this.isSpeedometerPanel(panel)) {
 			this.setPanelInfoEvents(panel);
 		}

--- a/scripts/settings_search.js
+++ b/scripts/settings_search.js
@@ -53,7 +53,7 @@ class SettingsSearch {
 		// Don't bother show anything if we only have one char words, can spawn hundreds of panels.
 		if (!this.strings.some((str) => str.length > 1)) return;
 
-		// Initalise matches array
+		// Initialise matches array
 		this.matches = [];
 
 		// Search through each page
@@ -202,7 +202,7 @@ class SettingsSearch {
 
 		var searchResult = $.CreatePanel('Panel', this.panels.results, '');
 
-		// If the text property is set, we're targetting an individual setting. Otherwise, a group.
+		// If the text property is set, we're targeting an individual setting. Otherwise, a group.
 		const isGroupPanel = !matches.text;
 
 		if (!searchResult.LoadLayoutSnippet(isGroupPanel ? 'GroupSearchResult' : 'FullSearchResult')) return;

--- a/scripts/settings_speedometer.js
+++ b/scripts/settings_speedometer.js
@@ -175,7 +175,7 @@ class Speedometers {
 		Object.keys(SpeedometerIDs)
 			.filter((speedoName) => Speedometers.objectList[SpeedometerIDs[speedoName]] === undefined)
 			.forEach((speedoName) => disabledIDs.push(SpeedometerIDs[speedoName]));
-		if (disabledIDs.length === 0) return; // nothing is disabled, dont bother showing popup
+		if (disabledIDs.length === 0) return; // nothing is disabled, don't bother showing popup
 		UiToolkitAPI.ShowCustomLayoutPopupParameters(
 			'',
 			'file://{resources}/layout/popups/popup_speedometerselect.xml',
@@ -280,7 +280,7 @@ class Speedometers {
 		Object.keys(SpeedometerIDs)
 			.filter((speedoName) => Speedometers.objectList[SpeedometerIDs[speedoName]] === undefined)
 			.forEach((speedoName) => {
-				// make sure speedometers that arent visible (their panels are deleted) have an ordering that's above
+				// make sure speedometers that aren't visible (their panels are deleted) have an ordering that's above
 				// the speedometers that are actually visible
 				if (Speedometers.keyvalues?.['order']?.[speedoName])
 					Speedometers.keyvalues['order'][speedoName] = orderCtr++;

--- a/scripts/toastmanager.js
+++ b/scripts/toastmanager.js
@@ -233,7 +233,7 @@ class ToastManager {
 	static clearToasts(locationNum) {
 		const location = convertLocationNum(locationNum);
 
-		// Panorama/JS doesn't run this syncronously for some reason, so put a slight delay between deletions. Also looks kinda cool!
+		// Panorama/JS doesn't run this synchronously for some reason, so put a slight delay between deletions. Also looks kinda cool!
 		let delay = 0;
 		if (location && location !== 'all') {
 			if (!Locations.includes(location)) return;

--- a/scripts/tooltips/credit.js
+++ b/scripts/tooltips/credit.js
@@ -24,7 +24,7 @@ class Credit {
 		const email = cp.GetAttributeString('email', '');
 		const github = cp.GetAttributeString('github', '');
 
-		// Reconstrct full bio strings
+		// Reconstruct full bio strings
 		let bio = '';
 		let i = 1;
 		let curBioSection;


### PR DESCRIPTION
These are autogenerated comment spelling/grammar fixes. 
Two notes:
1. It was set to English-UK due to the spelling of initialise and such, so those inferior spellings are ignored.
2. This does not fix the fact that the methods like setComparisionStats() are misspelled, only the comments.