### PR TITLE
Add 'enable cursor' label tip to hud leaderboard + misc fix (redo)

### DIFF
--- a/layout/hud/leaderboards.xml
+++ b/layout/hud/leaderboards.xml
@@ -19,7 +19,7 @@
 					<Panel class="hud-leaderboards-map-info__top">
 						<Label class="hud-leaderboards-map-info__map-name" text="{s:map}" />
 						<TooltipPanel tooltip="View showcase run" class="hud-leaderboards-map-info__showcase">
-							<Button class="button full" onactivate="ToastAPI.CreateToast('', '', 'This system is not yet implemented!! Sorry!', 1, 3, 'tooltips/negative', 'red')">
+							<Button class="button full" onactivate="ToastAPI.CreateToast('', '', 'This system is not yet implemented!! Sorry!', 1, 3, 'negative', 'red')">
 								<Image class="button__icon" src="file://{images}/filmstrip.svg" textureheight="64" />
 							</Button>
 						</TooltipPanel>

--- a/layout/hud/leaderboards.xml
+++ b/layout/hud/leaderboards.xml
@@ -52,6 +52,10 @@
 
 			<Panel class="hud-leaderboards__stats">
 			</Panel>
+			
+			<Panel class="hud-leaderboards__enable-cursor">
+				<Label class="hud-leaderboards__enable-cursor-tip" text="#HudLeaderboards_EnableCursorTip"/> 
+			</Panel>
 		</Panel>
 	</HudLeaderboards>
 </root>

--- a/styles/hud/leaderboards.scss
+++ b/styles/hud/leaderboards.scss
@@ -55,6 +55,7 @@
 		width: 100%;
 		padding: 24px;
 		padding-top: 16px;
+		padding-bottom: 14px;
 		background-color: rgba(0, 0, 0, 0.6);
 
 		&--hidden {
@@ -68,6 +69,20 @@
 		&--hidden {
 			visibility: collapse;
 		}
+	}
+
+	&__enable-cursor {
+		border-top: 1px solid rgba(0, 0, 0, 0.4);
+		width: 100%;
+		padding: 12px 24px 12px 0;
+		vertical-align: bottom;
+		background-color: rgba(0, 0, 0, 0.6);
+	}
+
+	&__enable-cursor-tip {
+		font-size: 11px;
+		color: rgba(255, 255, 255, 0.6);
+		horizontal-align: right;
 	}
 }
 

--- a/styles/pages/end-of-run.scss
+++ b/styles/pages/end-of-run.scss
@@ -225,6 +225,7 @@
 	height: 180px + $linegraph-axis-width;
 	width: 560px + $linegraph-axis-width;
 	padding: 12px 16px 8px 4px;
+	margin-bottom: 2px;
 
 	&--hidden {
 		visibility: collapse;
@@ -271,8 +272,8 @@
 	overflow: squish scroll;
 	padding-right: 12px;
 	padding-left: 0px;
-	padding-bottom: 12px;
-	margin-bottom: 24px;
+	// padding-bottom: 12px;
+	margin-bottom: 16px;
 
 	& VerticalScrollBar {
 		width: 2px;


### PR DESCRIPTION
[Closes #2006](https://github.com/momentum-mod/game/issues/2006#issue-1591093851)
[Closes #1764](https://github.com/momentum-mod/game/issues/1764#issue-1204260535)

<!-- Describe what your pull request is doing here -->
Redoing this PR, having troubles w/ previous

fix: chose correct file location of an icon for a toast
(probably not going to matter when that feature is implemented and its deleted, but I'm just practicing git stuff)

feat: created label telling you to right-click to enable your cursor - in leaderboards/end of run panel

![image](https://user-images.githubusercontent.com/66272165/220508819-8d4ee9f6-00ea-4e63-9ec0-aba78dc904af.png)
-bottom right of leaderboard (looks clearer in game)
-looks good in end of run panel as well


### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits. 
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "HudLeaderboards_EnableCursorTip",
		"definition": "[Right-Click] Enable Cursor"
	}
]
```
