### PR TITLE
feat: Improve defrag groundboost indicator behavior

### DIFF
--- a/layout/hud/ground-boost.xml
+++ b/layout/hud/ground-boost.xml
@@ -7,8 +7,8 @@
 	</scripts>
 
 	<MomHudGroundboost class="horizontal-align-center" alternateTicks="false">
-		<ConVarEnabler id="GroundboostContainer" class="groundboost__container" convar="mom_df_hud_groundboost_enable" togglevisibility="true">
-			<Image id="GroundboostBackground" class="groundboost__background--meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
+		<ConVarEnabler id="GroundboostContainer" class="groundboost__container groundboost__container--hide" convar="mom_df_hud_groundboost_enable" togglevisibility="true">
+			<Image id="GroundboostBackground" class="groundboost__background-meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
 			<Image id="GroundboostMeter" class="groundboost__meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
 			<Label id="GroundboostTime" text="" class="groundboost__label" />
 		</ConVarEnabler>

--- a/layout/pages/settings/gameplay.xml
+++ b/layout/pages/settings/gameplay.xml
@@ -659,6 +659,11 @@
 					</ConVarEnabler>
 
 				</Panel>
+				
+				<ChaosSettingsEnum text="#Settings_Defrag_Groundboost" convar="mom_df_hud_groundboost_enable" infomessage="#Settings_Defrag_Groundboost_Info" tags="groundboost">
+					<RadioButton group="groundboostenable" text="#Common_Off" value="0" />
+					<RadioButton group="groundboostenable" text="#Common_On" value="1" />
+				</ChaosSettingsEnum>
 			</Panel>
 		</Panel>
 	</Panel>

--- a/styles/hud/ground-boost.scss
+++ b/styles/hud/ground-boost.scss
@@ -7,6 +7,7 @@
 		margin: 6px 0px;
 
 		transition-property: opacity;
+		transition-delay: 0.5s;
 		transition-timing-function: ease-in-out;
 		transition-duration: 0.5s;
 		opacity: 1;
@@ -21,18 +22,19 @@
 		height: 100%;
 		width: 100%;
 
-		&--knockback {
+		&--friction {
 			wash-color: $red;
 		}
 
-		&--groundboost {
+		&--slick {
 			wash-color: $blue;
 		}
 	}
 
-	&__background--meter {
+	&__background-meter {
 		height: 100%;
 		width: 100%;
+		opacity: 0.5;
 		wash-color: $progressbar-background;
 		img-shadow: 1px 1px 3px 0.8 rgba(0, 0, 0, 0.35);
 	}


### PR DESCRIPTION
Closes momentum-mod/game/issues/2040

This pull request improves the prototype behavior of the defrag groundboost indicator based on player feedback.

- HUD element is only toggled ON if the player is grounded
- HUD element is frozen when the player jumps
- Color is repurposed to show friction state instead of crashland state
- Added delay on fade out to help clarity
- Reduced background opacity to help clarity
- Added settings UI

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "Settings_Defrag_Groundboost",
		"definition": "Display groundboost indicator"
	},
	{
		"term": "Settings_Defrag_Groundboost_Info",
		"definition": "This HUD element shows when the player is able to utilize the no-friction state caused by taking knockback or using a teleporter. If the player jumps too late, the meter changes color and counts the time duration since knockback ran out. Jumping while the groundboost indicator is active will freeze the meter to show the end state or wasted slick time."
	}
]
```
