### PR TITLE
Fix: mirror zones flickering and wrong shape with Haste

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -4,7 +4,9 @@
 let MAX_GROUND_SPEED = 320;
 const AIR_ACCEL = 1;
 const DEFAULT_ACCEL = 2.56;
+const DEFAULT_SPEED = 320;
 const HASTE_ACCEL = 3.328; // (max speed) * (air accel = 1) * (tick interval) * (haste factor)
+const HASTE_SPEED = 416;
 
 let NEUTRAL_CLASS;
 let SLOW_CLASS;
@@ -269,8 +271,10 @@ class Cgaz {
 
 		if (lastMoveData.hasteEndTime < 0 || lastMoveData.hasteEndTime > MomentumMovementAPI.GetCurrentTime()) {
 			this.snapAccel = HASTE_ACCEL;
+			MAX_GROUND_SPEED = HASTE_SPEED;
 		} else {
 			this.snapAccel = DEFAULT_ACCEL;
+			MAX_GROUND_SPEED = DEFAULT_SPEED;
 		}
 
 		const velocity = MomentumPlayerAPI.GetVelocity();

--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -283,7 +283,7 @@ class Cgaz {
 		const velDir = this.getNormal(velocity, 0.001);
 		const velAngle = Math.atan2(velocity.y, velocity.x);
 		const wishDir = lastMoveData.wishdir;
-		const wishAngle = this.getSizeSquared(wishDir) > 0.0001 ? Math.atan2(wishDir.y, wishDir.x) : 0;
+		const wishAngle = this.getSizeSquared(wishDir) > 0.001 ? Math.atan2(wishDir.y, wishDir.x) : 0;
 		const viewAngle = (MomentumPlayerAPI.GetAngles().y * Math.PI) / 180;
 		const viewDir = {
 			x: Math.cos(viewAngle),
@@ -294,9 +294,9 @@ class Cgaz {
 		let rightMove = this.getCross(viewDir, wishDir).toFixed();
 
 		const bIsFalling = lastMoveData.moveStatus == 0;
-		const bHasAirControl = phyMode && this.floatEquals(wishAngle, viewAngle, 0.001) && bIsFalling;
+		const bHasAirControl = phyMode && this.floatEquals(wishAngle, viewAngle, 0.01) && bIsFalling;
 		const bSnapShift =
-			!this.floatEquals(Math.abs(forwardMove), Math.abs(rightMove), 0.001) && !(phyMode && bIsFalling);
+			!this.floatEquals(Math.abs(forwardMove), Math.abs(rightMove), 0.01) && !(phyMode && bIsFalling);
 
 		// find cgaz angles
 		const angleOffset = this.remapAngle(velAngle - wishAngle);
@@ -385,7 +385,7 @@ class Cgaz {
 				let mirrorOffset = this.remapAngle(velAngle - viewAngle);
 				const inputAngle = this.remapAngle(viewAngle - wishAngle);
 
-				if (this.floatEquals(Math.abs(inputAngle), 0.25 * Math.PI, 0.001)) {
+				if (this.floatEquals(Math.abs(inputAngle), 0.25 * Math.PI, 0.01)) {
 					mirrorOffset += (inputAngle > 0 ? -1 : 1) * Math.PI * 0.25;
 					this.updateZone(
 						this.leftMirrorZone,


### PR DESCRIPTION
This pull request fixes two bugs with outline/mirror zone behavior:
- flickering while strafing
- wrong shape with Haste powerup