### PR TITLE
feat: enhanced snap highlight

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,8 @@ module.exports = {
 		// Fuck you I wanna
 		'unicorn/no-abusive-eslint-disable': ['off'],
 		// Terrible rule, it's often practically useful to explicitly state what's happening in cases
-		'unicorn/no-useless-switch-case': ['off']
+		'unicorn/no-useless-switch-case': ['off'],
+		// //In certain cases this matters, but often completely redundant as V8 optimises it fine. Worth flagging potential cases in code review, but annoying as a linting rule
+		'unicorn/consistent-function-scoping': ['off']
 	}
 };

--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -101,10 +101,10 @@ class Cgaz {
 	static screenY = $.GetContextPanel().actuallayoutheight;
 	static screenX = $.GetContextPanel().actuallayoutwidth;
 	static scale = $.GetContextPanel().actualuiscale_y;
-	static fov4_3 = GameInterfaceAPI.GetSettingFloat('fov_desired'); //source uses 4:3 for fov setting
-	static vFov_tangent = 0.75 * Math.tan((0.5 * this.fov4_3 * Math.PI) / 180);
-	static vFov = Math.atan(this.vFov_tangent);
-	static hFov = Math.atan((this.vFov_tangent * this.screenX) / this.screenY);
+	static fov4By3 = GameInterfaceAPI.GetSettingFloat('fov_desired'); //source uses 4:3 for fov setting
+	static vFovTangent = 0.75 * Math.tan((0.5 * this.fov4By3 * Math.PI) / 180);
+	static vFov = Math.atan(this.vFovTangent);
+	static hFov = Math.atan((this.vFovTangent * this.screenX) / this.screenY);
 	static theta = Math.PI * 0.5 - 2 * Math.atan(Math.sqrt(2 + Math.sqrt(3)));
 	static halfPi = 0.5 * Math.PI;
 	static snapGainRange = []; // stored as [min, max]
@@ -130,78 +130,78 @@ class Cgaz {
 	}
 
 	static onHudFovChange() {
-		this.hud_fov = DefragAPI.GetHUDFOV();
+		this.hudFov = DefragAPI.GetHUDFOV();
 		this.bShouldUpdateStyles = true;
 	}
 
 	static onAccelConfigChange() {
 		const accelConfig = DefragAPI.GetHUDAccelCFG();
-		this.accel_enable = accelConfig.enable;
-		this.accel_min_speed = accelConfig.minSpeed;
-		this.accel_height = accelConfig.height;
-		this.accel_offset = accelConfig.offset;
-		this.accel_slow_color = accelConfig.slowColor;
-		this.accel_fast_color = accelConfig.fastColor;
-		this.accel_turn_color = accelConfig.turnColor;
-		this.accel_dz_color = accelConfig.dzColor;
-		this.accel_scale_enable = accelConfig.scaleEnable;
-		this.accel_mirror_enable = accelConfig.mirrorEnable;
+		this.accelEnable = accelConfig.enable;
+		this.accelMinSpeed = accelConfig.minSpeed;
+		this.accelHeight = accelConfig.height;
+		this.accelOffset = accelConfig.offset;
+		this.accelSlowColor = accelConfig.slowColor;
+		this.accelFastColor = accelConfig.fastColor;
+		this.accelTurnColor = accelConfig.turnColor;
+		this.accelDzColor = accelConfig.dzColor;
+		this.accelScaleEnable = accelConfig.scaleEnable;
+		this.accelMirrorEnable = accelConfig.mirrorEnable;
 
 		this.bShouldUpdateStyles = true;
 	}
 
 	static onSnapConfigChange() {
 		const snapConfig = DefragAPI.GetHUDSnapCFG();
-		this.snap_enable = snapConfig.enable;
-		this.snap_min_speed = snapConfig.minSpeed;
-		this.snap_height = snapConfig.height;
-		this.snap_offset = snapConfig.offset;
-		this.snap_color = snapConfig.color;
-		this.snap_alt_color = snapConfig.altColor;
-		this.snap_fast_color = snapConfig.fastColor;
-		this.snap_slow_color = snapConfig.slowColor;
-		this.snap_hl_color = snapConfig.highlightColor;
-		this.snap_hl_alt_color = snapConfig.altHighlightColor;
-		this.snap_hl_mode = snapConfig.highlightMode;
-		this.snap_color_mode = snapConfig.colorMode;
-		this.snap_heightgain_enable = snapConfig.enableHeightGain;
+		this.snapEnable = snapConfig.enable;
+		this.snapMinSpeed = snapConfig.minSpeed;
+		this.snapHeight = snapConfig.height;
+		this.snapOffset = snapConfig.offset;
+		this.snapColor = snapConfig.color;
+		this.snapAltColor = snapConfig.altColor;
+		this.snapFastColor = snapConfig.fastColor;
+		this.snapSlowColor = snapConfig.slowColor;
+		this.snapHlColor = snapConfig.highlightColor;
+		this.snapHlAltColor = snapConfig.altHighlightColor;
+		this.snapHlMode = snapConfig.highlightMode;
+		this.snapColorMode = snapConfig.colorMode;
+		this.snapHeightgainEnable = snapConfig.enableHeightGain;
 
 		this.bShouldUpdateStyles = true;
 	}
 
 	static onWindicatorConfigChange() {
 		const windicatorArrowConfig = DefragAPI.GetHUDWIndicatorCFG();
-		this.windicator_enable = windicatorArrowConfig.enable;
-		this.windicator_size = windicatorArrowConfig.size;
-		this.windicator_color = windicatorArrowConfig.color;
+		this.windicatorEnable = windicatorArrowConfig.enable;
+		this.windicatorSize = windicatorArrowConfig.size;
+		this.windicatorColor = windicatorArrowConfig.color;
 
 		this.bShouldUpdateStyles = true;
 	}
 
 	static onCompassConfigChange() {
 		const compassConfig = DefragAPI.GetHUDCompassCFG();
-		this.compass_mode = compassConfig.compassMode;
-		this.compass_size = compassConfig.compassSize;
-		this.compass_pitch_enable = compassConfig.pitchEnable;
-		this.compass_pitch_target = compassConfig.pitchTarget;
-		this.compass_stat_mode = compassConfig.statMode;
-		this.compass_color = compassConfig.color;
-		this.compass_hl_color = compassConfig.highlightColor;
+		this.compassMode = compassConfig.compassMode;
+		this.compassSize = compassConfig.compassSize;
+		this.compassPitchEnable = compassConfig.pitchEnable;
+		this.compassPitchTarget = compassConfig.pitchTarget;
+		this.compassStatMode = compassConfig.statMode;
+		this.compassColor = compassConfig.color;
+		this.compassHlColor = compassConfig.highlightColor;
 
 		this.bShouldUpdateStyles = true;
 	}
 
 	static applyStyles() {
 		// accel zone classes
-		let height = this.accel_height;
+		let height = this.accelHeight;
 		let offset = 0;
 		let align = 'middle';
-		NEUTRAL_CLASS = new StyleObject(height, offset, align, this.accel_dz_color);
-		SLOW_CLASS = new StyleObject(height, offset, align, this.accel_slow_color);
-		FAST_CLASS = new StyleObject(height, offset, align, this.accel_fast_color);
-		TURN_CLASS = new StyleObject(height, offset, align, this.accel_turn_color);
-		MIRROR_CLASS = new StyleObject(height, offset, align, this.accel_slow_color);
-		WIN_ZONE_CLASS = new StyleObject(height, offset, align, this.windicator_color);
+		NEUTRAL_CLASS = new StyleObject(height, offset, align, this.accelDzColor);
+		SLOW_CLASS = new StyleObject(height, offset, align, this.accelSlowColor);
+		FAST_CLASS = new StyleObject(height, offset, align, this.accelFastColor);
+		TURN_CLASS = new StyleObject(height, offset, align, this.accelTurnColor);
+		MIRROR_CLASS = new StyleObject(height, offset, align, this.accelSlowColor);
+		WIN_ZONE_CLASS = new StyleObject(height, offset, align, this.windicatorColor);
 
 		this.setupContainer(this.accelContainer, this.accelOffset, align);
 		this.applyClass(this.leftTurnZone, TURN_CLASS);
@@ -218,13 +218,13 @@ class Cgaz {
 		this.applyClassBorder(this.windicatorZone, WIN_ZONE_CLASS);
 
 		// snap zone classes
-		height = this.snap_height;
-		offset = 0.5 * this.accel_height + this.accel_offset + this.snap_offset;
+		height = this.snapHeight;
+		offset = 0.5 * this.accelHeight + this.accelOffset + this.snapOffset;
 		align = 'middle';
-		COLORED_SNAP_CLASS = new StyleObject(height, offset, align, this.snap_color);
-		UNCOLORED_SNAP_CLASS = new StyleObject(height, offset, align, this.snap_alt_color);
-		HIGHLIGHTED_SNAP_CLASS = new StyleObject(height, offset, align, this.snap_hl_color);
-		HIGHLIGHTED_ALT_SNAP_CLASS = new StyleObject(height, offset, align, this.snap_hl_alt_color);
+		COLORED_SNAP_CLASS = new StyleObject(height, offset, align, this.snapColor);
+		UNCOLORED_SNAP_CLASS = new StyleObject(height, offset, align, this.snapAltColor);
+		HIGHLIGHTED_SNAP_CLASS = new StyleObject(height, offset, align, this.snapHlColor);
+		HIGHLIGHTED_ALT_SNAP_CLASS = new StyleObject(height, offset, align, this.snapHlAltColor);
 
 		this.setupContainer(this.snapContainer, offset, align);
 		for (let i = 0; i < this.snapZones.length; ++i) {
@@ -232,26 +232,26 @@ class Cgaz {
 		}
 
 		// compass ticks
-		offset = this.accel_offset - 0.5 * (this.accel_height + this.compass_size);
+		offset = this.accelOffset - 0.5 * (this.accelHeight + this.compassSize);
 		align = 'middle';
-		const size = this.NaNCheck(this.compass_size, 0);
+		const size = this.NaNCheck(this.compassSize, 0);
 		this.setupContainer(this.tickContainer, offset, align);
 		this.compassTickFull.style.height = size + 'px';
 		this.compassTickHalf.style.height = size * 0.5 + 'px';
 
 		// compass arrow classes
-		let color = this.compass_color;
-		let width = 2 * this.compass_size;
-		height = this.accel_height + 2 * width;
-		offset = this.accel_offset;
+		let color = this.compassColor;
+		let width = 2 * this.compassSize;
+		height = this.accelHeight + 2 * width;
+		offset = this.accelOffset;
 		align = 'bottom';
 		this.setupArrow(this.compassArrow, this.compassArrowIcon, height, width, offset, align, color);
 
 		// windicator arrow classes
-		color = this.windicator_color;
-		width = 2 * this.windicator_size;
-		height = this.accel_height + 2 * width;
-		offset = this.accel_offset;
+		color = this.windicatorColor;
+		width = 2 * this.windicatorSize;
+		height = this.accelHeight + 2 * width;
+		offset = this.accelOffset;
 		align = 'top';
 		this.setupArrow(this.windicatorArrow, this.windicatorArrowIcon, height, width, offset, align, color);
 
@@ -267,16 +267,16 @@ class Cgaz {
 		this.screenY = $.GetContextPanel().actuallayoutheight;
 		this.screenX = $.GetContextPanel().actuallayoutwidth;
 		this.scale = $.GetContextPanel().actualuiscale_y;
-		this.fov4_3 = this.hud_fov || GameInterfaceAPI.GetSettingFloat('fov_desired'); //source uses 4:3 for fov setting
-		this.vFov_tangent = 0.75 * Math.tan((0.5 * this.fov4_3 * Math.PI) / 180);
-		this.vFov = Math.atan(this.vFov_tangent);
-		this.hFov = Math.atan((this.vFov_tangent * this.screenX) / this.screenY);
+		this.fov4By3 = this.hudFov || GameInterfaceAPI.GetSettingFloat('fov_desired'); //source uses 4:3 for fov setting
+		this.vFovTangent = 0.75 * Math.tan((0.5 * this.fov4By3 * Math.PI) / 180);
+		this.vFov = Math.atan(this.vFovTangent);
+		this.hFov = Math.atan((this.vFovTangent * this.screenX) / this.screenY);
 
 		const phyMode = DefragAPI.GetDFPhysicsMode();
 		const lastMoveData = MomentumMovementAPI.GetLastMoveData();
 
 		const tickInterval = MomentumMovementAPI.GetTickInterval();
-		const maxSpeed = this.accel_scale_enable ? lastMoveData.wishspeed : lastMoveData.maxspeed;
+		const maxSpeed = this.accelScaleEnable ? lastMoveData.wishspeed : lastMoveData.maxspeed;
 		const accel = lastMoveData.acceleration;
 		const maxAccel = accel * maxSpeed * tickInterval;
 
@@ -320,9 +320,9 @@ class Cgaz {
 		const turnCgazAngle = this.findTurnAngle(speed, dropSpeed, maxAccel, fastCgazAngle);
 		const stopCgazAngle = this.findStopAngle(maxAccel, speedSquared, dropSpeed, dropSpeedSquared, turnCgazAngle);
 
-		if (this.accel_enable) {
+		if (this.accelEnable) {
 			// draw accel zones
-			if (speed >= this.accel_min_speed) {
+			if (speed >= this.accelMinSpeed) {
 				this.updateZone(
 					this.leftTurnZone,
 					-stopCgazAngle,
@@ -384,7 +384,7 @@ class Cgaz {
 			}
 
 			// draw mirrored strafe zones
-			if (speed >= this.accel_min_speed && this.accel_mirror_enable) {
+			if (speed >= this.accelMinSpeed && this.accelMirrorEnable) {
 				const mirrorAccel = (bIsFalling ? AIR_ACCEL : accel) * MAX_GROUND_SPEED * tickInterval;
 				const minMirrorAngle = this.findSlowAngle(dropSpeed, dropSpeedSquared, speedSquared, MAX_GROUND_SPEED);
 				const fastMirrorAngle = this.findFastAngle(dropSpeed, MAX_GROUND_SPEED, mirrorAccel);
@@ -441,7 +441,7 @@ class Cgaz {
 			}
 		}
 
-		if (this.snap_enable && this.snapAccel) {
+		if (this.snapEnable && this.snapAccel) {
 			// find snap zone borders
 			const snapAngles = this.findSnapAngles(this.snapAccel);
 			const snapOffset = (bSnapShift ? 0 : Math.PI * 0.25) - viewAngle;
@@ -460,7 +460,7 @@ class Cgaz {
 			}
 
 			// draw snap zones
-			if (speed >= this.snap_min_speed) {
+			if (speed >= this.snapMinSpeed) {
 				this.updateSnaps(this.snapZones, snapAngles, snapOffset, leftTarget, rightTarget);
 			} else {
 				this.clearZones(this.snapZones);
@@ -471,10 +471,10 @@ class Cgaz {
 
 		let velocityAngle = this.remapAngle(viewAngle - velAngle);
 		// compass
-		if (this.compass_mode) {
+		if (this.compassMode) {
 			const bShouldHighlight =
-				Math.abs(this.remapAngle(8 * velAngle) * 0.125) < 0.01 && speed >= this.accel_min_speed;
-			const color = bShouldHighlight ? this.compass_hl_color : this.compass_color;
+				Math.abs(this.remapAngle(8 * velAngle) * 0.125) < 0.01 && speed >= this.accelMinSpeed;
+			const color = bShouldHighlight ? this.compassHlColor : this.compassColor;
 
 			// ticks
 			const fullTickLeftEdge = this.findCompassTick(viewAngle);
@@ -505,48 +505,48 @@ class Cgaz {
 				this.compassArrowIcon.AddClass('arrow__down');
 				velocityAngle = this.remapAngle(velocityAngle - Math.PI);
 			}
-			const leftEdge = this.mapToScreenWidth(velocityAngle) - this.compass_size;
+			const leftEdge = this.mapToScreenWidth(velocityAngle) - this.compassSize;
 			this.compassArrow.style.marginLeft = this.NaNCheck(leftEdge, 0) + 'px';
 			this.compassArrowIcon.style.washColor = color;
 		}
-		this.compassArrow.visible = this.compass_mode % 2 && speed >= this.accel_min_speed;
-		this.tickContainer.visible = this.compass_mode > 1;
+		this.compassArrow.visible = this.compassMode % 2 && speed >= this.accelMinSpeed;
+		this.tickContainer.visible = this.compassMode > 1;
 
 		// pitch line
-		if (this.compass_pitch_enable) {
+		if (this.compassPitchEnable) {
 			const pitchDelta = this.mapToScreenHeight(
-				((MomentumPlayerAPI.GetAngles().x - this.compass_pitch_target) * Math.PI) / 180
+				((MomentumPlayerAPI.GetAngles().x - this.compassPitchTarget) * Math.PI) / 180
 			);
 			this.pitchLine.style.height = this.NaNCheck(pitchDelta, 0) + 'px';
 			this.pitchLine.style.borderColor =
-				Math.abs(MomentumPlayerAPI.GetAngles().x - this.compass_pitch_target) > 0.1
-					? this.compass_color
-					: this.compass_hl_color;
+				Math.abs(MomentumPlayerAPI.GetAngles().x - this.compassPitchTarget) > 0.1
+					? this.compassColor
+					: this.compassHlColor;
 		}
-		this.pitchLine.visible = this.compass_pitch_enable === true;
+		this.pitchLine.visible = this.compassPitchEnable === true;
 
 		// compass stats
-		if (this.compass_stat_mode) {
+		if (this.compassStatMode) {
 			this.yawStat.text = MomentumPlayerAPI.GetAngles().y.toFixed(0);
 			this.yawStat.style.color =
-				Math.abs(this.distToNearestTick(velAngle)) < 0.01 && speed >= this.accel_min_speed
-					? this.compass_hl_color
-					: this.compass_color;
+				Math.abs(this.distToNearestTick(velAngle)) < 0.01 && speed >= this.accelMinSpeed
+					? this.compassHlColor
+					: this.compassColor;
 
 			this.pitchStat.text = MomentumPlayerAPI.GetAngles().x.toFixed(1);
 			this.pitchStat.style.color =
-				Math.abs(MomentumPlayerAPI.GetAngles().x - this.compass_pitch_target) > 0.1
-					? this.compass_color
-					: this.compass_hl_color;
+				Math.abs(MomentumPlayerAPI.GetAngles().x - this.compassPitchTarget) > 0.1
+					? this.compassColor
+					: this.compassHlColor;
 		}
-		this.pitchStat.visible = this.compass_stat_mode % 2;
-		this.yawStat.visible = this.compass_stat_mode > 1;
+		this.pitchStat.visible = this.compassStatMode % 2;
+		this.yawStat.visible = this.compassStatMode > 1;
 
 		const wTurnAngle = velocityAngle > 0 ? velocityAngle + this.theta : velocityAngle - this.theta;
 		// draw w-turn indicator
-		if (this.windicator_enable && Math.abs(wTurnAngle) < this.hFov && speed >= this.accel_min_speed) {
+		if (this.windicatorEnable && Math.abs(wTurnAngle) < this.hFov && speed >= this.accelMinSpeed) {
 			this.windicatorArrow.visible = true;
-			const leftEdge = this.mapToScreenWidth(wTurnAngle) - this.windicator_size;
+			const leftEdge = this.mapToScreenWidth(wTurnAngle) - this.windicatorSize;
 			this.windicatorArrow.style.marginLeft = this.NaNCheck(leftEdge, 0) + 'px';
 
 			const minAngle = Math.min(wTurnAngle, 0);
@@ -705,7 +705,7 @@ class Cgaz {
 			}
 
 			let bHighlight = false;
-			switch (this.snap_hl_mode) {
+			switch (this.snapHlMode) {
 				case 0:
 					bHighlight = false;
 					break;
@@ -714,7 +714,7 @@ class Cgaz {
 					break;
 				case 2:
 					// "target" zones only highlight when moving
-					if (this.getSize(MomentumPlayerAPI.GetVelocity()) > this.accel_min_speed) {
+					if (this.getSize(MomentumPlayerAPI.GetVelocity()) > this.accelMinSpeed) {
 						if (left - leftTarget < 0 && right - leftTarget > 0) {
 							bHighlight = true;
 						} else if (left - rightTarget < 0 && right - rightTarget > 0) {

--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -30,18 +30,30 @@ class StyleObject {
 	}
 }
 
+function initZonePanel(panel) {
+	return Object.assign(panel, {
+		leftAngle: 0,
+		rightAngle: 0,
+		leftPx: 0,
+		rightPx: 0
+	});
+}
+
 class Cgaz {
 	static accelContainer = $('#AccelContainer');
-
 	static accelZones = [
-		$('#LeftTurnZone'),
-		$('#LeftFastZone'),
-		$('#LeftSlowZone'),
-		$('#DeadZone'),
-		$('#RightSlowZone'),
-		$('#RightFastZone'),
-		$('#RightTurnZone')
-	];
+		'LeftTurnZone',
+		'LeftFastZone',
+		'LeftSlowZone',
+		'DeadZone',
+		'RightSlowZone',
+		'RightFastZone',
+		'RightTurnZone',
+		'AccelSplitZone',
+		'LeftMirrorZone',
+		'RightMirrorZone',
+		'MirrorSplitZone'
+	].map((id) => initZonePanel($('#' + id)));
 
 	static leftTurnZone = this.accelZones[0];
 	static leftFastZone = this.accelZones[1];
@@ -50,29 +62,28 @@ class Cgaz {
 	static rightSlowZone = this.accelZones[4];
 	static rightFastZone = this.accelZones[5];
 	static rightTurnZone = this.accelZones[6];
+	static accelSplitZone = this.accelZones[7];
 
-	static leftMirrorZone = $('#LeftMirrorZone');
-	static rightMirrorZone = $('#RightMirrorZone');
-
-	static accelSplitZone = $('#AccelSplitZone');
-	static snapSplitZone = $('#SnapSplitZone');
-	static mirrorSplitZone = $('#MirrorSplitZone');
+	static leftMirrorZone = this.accelZones[8];
+	static rightMirrorZone = this.accelZones[9];
+	static mirrorSplitZone = this.accelZones[10];
 
 	static snapContainer = $('#SnapContainer');
 	static snapZones = [
-		$('#SnapZone0'),
-		$('#SnapZone1'),
-		$('#SnapZone2'),
-		$('#SnapZone3'),
-		$('#SnapZone4'),
-		$('#SnapZone5'),
-		$('#SnapZone6'),
-		$('#SnapZone7'),
-		$('#SnapZone8'),
-		$('#SnapZone9'),
-		$('#SnapZone10'),
-		$('#SnapZone11')
+		initZonePanel($('#SnapZone0')),
+		initZonePanel($('#SnapZone1')),
+		initZonePanel($('#SnapZone2')),
+		initZonePanel($('#SnapZone3')),
+		initZonePanel($('#SnapZone4')),
+		initZonePanel($('#SnapZone5')),
+		initZonePanel($('#SnapZone6')),
+		initZonePanel($('#SnapZone7')),
+		initZonePanel($('#SnapZone8')),
+		initZonePanel($('#SnapZone9')),
+		initZonePanel($('#SnapZone10')),
+		initZonePanel($('#SnapZone11'))
 	];
+	static snapSplitZone = initZonePanel($('#SnapSplitZone'));
 
 	static compassArrow = $('#CompassArrow');
 	static compassArrowIcon = $('#CompassArrowIcon');
@@ -85,7 +96,7 @@ class Cgaz {
 
 	static windicatorArrow = $('#WindicatorArrow');
 	static windicatorArrowIcon = $('#WindicatorArrowIcon');
-	static windicatorZone = $('#WindicatorZone');
+	static windicatorZone = initZonePanel($('#WindicatorZone'));
 
 	static screenY = $.GetContextPanel().actuallayoutheight;
 	static screenX = $.GetContextPanel().actuallayoutwidth;
@@ -192,7 +203,7 @@ class Cgaz {
 		MIRROR_CLASS = new StyleObject(height, offset, align, this.accel_slow_color);
 		WIN_ZONE_CLASS = new StyleObject(height, offset, align, this.windicator_color);
 
-		this.setupContainer(this.accelContainer, this.accel_offset, align);
+		this.setupContainer(this.accelContainer, this.accelOffset, align);
 		this.applyClass(this.leftTurnZone, TURN_CLASS);
 		this.applyClass(this.leftFastZone, FAST_CLASS);
 		this.applyClass(this.leftSlowZone, SLOW_CLASS);
@@ -433,7 +444,6 @@ class Cgaz {
 		if (this.snap_enable && this.snapAccel) {
 			// find snap zone borders
 			const snapAngles = this.findSnapAngles(this.snapAccel);
-			const snapGains = this.findSnapGains(snapAngles, this.snapAccel);
 			const snapOffset = (bSnapShift ? 0 : Math.PI * 0.25) - viewAngle;
 
 			const targetOffset = this.remapAngle(velAngle - viewAngle);
@@ -451,7 +461,7 @@ class Cgaz {
 
 			// draw snap zones
 			if (speed >= this.snap_min_speed) {
-				this.updateSnaps(this.snapZones, snapAngles, snapGains, snapOffset, leftTarget, rightTarget);
+				this.updateSnaps(this.snapZones, snapAngles, snapOffset, leftTarget, rightTarget);
 			} else {
 				this.clearZones(this.snapZones);
 			}
@@ -611,7 +621,7 @@ class Cgaz {
 		return breakPoints;
 	}
 
-	static findSnapGains(snapAngles, snapAccel) {
+	static findSnapGains(snapAngles) {
 		const snapGains = [];
 		this.snapGainRange = [0, 0];
 		for (let i = 0; i < 0.5 * snapAngles.length; ++i) {
@@ -619,9 +629,9 @@ class Cgaz {
 			const right = snapAngles[i + 1];
 			const angle = 0.5 * (left + right);
 
-			const xGain = (snapAccel * Math.cos(angle)).toFixed(0);
-			const yGain = (snapAccel * Math.sin(angle)).toFixed(0);
-			const gainDiff = Math.sqrt(xGain * xGain + yGain * yGain) - snapAccel;
+			const xGain = (this.snapAccel * Math.cos(angle)).toFixed(0);
+			const yGain = (this.snapAccel * Math.sin(angle)).toFixed(0);
+			const gainDiff = Math.sqrt(xGain * xGain + yGain * yGain) - this.snapAccel;
 			snapGains.push(gainDiff);
 
 			this.snapGainRange[0] = Math.min(gainDiff, this.snapGainRange[0]);
@@ -633,32 +643,66 @@ class Cgaz {
 	static updateZone(zone, left, right, offset, zoneClass, splitZone) {
 		let wrap = right > left;
 
-		left = this.remapAngle(left - offset);
-		right = this.remapAngle(right - offset);
+		zone.leftAngle = this.remapAngle(left - offset);
+		zone.rightAngle = this.remapAngle(right - offset);
 
-		wrap = right > left ? !wrap : wrap;
+		wrap = zone.rightAngle > zone.leftAngle ? !wrap : wrap;
 
 		// map angles to screen
-		left = this.mapToScreenWidth(left);
-		right = this.mapToScreenWidth(right);
+		zone.leftPx = this.mapToScreenWidth(zone.leftAngle);
+		zone.rightPx = this.mapToScreenWidth(zone.rightAngle);
 
 		if (wrap) {
-			this.drawZone(zone, this.mapToScreenWidth(-this.hFov), right);
-
 			// draw second part of split zone
 			this.applyClass(splitZone, zoneClass);
-			this.drawZone(splitZone, left, this.mapToScreenWidth(this.hFov));
-		} else {
-			this.drawZone(zone, left, right);
+			splitZone.leftAngle = -this.hFov;
+			splitZone.rightAngle = zone.rightAngle;
+			splitZone.leftPx = this.mapToScreenWidth(this.accelSplitZone.leftAngle);
+			splitZone.rightPx = this.mapToScreenWidth(this.accelSplitZone.rightAngle);
+			//this.drawZone(splitZone, left, this.mapToScreenWidth(this.hFov));
+			this.drawZone(splitZone);
+
+			zone.rightAngle = this.hFov;
+			zone.rightPx = this.mapToScreenWidth(zone.rightAngle);
 		}
+		this.drawZone(zone);
 	}
 
-	static updateSnaps(zones, snapAngles, snapGains, snapOffset, leftTarget, rightTarget) {
+	static updateSnaps(zones, snapAngles, snapOffset, leftTarget, rightTarget) {
+		const snapGains = this.findSnapGains(snapAngles);
+
 		for (let i = 0; i < zones.length; ++i) {
 			// wrap the angles to only [-pi/2, pi/2]
 			const left = this.wrapToHalfPi(snapAngles[i] - snapOffset);
 			const right = this.wrapToHalfPi(snapAngles[(i + 1) % zones.length] - snapOffset);
-			const bUseUncolored = !this.snap_heightgain_enable && !this.snap_color_mode && i % 2;
+			const bUseUncolored = !this.snapHeightgainEnable && !this.snapColorMode && i % 2;
+			let snapColor = bUseUncolored ? this.snapAltColor : this.snapColor;
+			const hlSnapColor = bUseUncolored ? this.snapHlAltColor : this.snapHlColor;
+			const snapClass = bUseUncolored ? UNCOLORED_SNAP_CLASS : COLORED_SNAP_CLASS;
+
+			const minGain = this.snapGainRange[0];
+			const maxGain = this.snapGainRange[1];
+			const diffGain = snapGains[i % snapGains.length];
+			const alpha = maxGain === minGain ? 1 : (diffGain - minGain) / (maxGain - minGain);
+			const heightFactor = 0.8 * alpha + 0.2;
+			const height = this.NaNCheck(this.snapHeight, 0);
+
+			if (this.snapHeightgainEnable && !Number.isNaN(heightFactor)) {
+				zones[i].style.height = heightFactor * height + 'px';
+				zones[i].style.marginBottom = height + 'px';
+				zones[i].style.verticalAlign = 'bottom';
+			} else {
+				zones[i].style.height = height + 'px';
+				zones[i].style.marginBottom = height + 'px';
+			}
+
+			this.updateZone(zones[i], left, right, 0, snapClass, this.snapSplitZone);
+
+			if (this.snapColorMode) {
+				const A = this.splitColorString(this.snapSlowColor);
+				const B = this.splitColorString(this.snapFastColor);
+				snapColor = this.getColorStringFromArray(this.colorLerp(A, B, alpha));
+			}
 
 			let bHighlight = false;
 			switch (this.snap_hl_mode) {
@@ -680,44 +724,17 @@ class Cgaz {
 					break;
 			}
 
-			let snapColor = bUseUncolored ? this.snap_alt_color : this.snap_color;
-			const hlSnapColor = bUseUncolored ? this.snap_hl_alt_color : this.snap_hl_color;
-			const snapClass = bUseUncolored ? UNCOLORED_SNAP_CLASS : COLORED_SNAP_CLASS;
-
-			const minGain = this.snapGainRange[0];
-			const maxGain = this.snapGainRange[1];
-			const diffGain = snapGains[i % snapGains.length];
-			const alpha = (diffGain - minGain) / (maxGain - minGain);
-			const heightFactor = 0.8 * alpha + 0.2;
-			const height = this.NaNCheck(this.snap_height, 0);
-
-			if (this.snap_color_mode) {
-				const A = this.splitColorString(this.snap_slow_color);
-				const B = this.splitColorString(this.snap_fast_color);
-				snapColor = this.getColorStringFromArray(this.colorLerp(A, B, alpha));
-			}
 			zones[i].style.backgroundColor = bHighlight ? hlSnapColor : snapColor;
-
-			if (this.snap_heightgain_enable) {
-				zones[i].style.height = heightFactor * height + 'px';
-				zones[i].style.marginBottom = height + 'px';
-				zones[i].style.verticalAlign = 'bottom';
-			} else {
-				zones[i].style.height = height + 'px';
-				zones[i].style.marginBottom = height + 'px';
-			}
-
-			this.updateZone(zones[i], left, right, 0, snapClass, this.snapSplitZone);
 		}
 	}
 
-	static drawZone(zone, left, right) {
+	static drawZone(zone) {
 		// assign widths
-		const width = right - left;
+		const width = zone.rightPx - zone.leftPx;
 		zone.style.width = this.NaNCheck(Number(width).toFixed(0), 0) + 'px';
 
 		// assign position via margin (center screen at 0)
-		zone.style.marginLeft = this.NaNCheck(Number(left).toFixed(0), 0) + 'px';
+		zone.style.marginLeft = this.NaNCheck(Number(zone.leftPx).toFixed(0), 0) + 'px';
 	}
 
 	static findCompassTick(angle) {
@@ -737,19 +754,19 @@ class Cgaz {
 		container.style.overflow = 'noclip noclip';
 	}
 
-	static applyClass(zone, zoneClass) {
-		zone.style.height = this.NaNCheck(zoneClass.height, 0) + 'px';
-		zone.style.verticalAlign = zoneClass.align;
-		zone.style.backgroundColor = zoneClass.color;
-		zone.style.overflow = 'noclip noclip';
+	static applyClass(panel, zoneClass) {
+		panel.style.height = this.NaNCheck(zoneClass.height, 0) + 'px';
+		panel.style.verticalAlign = zoneClass.align;
+		panel.style.backgroundColor = zoneClass.color;
+		panel.style.overflow = 'noclip noclip';
 	}
 
-	static applyClassBorder(zone, zoneClass) {
-		zone.style.height = this.NaNCheck(zoneClass.height, 0) + 'px';
-		zone.style.border = `2px solid ${zoneClass.color}`;
-		zone.style.padding = '-2px';
-		zone.style.verticalAlign = zoneClass.align;
-		zone.style.overflow = 'noclip noclip';
+	static applyClassBorder(panel, zoneClass) {
+		panel.style.height = this.NaNCheck(zoneClass.height, 0) + 'px';
+		panel.style.border = `2px solid ${zoneClass.color}`;
+		panel.style.padding = '-2px';
+		panel.style.verticalAlign = zoneClass.align;
+		panel.style.overflow = 'noclip noclip';
 	}
 
 	static setupArrow(arrow, arrowIcon, height, width, offset, align, color) {
@@ -767,7 +784,11 @@ class Cgaz {
 	}
 
 	static clearZones(zones) {
-		zones.map((zone) => (zone.style.width = '0px'));
+		for (const zone of zones) {
+			zone.leftPx = 0;
+			zone.rightPx = 0;
+			this.drawZone(zone);
+		}
 	}
 
 	static mapToScreenWidth(angle) {


### PR DESCRIPTION
This pull request enhances the functionality of snap hud for defrag. This pull request also lays the groundwork for the CGAZ 2.0 overhaul.

Changes:
- When using highlight mode 2, only the portion of the highlighted snap zone that can provide acceleration is colored
- Zones (snaps, CGAZ, mirror) are refactored as objects containing a reference to some panel, angles representing the left and right edges of that panel, and pixel values for the left and right edge of the panel on screen.
- Cleaned up member variable names to align with style convention (camelCase)
- Fix js error when scaling/interpolating across a range with 0 distance.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

```
