### PR TITLE
fix: snap divide by zero

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -724,7 +724,7 @@ class Cgaz {
 					if (this.getSize(MomentumPlayerAPI.GetVelocity()) > this.accelMinSpeed) {
 						let stopPoint, direction;
 						if (left - leftTarget < 0 && right - leftTarget > 0) {
-							stopPoint = this.floatEquals(zones[i].rightPx, zones[i].leftPx)
+							stopPoint = this.floatEquals(zones[i].rightPx, zones[i].leftPx, 1)
 								? 0
 								: this.NaNCheck(
 										(
@@ -736,7 +736,7 @@ class Cgaz {
 							direction = '0% 0%, 100% 0%';
 							bHighlight = true;
 						} else if (left - rightTarget < 0 && right - rightTarget > 0) {
-							stopPoint = this.floatEquals(zones[i].rightPx - zones[i].leftPx)
+							stopPoint = this.floatEquals(zones[i].rightPx, zones[i].leftPx, 1)
 								? 0
 								: this.NaNCheck(
 										(


### PR DESCRIPTION
Closes momentum-mod/game/issues/2012

This PR fixes a js error in the advanced snap target highlight code introduced with the last update.

### Checks

-   [x] **I have (actually) thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
