### PR TITLE
Add groundboost indicator for defrag

### DIFF
--- a/images/hud/meter-ring.svg
+++ b/images/hud/meter-ring.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="100px" width="100px" viewBox="0 0 100 100">
+  <g>
+    <path
+          d="
+          M 50, 50
+          m 0, -48
+          a 48,48 0 0,1 0,96
+          a 48,48 0 0,1 0,-96
+          z
+          m 0, 16
+          a 32,32 0 0,0 0,64
+          a 32,32 0 0,0 0,-64
+          z
+          "
+          style="fill:#fff"
+    />
+  </g>
+</svg>

--- a/layout/hud/ground-boost.xml
+++ b/layout/hud/ground-boost.xml
@@ -1,0 +1,16 @@
+<root>
+	<styles>
+		<include src="file://{resources}/styles/main.scss" />
+	</styles>
+	<scripts>
+		<include src="file://{resources}/scripts/hud/ground-boost.js" />
+	</scripts>
+
+	<MomHudGroundboost class="horizontal-align-center" alternateTicks="false">
+		<ConVarEnabler id="GroundboostContainer" class="groundboost__container" convar="mom_df_hud_groundboost_enable" togglevisibility="true">
+			<Image id="GroundboostBackground" class="groundboost__background--meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
+			<Image id="GroundboostMeter" class="groundboost__meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
+			<Label id="GroundboostTime" text="" class="groundboost__label" />
+		</ConVarEnabler>
+	</MomHudGroundboost>
+</root>

--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -38,6 +38,7 @@
 			<MomHudStatus />
 			<MomHudTimer />
 			<MomHudStrafeSync />
+			<MomHudGroundboost />
 			<ChaosHudHintText id="HudHintText" />
 		</Panel>
 

--- a/scripts/hud/ground-boost.js
+++ b/scripts/hud/ground-boost.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const TimerFlags = {
+	NONE: 0,
+	LANDING: 1 << 0,
+	KNOCKBACK: 1 << 1,
+	WATERJUMP: 1 << 2
+};
+
+const ColorClass = {
+	KB: 'groundboost__meter--knockback',
+	GB: 'groundboost__meter--groundboost'
+};
+
+const MS_2_DEG = 360 / 250;
+
+class Groundboost {
+	/** @type {Panel} @static */
+	static groundboostMeter = $('#GroundboostMeter');
+	/** @type {Label} @static */
+	static groundboostTime = $('#GroundboostTime');
+	/** @type {Panel} @static */
+	static container = $('#GroundboostContainer');
+
+	static onLoad() {
+		this.colorClass = ColorClass.KB;
+		this.groundboostMeter.AddClass(this.colorClass);
+
+		this.container.AddClass('groundboost__container--hide');
+		this.visible = false;
+	}
+
+	static onUpdate() {
+		const lastMoveData = MomentumMovementAPI.GetLastMoveData();
+		const timer = lastMoveData.defragTimer;
+		const timerFlags = lastMoveData.defragTimerFlags;
+		const newColor = timerFlags & TimerFlags.LANDING ? ColorClass.GB : ColorClass.KB;
+
+		//knockback is what causes no-friction condition, so only display meter when the player has this flag
+		if (timerFlags & TimerFlags.KNOCKBACK) {
+			this.groundboostTime.text = timer;
+
+			const fill = Math.min(timer * MS_2_DEG, 360).toFixed(2) - 360;
+			this.groundboostMeter.style.clip = `radial(50% 50%, 0deg, ${fill}deg)`;
+
+			if (this.colorClass !== newColor) {
+				this.groundboostMeter.RemoveClass(this.colorClass);
+				this.colorClass = newColor;
+				this.groundboostMeter.AddClass(this.colorClass);
+			}
+
+			if (!this.visible) {
+				this.container.RemoveClass('groundboost__container--hide');
+				this.visible = true;
+			}
+		} else if (this.visible) {
+			this.groundboostTime.text = '';
+			this.groundboostMeter.style.clip = 'radial(50% 50%, 0deg, 360deg)';
+			this.container.AddClass('groundboost__container--hide');
+			this.visible = false;
+		}
+	}
+
+	static {
+		$.RegisterEventHandler('ChaosHudProcessInput', $.GetContextPanel(), this.onUpdate.bind(this));
+		$.RegisterForUnhandledEvent('ChaosLevelInitPostEntity', this.onLoad.bind(this));
+	}
+}

--- a/scripts/util/panel-registration.js
+++ b/scripts/util/panel-registration.js
@@ -14,6 +14,7 @@ UiToolkitAPI.RegisterHUDPanel2d('MomHudStatus', 'file://{resources}/layout/hud/s
 UiToolkitAPI.RegisterHUDPanel2d('MomHudMapInfo', 'file://{resources}/layout/hud/map-info.xml');
 UiToolkitAPI.RegisterHUDPanel2d('MomHudWeaponSelection', 'file://{resources}/layout/hud/weapon-selection.xml');
 UiToolkitAPI.RegisterHUDPanel2d('MomHudCgaz', 'file://{resources}/layout/hud/cgaz.xml');
+UiToolkitAPI.RegisterHUDPanel2d('MomHudGroundboost', 'file://{resources}/layout/hud/ground-boost.xml');
 UiToolkitAPI.RegisterHUDPanel2d('MomHudDFJump', 'file://{resources}/layout/hud/df-jump.xml');
 UiToolkitAPI.RegisterHUDPanel2d('MomHudJumpStats', 'file://{resources}/layout/hud/jump-stats.xml');
 UiToolkitAPI.RegisterHUDPanel2d('MomHudSpecInfo', 'file://{resources}/layout/hud/spec-info.xml');

--- a/styles/hud/_index.scss
+++ b/styles/hud/_index.scss
@@ -8,6 +8,7 @@
 @use 'damage-indicator';
 @use 'df-jump';
 @use 'ghost-entities';
+@use 'ground-boost';
 @use 'hud';
 @use 'comparisons';
 @use 'leaderboards';

--- a/styles/hud/ground-boost.scss
+++ b/styles/hud/ground-boost.scss
@@ -1,0 +1,47 @@
+@use '../config' as *;
+
+.groundboost {
+	&__container {
+		height: 100px;
+		width: 100px;
+		margin: 6px 0px;
+
+		transition-property: opacity;
+		transition-timing-function: ease-in-out;
+		transition-duration: 0.5s;
+		opacity: 1;
+
+		&--hide {
+			transition-duration: 0s;
+			opacity: 0;
+		}
+	}
+
+	&__meter {
+		height: 100%;
+		width: 100%;
+
+		&--knockback {
+			wash-color: $red;
+		}
+
+		&--groundboost {
+			wash-color: $blue;
+		}
+	}
+
+	&__background--meter {
+		height: 100%;
+		width: 100%;
+		wash-color: $progressbar-background;
+		img-shadow: 1px 1px 3px 0.8 rgba(0, 0, 0, 0.35);
+	}
+
+	&__label {
+		align: center center;
+		text-align: center;
+		font-size: 20px;
+		font-weight: bold;
+		text-shadow: rgba(0, 0, 0, 0.5) 0px 1px 2px 2.5;
+	}
+}


### PR DESCRIPTION
Closes momentum-mod/game/issues/2035 (convar implemented in red repo)

This PR adds a groundboost feature for defrag. The indicator shows when the player has the knockback flag (from weapon or teleporter) and changes state to show a successful crash landing to extend the defrag timer to max duration.

Currently intended to be implemented for testing and feedback - no settings UI included in this PR. The feature as implemented is only available through the console.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
