### PR TITLE
New speedometer format

### DIFF
--- a/layout/hud/speedometer.xml
+++ b/layout/hud/speedometer.xml
@@ -7,48 +7,19 @@
 		<include src="file://{resources}/scripts/hud/speedometer.js" />
 	</scripts>
 
-	<MomHudSpeedometer class="horizontal-align-center" onload="Speedometer.onLoad()">
-		<Panel id="SpeedometerContainer" class="speedometers">
-			<Panel id="AbsSpeedometerContainer" class="speedometer">
-				<Label id="AbsSpeedometer" text="" class="text-align-center speedometer__axis" />
-				<Label id="AbsSpeedometerComparison" text="" class="speedometer__axis__comparison" />
+	<snippets>
+		<snippet name="speedometer-entry">
+			<Panel class="vertical-align-center horizontal-align-center">
+				<Panel id="SpeedometerContainer" class="speedometer">
+					<Label id="SpeedometerLabel" text="" class="text-align-center" />
+					<Label id="SpeedometerComparisonLabel" text="" />
+				</Panel>
 			</Panel>
-			<Panel id="HorizSpeedometerContainer" class="speedometer">
-				<Label id="HorizSpeedometer" text="" class="text-align-center speedometer__axis" />
-				<Label id="HorizSpeedometerComparison" text="" class="speedometer__axis__comparison" />
-			</Panel>
-			<Panel id="VertSpeedometerContainer" class="speedometer">
-				<Label id="VertSpeedometer" text="" class="text-align-center speedometer__axis" />
-				<Label id="VertSpeedometerComparison" text="" class="speedometer__axis__comparison" />
-			</Panel>
-			<Panel id="EnergySpeedometerContainer" class="speedometer">
-				<Label id="EnergySpeedometer" text="" class="text-align-center speedometer__axis" />
-				<Label id="EnergySpeedometerComparison" text="" class="speedometer__axis__comparison" />
-			</Panel>
-			<Panel id="ExplosiveJumpVelocityContainer" class="speedometer">
-				<Label id="ExplosiveJumpVelocity" text="" class="text-align-center speedometer__event" />
-				<Label id="ExplosiveJumpVelocityComparison" text="" class="speedometer__event__comparison" />
-			</Panel>
-			<Panel id="LastJumpVelocityContainer" class="speedometer">
-				<Label id="LastJumpVelocity" text="" class="text-align-center speedometer__event" />
-				<Label id="LastJumpVelocityComparison" text="" class="speedometer__event__comparison" />
-			</Panel>
-			<Panel id="RampBoardVelocityContainer" class="speedometer">
-				<Label id="RampBoardVelocity" text="" class="text-align-center speedometer__event" />
-				<Label id="RampBoardVelocityComparison" text="" class="speedometer__event__comparison" />
-			</Panel>
-			<Panel id="RampLeaveVelocityContainer" class="speedometer">
-				<Label id="RampLeaveVelocity" text="" class="text-align-center speedometer__event" />
-				<Label id="RampLeaveVelocityComparison" text="" class="speedometer__event__comparison" />
-			</Panel>
-			<Panel id="StageEnterExitAbsVelocityContainer" class="speedometer">
-				<Label id="StageEnterExitAbsVelocity" text="" class="text-align-center speedometer__event" />
-				<Label id="StageEnterExitAbsVelocityComparison" text="" class="speedometer__event__comparison" />
-			</Panel>
-			<Panel id="StageEnterExitHorizVelocityContainer" class="speedometer">
-				<Label id="StageEnterExitHorizVelocity" text="" class="text-align-center speedometer__event" />
-				<Label id="StageEnterExitHorizVelocityComparison" text="" class="speedometer__event__comparison" />
-			</Panel>
+		</snippet>
+	</snippets>
+
+	<MomHudSpeedometer class="horizontal-align-center">
+		<Panel id="SpeedometersContainer" class="speedometers">
 		</Panel>
 	</MomHudSpeedometer>
 </root>

--- a/layout/modals/popups/speedometer-select.xml
+++ b/layout/modals/popups/speedometer-select.xml
@@ -21,6 +21,9 @@
 		</Panel>
 		<Panel id="SpeedometerSelectContainer" class="flow-down horizontal-align-center">
 		</Panel>
