### PR TITLE
fix: snap offset decoupling from cgaz

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -180,7 +180,7 @@ class Cgaz {
 		this.snapHeightgainEnable = snapConfig.enableHeightGain;
 
 		const accelConfig = DefragAPI.GetHUDAccelCFG(); // needed for aligning snaps to top of cgaz bar by default
-		const offset = this.snapOffset + accelConfig.enable ? 0.5 * accelConfig.height + accelConfig.offset : 0;
+		const offset = this.snapOffset + (accelConfig.enable ? 0.5 * accelConfig.height + accelConfig.offset : 0);
 		COLORED_SNAP_CLASS = new StyleObject(this.snapHeight, offset, this.snapColor);
 		UNCOLORED_SNAP_CLASS = new StyleObject(this.snapHeight, offset, this.snapAltColor);
 		HIGHLIGHTED_SNAP_CLASS = new StyleObject(this.snapHeight, offset, this.snapHlColor);


### PR DESCRIPTION
Closes momentum-mod/game/issues/2039

This PR fixes a bug preventing CGAZ snap hud offset from being calculated correctly.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
