### PR TITLE
Add sleep_when_meeting_framerate option to video settings

### DIFF
--- a/layout/settings/settings_video.xml
+++ b/layout/settings/settings_video.xml
@@ -133,6 +133,18 @@
 					<Label text="#Settings_General_Disabled" value="0" id="laptoppower0" />
 					<Label text="#Settings_General_Enabled" value="1" id="laptoppower1" />
 				</ChaosSettingsEnumDropDown>
+
+				<ChaosSettingsEnumDropDown
+					text="#Settings_Video_PreventThreadSleep"
+					onuserinputsubmit="SettingsShared.videoSettingsOnUserInputSubmit()"
+					id="PreventThreadSleep"
+					convar="sleep_when_meeting_framerate"
+					infomessage="#Settings_Video_PreventThreadSleep_Info"
+				>
+					<Label text="#Settings_General_Disabled" value="1" id="preventthreadsleep1" />
+					<Label text="#Settings_General_Enabled" value="0" id="preventthreadsleep0" />
+				</ChaosSettingsEnumDropDown>
+				
 			</Panel>
 
 			<Panel class="settings-page__spacer" />


### PR DESCRIPTION
```
"Settings_Video_PreventThreadSleep" "Prevent Thread Sleep"
"Settings_Video_PreventThreadSleep_Info" "Prevent the game thread from sleeping when at maximum FPS limit. Enabling this option results in higher CPU utilization and potentially smoother performance."
```