+		<Panel class="row horizontal-align-center mt-4">
+			<TextEntry id="SpeedometerName" class="textentry" maxchars="255" placeholder="#Settings_Speedometer_Customname_Placeholder" text="" />
+		</Panel>
 		<Panel class="row horizontal-align-center mt-4 generic-popup__button-row">
 			<Button id="CancelButton" class="button mr-4" onactivate="UiToolkitAPI.CloseAllVisiblePopups();">
 				<Label class="button__text" text="#Common_Cancel" />

--- a/layout/pages/settings/interface.xml
+++ b/layout/pages/settings/interface.xml
@@ -30,13 +30,19 @@
 					</ToggleButton>
 				</Panel>
 				<Panel id="SpeedometerDetailContainer" class="settings-speedometer__detail settings-speedometer__detail--hidden">
-					<Panel id="SpeedometerUnitsContainer" class="settings-speedometer__settingcontainer">
-						<Label class="settings-speedometer__settinglabel" text="#Settings_Speedometer_Units" />
-						<DropDown id="SpeedometerUnits" class="dropdown horizontal-align-right" menuclass="dropdown-menu">
-							<Label id="units0" text="#Settings_Speedometer_Units_UPS" value="0" />
-							<Label id="units1" text="#Settings_Speedometer_Units_KPH" value="1" />
-							<Label id="units2" text="#Settings_Speedometer_Units_MPH" value="2" />
-						</DropDown>
+					<Panel class="settings-speedometer__settingcontainer mt-2">
+						<Label class="settings-speedometer__settinglabel" text="#Settings_Speedometer_EnabledAxes" />
+						<Panel id="SpeedometerAxesContainer" class="settings-speedometer__axestogglebuttoncontainer">
+							<ToggleButton id="SpeedometerXAxisToggleButton" class="button togglebutton togglebutton--blue mr-2" >
+								<Label class="button__text" text="X" />
+							</ToggleButton>
+							<ToggleButton id="SpeedometerYAxisToggleButton" class="button togglebutton togglebutton--blue mr-2" >
+								<Label class="button__text" text="Y" />
+							</ToggleButton>
+							<ToggleButton id="SpeedometerZAxisToggleButton" class="button togglebutton togglebutton--blue" >
+								<Label class="button__text" text="Z" />
+							</ToggleButton>
+						</Panel>
 					</Panel>
 					<Panel class="settings-speedometer__settingcontainer mt-2">
 						<Label class="settings-speedometer__settinglabel" text="#Settings_Speedometer_Colorize_Type" />

--- a/scripts/common/speedometer.js
+++ b/scripts/common/speedometer.js
@@ -1,41 +1,38 @@
 'use strict';
 
