### PR TITLE
fix: wrong term in Efficiency description slot

### DIFF
--- a/layout/pages/settings/interface.xml
+++ b/layout/pages/settings/interface.xml
@@ -774,7 +774,7 @@
 					<ChaosSettingsEnum
 						text="#Settings_JumpStats_Efficiency"
 						convar="mom_hud_jstats_efficiency_enable"
-						infomessage="#Settings_JumpStats_Efficiency"
+						infomessage="#Settings_JumpStats_Efficiency_Info"
 					>
 						<RadioButton group="efficiency" text="#Common_Off" value="0" />
 						<RadioButton group="efficiency" text="#Common_On" value="1" />


### PR DESCRIPTION
### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "",
		"definition": ""
	}
]
```
