### PR TITLE
Bhop trainer improvements

### DIFF
--- a/layout/settings/settings_interface.xml
+++ b/layout/settings/settings_interface.xml
@@ -913,8 +913,8 @@
 						convar="mom_hud_synchro_flip_enable"
 						infomessage="#Settings_Synchronizer_Direction_Info"
 					>
-						<RadioButton group="synchrodirection" text="Normal" value="0" />
-						<RadioButton group="synchrodirection" text="Flipped" value="1" />
+						<RadioButton group="synchrodirection" text="#Settings_Synchronizer_Direction_Normal" value="0" />
+						<RadioButton group="synchrodirection" text="#Settings_Synchronizer_Direction_Flipped" value="1" />
 					</ChaosSettingsEnum>
 
 					<ChaosSettingsEnumDropDown

--- a/layout/settings/settings_interface.xml
+++ b/layout/settings/settings_interface.xml
@@ -888,18 +888,7 @@
 					<Label id="mode4" text="#Settings_Synchronizer_DisplayMode_Mode4" value="4" />
 				</ChaosSettingsEnumDropDown>
 
-
 				<ConVarEnabler convar="mom_hud_synchro_mode" class="flow-down">
-					<ChaosSettingsEnumDropDown
-						text="#Settings_Synchronizer_Stats_Mode"
-						convar="mom_hud_synchro_stat_mode"
-						infomessage="#Settings_Synchronizer_Stats_Mode_Info"
-					>
-						<Label id="mode0" text="#Common_Off" value="0" />
-						<Label id="mode1" text="#Settings_Synchronizer_StatsMode_Mode1" value="1" />
-						<Label id="mode2" text="#Settings_Synchronizer_StatsMode_Mode2" value="2" />
-					</ChaosSettingsEnumDropDown>
-				
 					<ChaosSettingsEnum
 						text="#Settings_Synchronizer_Color"
 						convar="mom_hud_synchro_color_enable"
@@ -938,6 +927,26 @@
 						<Label text="#Settings_Synchronizer_AveragingWindow_Mode3" value="10" id="buffer2" />
 						<Label text="#Settings_Synchronizer_AveragingWindow_Mode4" value="20" id="buffer3" />
 					</ChaosSettingsEnumDropDown>
+
+					<ChaosSettingsEnumDropDown
+						text="#Settings_Synchronizer_Stats_Mode"
+						convar="mom_hud_synchro_stat_mode"
+						infomessage="#Settings_Synchronizer_Stats_Mode_Info"
+					>
+						<Label id="mode0" text="#Common_Off" value="0" />
+						<Label id="mode1" text="#Settings_Synchronizer_StatsMode_Mode1" value="1" />
+						<Label id="mode2" text="#Settings_Synchronizer_StatsMode_Mode2" value="2" />
+					</ChaosSettingsEnumDropDown>
+
+					<ChaosSettingsEnum
+						text="#Settings_Synchronizer_StatColor"
+						convar="mom_hud_synchro_stat_color_enable"
+						infomessage="#Settings_Synchronizer_StatColor_Info"
+						tags="color"
+					>
+						<RadioButton group="synchrostatcolor" text="#Common_Off" value="0" />
+						<RadioButton group="synchrostatcolor" text="#Common_On" value="1" />
+					</ChaosSettingsEnum>
 				</ConVarEnabler>
 
 			</Panel>

--- a/layout/settings/settings_interface.xml
+++ b/layout/settings/settings_interface.xml
@@ -653,7 +653,7 @@
 				<ConVarEnabler convar="mom_hud_jstats_enable" class="flow-down">
 					<ChaosSettingsSlider
 						text="#Settings_JumpStats_First"
-						min="0"
+						min="1"
 						max="10"
 						convar="mom_hud_jstats_first"
 						displayprecision="0"
@@ -663,7 +663,7 @@
 				
 					<ChaosSettingsSlider
 						text="#Settings_JumpStats_Interval"
-						min="1"
+						min="0"
 						max="10"
 						convar="mom_hud_jstats_interval"
 						displayprecision="0"

