### PR TITLE
feat: multi-pitch

### DIFF
--- a/layout/hud/cgaz.xml
+++ b/layout/hud/cgaz.xml
@@ -46,7 +46,9 @@
 				<Image id="CompassArrowIcon" class="arrow__up" src="file://{images}/hud/cgaz-arrow.svg" textureheight="48" />
 			</ConVarEnabler>
 		</Panel>
-		<Panel id="PitchLine" class="cgaz-line" />
+		<ConVarEnabler class="full-height" convar="mom_df_hud_pitch_enable" togglevisibility="true">
+			<Panel id="PitchLines" class="cgaz-line__container" />
+		</ConVarEnabler>
 		<ConVarEnabler class="full-height" convar="mom_df_hud_compass_stat_mode" togglevisibility="true">
 			<Panel id="StatsBox" class="cgaz-stats__container">
 				<Label id="PitchStat" class="cgaz-stats cgaz-stats__pitch" />

--- a/styles/hud/cgaz.scss
+++ b/styles/hud/cgaz.scss
@@ -27,6 +27,12 @@
 	horizontal-align: center;
 	vertical-align: bottom;
 	overflow: noclip noclip;
+
+	&__container {
+		width: 100%;
+		height: 100%;
+		horizontal-align: center;
+	}
 }
 
 .cgaz-tick {


### PR DESCRIPTION
Closes #[1994](https://github.com/momentum-mod/game/issues/1994)

This pull request modifies the structure of pitch markers in the compass section of defrag HUD.

Changes:
- Pitch target convar is read as string and parsed into an array
- Panels are created or destroyed to match the size of the array of pitch angles to be marked
- The pitch stat is highlighted when the player aims within 0.1 degrees of any pitch target

THIS PR DEPENDS ON RED CHANGES.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

```
