### PR TITLE
fix: df pitch border bug

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -533,11 +533,11 @@ class Cgaz {
 			const pitchLines = this.pitchLineContainer.Children();
 			for (let i = 0; i < pitchLines?.length; ++i) {
 				const viewPitch = MomentumPlayerAPI.GetAngles().x;
-				const pitchDelta = viewPitch - this.compassPitchTarget[i];
+				const pitchDelta = this.compassPitchTarget[i] - viewPitch;
 				const pitchDeltaPx = this.mapToScreenHeight((pitchDelta * Math.PI) / 180);
-				pitchLines[i].style.height = this.NaNCheck(pitchDeltaPx, 0) + 'px';
-				pitchLines[i].style.borderColor =
-					Math.abs(viewPitch - this.compassPitchTarget[i]) > 0.1 ? this.compassColor : this.compassHlColor;
+				pitchLines[i].style.position = `0px ${this.NaNCheck(pitchDeltaPx, 0)}px 0px`;
+				pitchLines[i].style.backgroundColor =
+					Math.abs(pitchDelta) > 0.15 ? this.compassColor : this.compassHlColor;
 			}
 		}
 
@@ -553,7 +553,7 @@ class Cgaz {
 			let bShouldHighlight = false;
 			const viewPitch = MomentumPlayerAPI.GetAngles().x;
 			for (const target of this.compassPitchTarget) {
-				if (Math.abs(viewPitch - target) <= 0.1) bShouldHighlight = true;
+				if (Math.abs(viewPitch - target) <= 0.15) bShouldHighlight = true;
 			}
 			this.pitchStat.style.color = bShouldHighlight ? this.compassHlColor : this.compassColor;
 		}

--- a/styles/hud/cgaz.scss
+++ b/styles/hud/cgaz.scss
@@ -22,11 +22,9 @@
 
 .cgaz-line {
 	width: 100px;
-	margin-top: -1px;
-	border-top: 2px solid;
-	horizontal-align: center;
-	vertical-align: bottom;
-	overflow: noclip noclip;
+	height: 2px;
+	align: center top;
+	transform: translatey(-1px);
 
 	&__container {
 		width: 100%;


### PR DESCRIPTION
Closes momentum-mod/game/issues/2045

This pull request improves the behavior of the defrag pitch indicator. The root cause is not addressed - the pano bug needs to be investigated separately.

The changes in this pull request adjust panel behavior to address the bug outlined in issue 2045.
- Instead of using the edge of the panel to mark pitch target(s), the panel height is kept fixed and the border is not drawn.
- Panel is positioned with the `position` css property

This change is to be used as a prototype for improving the rest of the moving line/rectangle type defrag HUD elements. When cgaz.js is broken up into separate tools, this implementation should be adapted to the horizontal case.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings]

