### PR TITLE
fix: missing pitch marker

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -513,7 +513,7 @@ class Cgaz {
 					? this.compass_color
 					: this.compass_hl_color;
 		}
-		this.pitchLine.visible = this.compass_pitch_enable === 1;
+		this.pitchLine.visible = this.compass_pitch_enable === true;
 
 		// compass stats
 		if (this.compass_stat_mode) {


### PR DESCRIPTION
Closes https://github.com/momentum-mod/game/issues/1986

This PR fixes a regression with the defrag pitch hud. The visibility setting on the pitch marker is now set to the correct value.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "",
		"definition": ""
	}
]
```