-const SpeedometerUnitsType = {
-	UPS: 0,
-	KMH: 1,
-	MPH: 2
+const SpeedometerTypes = {
+	OVERALL_VELOCITY: 0,
+	EXPLOSION_VELOCITY: 1,
+	JUMP_VELOCITY: 2,
+	RAMP_VELOCITY: 3,
+	ZONE_VELOCITY: 4
 };
 
-const SpeedometerColorMode = {
+const SpeedometerDataKeys = {
+	CUSTOM_LABEL: 'custom_label',
+	TYPE: 'type',
+	ENABLED_AXES: 'enabled_axes',
+	COLOR_TYPE: 'color_type',
+	RANGE_COL_PROF: 'range_color_profile'
+};
+
+const RangeColorProfileKeys = {
+	PROFILE_NAME: 'profile_name',
+	PROFILE_RANGE_DATA: 'profile_ranges'
+};
+
+const SpeedometerColorTypes = {
 	NONE: 0,
 	RANGE: 1,
 	COMPARISON: 2,
 	COMPARISON_SEP: 3
 };
 
-// these key names match the names of speedometers in the .vdf files
-const SpeedometerIDs = {
-	AbsSpeedometer: 0,
-	HorizSpeedometer: 1,
-	VertSpeedometer: 2,
-	EnergySpeedometer: 3,
-	ExplosiveJumpVelocity: 4,
-	LastJumpVelocity: 5,
-	RampBoardVelocity: 6,
-	RampLeaveVelocity: 7,
-	StageEnterExitAbsVelocity: 8,
-	StageEnterExitHorizVelocity: 9
-};
-
+// To be index via SpeedometerTypes
 const SpeedometerDispNames = [
-	'#Speedometer_Type_Absolute',
-	'#Speedometer_Type_Horizonal',
-	'#Speedometer_Type_Vertical',
-	'#Speedometer_Type_Energy',
+	'#Speedometer_Type_OverallVelocity',
 	'#Speedometer_Type_ExplosiveJump',
 	'#Speedometer_Type_Jump',
-	'#Speedometer_Type_RampBoard',
-	'#Speedometer_Type_RampLeave',
-	'#Speedometer_Type_StageAbsolute',
-	'#Speedometer_Type_StageHorizontal'
+	'#Speedometer_Type_Ramp',
+	'#Speedometer_Type_Zone'
 ];

--- a/scripts/modals/popups/speedometer-select.js
+++ b/scripts/modals/popups/speedometer-select.js
@@ -1,28 +1,36 @@
 'use strict';
 
 class SpeedometerSelectPopup {
+	/** @static @type {Panel} */
 	static container = $('#SpeedometerSelectContainer');
+	/** @static @type {TextEntry} */
+	static textEntry = $('#SpeedometerName');
 	static selected = 0;
 
 	static onAddButtonPressed() {
 		const callbackHandle = $.GetContextPanel().GetAttributeInt('callback', -1);
-		if (callbackHandle !== -1) UiToolkitAPI.InvokeJSCallback(callbackHandle, SpeedometerSelectPopup.selected);
+		if (callbackHandle !== -1)
+			UiToolkitAPI.InvokeJSCallback(
+				callbackHandle,
+				SpeedometerSelectPopup.selected,
+				SpeedometerSelectPopup.textEntry.text
+			);
 		UiToolkitAPI.CloseAllVisiblePopups();
 	}
 
 	static init() {
-		const disabledIDs = $.GetContextPanel().GetAttributeString('disabledIDs', '').split(',');
-		for (const [index, id] of disabledIDs.entries()) {
+		for (const typeNum of Object.values(SpeedometerTypes)) {
 			const speedometer = $.CreatePanel('Panel', SpeedometerSelectPopup.container, '');
 			speedometer.LoadLayoutSnippet('speedometer-radiobutton');
-			speedometer.FindChildInLayoutFile('SpeedometerBtnLabel').text = SpeedometerDispNames[id];
+			speedometer.FindChildInLayoutFile('SpeedometerBtnLabel').text = $.Localize(SpeedometerDispNames[typeNum]);
 
 			const radioBtn = speedometer.FindChildInLayoutFile('SpeedometerRadioBtn');
 			radioBtn.SetPanelEvent('onactivate', () => {
-				SpeedometerSelectPopup.selected = id;
+				SpeedometerSelectPopup.selected = typeNum;
 			});
 
-			if (index === 0) radioBtn.selected = true;
+			// select overall velocity by default
+			if (typeNum === SpeedometerTypes.OVERALL_VELOCITY) radioBtn.selected = true;
 		}
 	}
 }

--- a/styles/hud/speedometer.scss
+++ b/styles/hud/speedometer.scss
@@ -22,6 +22,7 @@
 		font-weight: $speedometer-event-font-weight;
 		font-size: $speedometer-event-font-size;
 		&__comparison {
+			margin-left: 2px;
 			font-weight: $speedometer-event-comparison-font-weight;
 			font-size: $speedometer-event-comparison-font-size;
 		}

--- a/styles/pages/settings/speedometer.scss
+++ b/styles/pages/settings/speedometer.scss
@@ -52,6 +52,12 @@
 		width: 100%;
 		height: 32px;
 	}
+	&__axestogglebuttoncontainer {
+		horizontal-align: right;
+		vertical-align: center;
+		flow-children: right;
+		width: fit-children;
+	}
 	&__movedownbutton {
 		height: 32px;
 		margin-left: 4px;


### PR DESCRIPTION
Closes https://github.com/momentum-mod/game/issues/1906
Closes https://github.com/momentum-mod/game/issues/1907
Closes https://github.com/momentum-mod/game/issues/1787
Closes https://github.com/momentum-mod/game/issues/1770

Unblocks https://github.com/momentum-mod/game/issues/1767

**Functionality rework**
We no longer have 1 speedometer for a set type. Rather, players can add multiple speedometers of a type (the overall velocity one and the event ones), give it a custom name, and control which axes they care about.
There has also been some consolidation, in that the energy speedometer and different units have been removed. Ramp board and exit have been consolidated into 1 speedometer type.

**New data format**
New kv3 format allows for much easier data parsing (arrays! in 2023! can you believe it!).
We also no longer need to track speedometer order, rather it is handled implicitly on reordering arrays.

**Localizable presets**
Both speedometer and range color profile preset names are now localized. Woo!

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