--- a/scripts/hud/jumpstats.js
+++ b/scripts/hud/jumpstats.js
@@ -8,7 +8,7 @@ class JumpStats {
 	/** @type {Panel} @static */
 	static panel = $.GetContextPanel();
 
-	static onJumpEnded() {
+	static onJump() {
 		const lastJumpStats = MomentumMovementAPI.GetLastJumpStats();
 		if (lastJumpStats.jumpCount < this.jumpStatsConfig.statsFirstPrint) {
 			return;
@@ -115,7 +115,7 @@ class JumpStats {
 	}
 
 	static {
-		$.RegisterEventHandler('OnJumpEnded', this.container, this.onJumpEnded.bind(this));
+		$.RegisterEventHandler('OnJumpStarted', this.container, this.onJump.bind(this));
 
 		$.RegisterForUnhandledEvent('ChaosLevelInitPostEntity', this.onLoad.bind(this));
 		$.RegisterForUnhandledEvent('OnJumpStatsCFGChange', this.onConfigChange.bind(this));

--- a/scripts/hud/jumpstats.js
+++ b/scripts/hud/jumpstats.js
@@ -23,21 +23,38 @@ class JumpStats {
 			return;
 		}
 
-		this.addToBuffer(this.countBuffer, lastJumpStats.jumpCount + ':');
-		this.addToBuffer(this.takeoffSpeedBuffer, lastJumpStats.takeoffSpeed.toFixed());
-		this.addToBuffer(this.speedDeltaBuffer, lastJumpStats.jumpSpeedDelta.toFixed());
-		this.addToBuffer(this.takeoffTimeBuffer, this.makeTime(lastJumpStats.takeoffTime));
-		this.addToBuffer(this.timeDeltaBuffer, lastJumpStats.timeDelta.toFixed(3));
-		this.addToBuffer(this.strafesBuffer, lastJumpStats.strafeCount);
-		this.addToBuffer(this.syncBuffer, this.makePercentage(lastJumpStats.strafeSync));
-		this.addToBuffer(this.gainBuffer, this.makePercentage(lastJumpStats.speedGain));
-		this.addToBuffer(this.yawRatioBuffer, this.makePercentage(lastJumpStats.yawRatio));
-		this.addToBuffer(
-			this.heightDeltaBuffer,
-			(Math.abs(lastJumpStats.heightDelta) < 0.1 ? 0 : lastJumpStats.heightDelta).toFixed(1)
-		);
-		this.addToBuffer(this.distanceBuffer, lastJumpStats.distance.toFixed(1));
-		this.addToBuffer(this.efficiencyBuffer, this.makePercentage(lastJumpStats.efficiency));
+		if (lastJumpStats.jumpCount === 1) {
+			// Most stats are noise on the first jump when tracking jumps like css
+			// Only show takeoff speed
+			this.addToBuffer(this.countBuffer, lastJumpStats.jumpCount + ':');
+			this.addToBuffer(this.takeoffSpeedBuffer, lastJumpStats.takeoffSpeed.toFixed());
+			this.addToBuffer(this.speedDeltaBuffer, '');
+			this.addToBuffer(this.takeoffTimeBuffer, '');
+			this.addToBuffer(this.timeDeltaBuffer, '');
+			this.addToBuffer(this.strafesBuffer, '');
+			this.addToBuffer(this.syncBuffer, '');
+			this.addToBuffer(this.gainBuffer, '');
+			this.addToBuffer(this.yawRatioBuffer, '');
+			this.addToBuffer(this.heightDeltaBuffer, '');
+			this.addToBuffer(this.distanceBuffer, '');
+			this.addToBuffer(this.efficiencyBuffer, '');
+		} else {
+			this.addToBuffer(this.countBuffer, lastJumpStats.jumpCount + ':');
+			this.addToBuffer(this.takeoffSpeedBuffer, lastJumpStats.takeoffSpeed.toFixed());
+			this.addToBuffer(this.speedDeltaBuffer, lastJumpStats.jumpSpeedDelta.toFixed());
+			this.addToBuffer(this.takeoffTimeBuffer, this.makeTime(lastJumpStats.takeoffTime));
+			this.addToBuffer(this.timeDeltaBuffer, lastJumpStats.timeDelta.toFixed(3));
+			this.addToBuffer(this.strafesBuffer, lastJumpStats.strafeCount);
+			this.addToBuffer(this.syncBuffer, this.makePercentage(lastJumpStats.strafeSync));
+			this.addToBuffer(this.gainBuffer, this.makePercentage(lastJumpStats.speedGain));
+			this.addToBuffer(this.yawRatioBuffer, this.makePercentage(lastJumpStats.yawRatio));
+			this.addToBuffer(
+				this.heightDeltaBuffer,
+				(Math.abs(lastJumpStats.heightDelta) < 0.1 ? 0 : lastJumpStats.heightDelta).toFixed(1)
+			);
+			this.addToBuffer(this.distanceBuffer, lastJumpStats.distance.toFixed(1));
+			this.addToBuffer(this.efficiencyBuffer, this.makePercentage(lastJumpStats.efficiency));
+		}
 
 		this.setText();
 	}

--- a/scripts/hud/jumpstats.js
+++ b/scripts/hud/jumpstats.js
@@ -26,18 +26,18 @@ class JumpStats {
 		this.addToBuffer(this.countBuffer, lastJumpStats.jumpCount + ':');
 		this.addToBuffer(this.takeoffSpeedBuffer, lastJumpStats.takeoffSpeed.toFixed());
 		this.addToBuffer(this.speedDeltaBuffer, lastJumpStats.jumpSpeedDelta.toFixed());
-		this.addToBuffer(this.takeoffTimeBuffer, this.makeTime(lastJumpStats.takeoffTime.toFixed(3)));
+		this.addToBuffer(this.takeoffTimeBuffer, this.makeTime(lastJumpStats.takeoffTime));
 		this.addToBuffer(this.timeDeltaBuffer, lastJumpStats.timeDelta.toFixed(3));
 		this.addToBuffer(this.strafesBuffer, lastJumpStats.strafeCount);
-		this.addToBuffer(this.syncBuffer, lastJumpStats.strafeSync.toFixed(2));
-		this.addToBuffer(this.gainBuffer, lastJumpStats.speedGain.toFixed(2));
-		this.addToBuffer(this.yawRatioBuffer, lastJumpStats.yawRatio.toFixed(2));
+		this.addToBuffer(this.syncBuffer, this.makePercentage(lastJumpStats.strafeSync));
+		this.addToBuffer(this.gainBuffer, this.makePercentage(lastJumpStats.speedGain));
+		this.addToBuffer(this.yawRatioBuffer, this.makePercentage(lastJumpStats.yawRatio));
 		this.addToBuffer(
 			this.heightDeltaBuffer,
 			(Math.abs(lastJumpStats.heightDelta) < 0.1 ? 0 : lastJumpStats.heightDelta).toFixed(1)
 		);
 		this.addToBuffer(this.distanceBuffer, lastJumpStats.distance.toFixed(1));
-		this.addToBuffer(this.efficiencyBuffer, lastJumpStats.efficiency.toFixed(2));
+		this.addToBuffer(this.efficiencyBuffer, this.makePercentage(lastJumpStats.efficiency));
 
 		this.setText();
 	}
@@ -108,6 +108,10 @@ class JumpStats {
 		const minutes = (Math.floor(value / 60) % 60).toFixed().padStart(2, '0');
 		const seconds = (value % 60).toFixed(3).padStart(6, '0');
 		return `${hours}:${minutes}:${seconds}`;
+	}
+
+	static makePercentage(ratio) {
+		return (ratio * 100).toFixed(1) + '%';
 	}
 
 	static {

--- a/scripts/hud/synchronizer.js
+++ b/scripts/hud/synchronizer.js
@@ -35,7 +35,7 @@ class Synchronizer {
 	static onLoad() {
 		this.initializeSettings();
 
-		if (this.mom_hud_synchro_stat_mode) this.onJumpEnded(); // show stats if enabled
+		if (this.mom_hud_synchro_stat_mode) this.onJump(); // show stats if enabled
 	}
 
 	static onUpdate() {
@@ -100,7 +100,7 @@ class Synchronizer {
 		}
 	}
 
-	static onJumpEnded() {
+	static onJump() {
 		const lastJumpStats = MomentumMovementAPI.GetLastJumpStats();
 		this.panels.stats[0].text =
 			`${lastJumpStats.jumpCount}: `.padStart(6, ' ') +
@@ -307,7 +307,7 @@ class Synchronizer {
 		$.RegisterForUnhandledEvent('OnSynchroBufferChanged', this.setSynchroBufferLength.bind(this));
 		$.RegisterForUnhandledEvent('OnSynchroStatModeChanged', this.setSynchroStatMode.bind(this));
 		$.RegisterForUnhandledEvent('OnSynchroStatColorModeChanged', this.setSynchroStatColorMode.bind(this));
-		$.RegisterForUnhandledEvent('OnJumpEnded', this.onJumpEnded.bind(this));
+		$.RegisterForUnhandledEvent('OnJumpStarted', this.onJump.bind(this));
 		$.RegisterForUnhandledEvent('ChaosLevelInitPostEntity', this.onLoad.bind(this));
 	}
 }

--- a/scripts/hud/synchronizer.js
+++ b/scripts/hud/synchronizer.js
@@ -107,13 +107,11 @@ class Synchronizer {
 			`${lastJumpStats.takeoffSpeed.toFixed()} `.padStart(6, ' ') +
 			`(${(lastJumpStats.yawRatio * 100).toFixed(2)}%)`.padStart(10, ' ');
 		this.panels.stats[1].text = (lastJumpStats.speedGain * 100).toFixed(2);
-		/*
-		const colorTuple = this.mom_hud_synchro_color_enable
+
+		const colorTuple = this.mom_hud_synchro_stat_color_enable
 			? this.getColorTuple(lastJumpStats.speedGain, lastJumpStats.yawRatio > 0)
 			: COLORS.NEUTRAL;
-		const color = `gradient(linear, 0% 0%, 0% 100%, from(${colorTuple[0]}), to(${colorTuple[1]}))`;
-		this.panels.stats.forEach((stat) => (stat.style.color = color));
-		*/
+		this.panels.stats.forEach((stat) => (stat.style.color = colorTuple[1]));
 	}
 
 	static getColorTuple(ratio, bOverStrafing) {
@@ -281,6 +279,10 @@ class Synchronizer {
 		this.panels.wrapper.style.visibility = newStatMode === 2 ? 'collapse' : 'visible';
 	}
 
+	static setSynchroStatColorMode(newColorMode) {
+		this.mom_hud_synchro_stat_color_enable = newColorMode ?? DEFAULT_SETTING_OFF;
+	}
+
 	static NaNCheck(val, def) {
 		return isNaN(val) ? def : val;
 	}
@@ -292,6 +294,7 @@ class Synchronizer {
 		this.setSynchroDirection(GameInterfaceAPI.GetSettingFloat('mom_hud_synchro_flip_enable'));
 		this.setSynchroBufferLength(GameInterfaceAPI.GetSettingFloat('mom_hud_synchro_buffer_size'));
 		this.setSynchroStatMode(GameInterfaceAPI.GetSettingFloat('mom_hud_synchro_stat_mode'));
+		this.setSynchroColorMode(GameInterfaceAPI.GetSettingFloat('mom_hud_synchro_stat_color_enable'));
 	}
 
 	static {
@@ -303,6 +306,7 @@ class Synchronizer {
 		$.RegisterForUnhandledEvent('OnSynchroDirectionChanged', this.setSynchroDirection.bind(this));
 		$.RegisterForUnhandledEvent('OnSynchroBufferChanged', this.setSynchroBufferLength.bind(this));
 		$.RegisterForUnhandledEvent('OnSynchroStatModeChanged', this.setSynchroStatMode.bind(this));
+		$.RegisterForUnhandledEvent('OnSynchroStatColorModeChanged', this.setSynchroStatColorMode.bind(this));
 		$.RegisterForUnhandledEvent('OnJumpEnded', this.onJumpEnded.bind(this));
 		$.RegisterForUnhandledEvent('ChaosLevelInitPostEntity', this.onLoad.bind(this));
 	}


### PR DESCRIPTION
This pull request incorporates player feedback on the jump stats implementation.

- Updated display behavior to align with css. Jump stats are now printed on jump instead of on land.
- Only jump speed is printed on jump 1 (other stats are noise on the first jump)
- Added the option to color jump stats text on strafe synchronizer panel according to gain percentage (like jhud).
- Converted all ratio stats to show percentage  values.
- Fixed unlocalized text in strafe synchronizer settings

requires changes on red MR before merging.