### PR TITLE
fix: stuck compass

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -246,8 +246,6 @@ class Cgaz {
 	}
 
 	static onUpdate() {
-		if (!this.accel_enable && !this.snap_enable) return;
-
 		if (this.bShouldUpdateStyles) this.applyStyles();
 
 		// clear last frame's split zones
@@ -511,7 +509,7 @@ class Cgaz {
 					? this.compass_color
 					: this.compass_hl_color;
 		}
-		this.pitchLine.visible = this.compass_pitch_enable;
+		this.pitchLine.visible = this.compass_pitch_enable === 1;
 
 		// compass stats
 		if (this.compass_stat_mode) {


### PR DESCRIPTION
This PR fixes a lingering a bug that should have been fixed with the last cgaz-fixes PR.

Defrag compass/pitch tools are now properly hidden outside of defrag.
Defrag compass/pitch tools now update when both snaps and accel zones are turned off.