### PR TITLE
fix: Chat spec icon

### DIFF
--- a/layout/chat.xml
+++ b/layout/chat.xml
@@ -37,7 +37,7 @@
 
 		<snippet name="lobby-chat-message-spec">
 			<Panel class="flow-right">
-				<Image class="chat-entry__icon" src="file://{images}/spectating.svg" textureheight="16" />
+				<Image class="chat-entry__icon" src="file://{images}/spectatingIcon.svg" textureheight="16" />
 				<Label
 					class="chat-entry__message chat-entry__message--with-icon"
 					text="&lt;b&gt;{s:author_name}&lt;/b&gt;: {s:message}"


### PR DESCRIPTION
Chat icon was using the wrong filename.