### PR TITLE
fix: Set ammo via dialog variable

### DIFF
--- a/layout/hud/ammo.xml
+++ b/layout/hud/ammo.xml
@@ -4,6 +4,6 @@
 	</styles>
 
 	<MomHudAmmo class="full-width">
-		<Label class="ammo__label" id="AmmoCount" />
+		<Label class="ammo__label" text="{i:ammoCount}" />
 	</MomHudAmmo>
 </root>


### PR DESCRIPTION
closes https://github.com/momentum-mod/game/issues/1955

Requires internal PR to be merged first