### PR TITLE
Feat: Add defrag groundboost settings

### DIFF
--- a/layout/hud/ground-boost.xml
+++ b/layout/hud/ground-boost.xml
@@ -10,7 +10,7 @@
 		<ConVarEnabler id="GroundboostContainer" class="groundboost__container groundboost__container--hide" convar="mom_df_hud_groundboost_enable" togglevisibility="true">
 			<Image id="GroundboostBackground" class="groundboost__background-meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
 			<Image id="GroundboostMeter" class="groundboost__meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
-			<Label id="GroundboostTime" text="" class="groundboost__label" />
+			<Label id="GroundboostLabel" text="" class="groundboost__label" />
 		</ConVarEnabler>
 	</MomHudGroundboost>
 </root>

--- a/layout/pages/settings/gameplay.xml
+++ b/layout/pages/settings/gameplay.xml
@@ -615,10 +615,10 @@
 					</ConVarEnabler>
 
 					<ChaosSettingsEnumDropDown text="#Settings_Defrag_Compass_Stat_Mode" convar="mom_df_hud_compass_stat_mode" infomessage="#Settings_Defrag_Compass_Stat_Mode_Info" tags="compass">
-						<Label id="stat0" text="#Settings_Defrag_Compass_StatMode_Type0" value="0" />
-						<Label id="stat1" text="#Settings_Defrag_Compass_StatMode_Type1" value="1" />
-						<Label id="stat2" text="#Settings_Defrag_Compass_StatMode_Type2" value="2" />
-						<Label id="stat3" text="#Settings_Defrag_Compass_StatMode_Type3" value="3" />
+						<Label id="compassstat0" text="#Settings_Defrag_Compass_StatMode_Type0" value="0" />
+						<Label id="compassstat1" text="#Settings_Defrag_Compass_StatMode_Type1" value="1" />
+						<Label id="compassstat2" text="#Settings_Defrag_Compass_StatMode_Type2" value="2" />
+						<Label id="compassstat3" text="#Settings_Defrag_Compass_StatMode_Type3" value="3" />
 					</ChaosSettingsEnumDropDown>
 
 					<ConVarColorDisplay text="#Settings_Defrag_CompassColor" convar="mom_df_hud_compass_color" infomessage="#Settings_Defrag_CompassColor_Info" tags="compass" />
@@ -659,11 +659,43 @@
 					</ConVarEnabler>
 
 				</Panel>
-				
-				<ChaosSettingsEnum text="#Settings_Defrag_Groundboost" convar="mom_df_hud_groundboost_enable" infomessage="#Settings_Defrag_Groundboost_Info" tags="groundboost">
-					<RadioButton group="groundboostenable" text="#Common_Off" value="0" />
-					<RadioButton group="groundboostenable" text="#Common_On" value="1" />
-				</ChaosSettingsEnum>
+
+				<Panel class="settings-group__combo">
+
+					<Label class="settings-group__combo-header" text="#Settings_Defrag_Groundboost_Title" />
+
+					<ChaosSettingsEnum text="#Settings_Defrag_Groundboost" convar="mom_df_hud_gb_enable" infomessage="#Settings_Defrag_Groundboost_Info" tags="groundboost">
+						<RadioButton group="gbenable" text="#Common_Off" value="0" />
+						<RadioButton group="gbenable" text="#Common_On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ConVarEnabler convar="mom_df_hud_gb_enable" class="flow-down">
+						<ChaosSettingsEnumDropDown text="#Settings_Defrag_Groundboost_TextMode" convar="mom_df_hud_gb_text_mode" infomessage="#Settings_Defrag_Groundboost_TextMode_Info" tags="groundboost">
+							<Label id="gblabel0" text="#Settings_Defrag_Groundboost_TextMode_Type0" value="0" />
+							<Label id="gblabel1" text="#Settings_Defrag_Groundboost_TextMode_Type1" value="1" />
+							<Label id="gblabel2" text="#Settings_Defrag_Groundboost_TextMode_Type2" value="2" />
+						</ChaosSettingsEnumDropDown>
+						
+						<ConVarEnabler convar="mom_df_hud_gb_text_mode" class="flow-down">
+							<ChaosSettingsEnumDropDown text="#Settings_Defrag_Groundboost_TextColorMode" convar="mom_df_hud_gb_text_color_mode" infomessage="#Settings_Defrag_Groundboost_TextColorMode_Info" tags="groundboost">
+								<Label id="gbcolor0" text="#Settings_Defrag_Groundboost_TextColorMode_Type0" value="0" />
+								<Label id="gbcolor1" text="#Settings_Defrag_Groundboost_TextColorMode_Type1" value="1" />
+								<Label id="gbcolor2" text="#Settings_Defrag_Groundboost_TextColorMode_Type2" value="2" />
+							</ChaosSettingsEnumDropDown>
+						</ConVarEnabler>
+						
+						<ChaosSettingsEnum text="#Settings_Defrag_Groundboost_Overshoot" convar="mom_df_hud_gb_overshoot_enable" infomessage="#Settings_Defrag_Groundboost_Overshoot_Info" tags="groundboost">
+							<RadioButton group="gbovershootenable" text="#Common_Off" value="0" />
+							<RadioButton group="gbovershootenable" text="#Common_On" value="1" />
+						</ChaosSettingsEnum>
+						
+						<ChaosSettingsEnum text="#Settings_Defrag_Groundboost_CrashHighlight" convar="mom_df_hud_gb_crash_hl_enable" infomessage="#Settings_Defrag_Groundboost_CrashHighlight_Info" tags="groundboost">
+							<RadioButton group="gbcrashhlenable" text="#Common_Off" value="0" />
+							<RadioButton group="gbcrashhlenable" text="#Common_On" value="1" />
+						</ChaosSettingsEnum>
+					</ConVarEnabler>
+
+				</Panel>
 			</Panel>
 		</Panel>
 	</Panel>

--- a/scripts/hud/ground-boost.js
+++ b/scripts/hud/ground-boost.js
@@ -9,63 +9,81 @@ const TimerFlags = {
 
 const ColorClass = {
 	FRICTION: 'groundboost__meter--friction',
-	SLICK: 'groundboost__meter--slick'
+	SLICK: 'groundboost__meter--slick',
+	CRASH: 'groundboost__meter--crash'
+};
+
+const LabelClass = {
+	GAIN: 'groundboost__label--gain',
+	FLAT: 'groundboost__label--flat',
+	LOSS: 'groundboost__label--loss',
+	HIDE: 'groundboost__label--hide'
 };
 
 const MAX_TIMER_MS = 250;
 const MS_2_DEG = 360 / MAX_TIMER_MS;
+const IDEAL_END_MS = 40; // 5 ticks
 
 class Groundboost {
 	/** @type {Panel} @static */
 	static groundboostMeter = $('#GroundboostMeter');
 	/** @type {Label} @static */
-	static groundboostTime = $('#GroundboostTime');
+	static groundboostLabel = $('#GroundboostLabel');
 	/** @type {Panel} @static */
 	static container = $('#GroundboostContainer');
 
 	static onLoad() {
-		this.colorClass = ColorClass.FRICTION;
+		this.onConfigChange();
+
+		this.colorClass = ColorClass.SLICK;
 		this.groundboostMeter.AddClass(this.colorClass);
+
+		this.labelClass = LabelClass.FLAT;
 
 		this.container.AddClass('groundboost__container--hide');
 		this.visible = false;
 		this.missedJumpTimer = 0;
+		this.peakSpeed = 0;
+		this.startSpeed = 0;
 	}
 
 	static onUpdate() {
 		const lastMoveData = MomentumMovementAPI.GetLastMoveData();
-		const timer = lastMoveData.defragTimer;
+		let timer = lastMoveData.defragTimer;
 		const timerFlags = lastMoveData.defragTimerFlags;
 		const curTime = MomentumMovementAPI.GetCurrentTime();
+		const speed = this.getSize(MomentumPlayerAPI.GetVelocity());
+		const deltaSpeed = speed - this.peakSpeed;
+		let bUpdateMeter = false;
 
 		// Only toggle visibility on if the player is grounded
 		if (lastMoveData.moveStatus === 1) {
 			if (timerFlags & TimerFlags.KNOCKBACK) {
 				// Knockback is what causes no-friction condition
-				this.setColor(ColorClass.SLICK);
-				const fill = Math.min(timer * MS_2_DEG, 360).toFixed(2) - 360;
-
-				this.missedJumpTimer = 0;
-				this.groundboostTime.text = timer;
-				this.groundboostMeter.style.clip = `radial(50% 50%, 0deg, ${fill}deg)`;
-
+				// Crashland extends the timer to max duration
 				if (!this.visible) {
-					this.container.RemoveClass('groundboost__container--hide');
-					this.visible = true;
+					this.startGB(timerFlags & TimerFlags.LANDING);
 				}
-			} else if (this.visible) {
+				bUpdateMeter = true;
+			} else if (this.overshootEnable && this.visible) {
 				// Player is grounded and no longer has the friction flag
 				if (this.missedJumpTimer === 0) {
 					this.missedJumpTimer = curTime;
-					this.setColor(ColorClass.FRICTION);
+					this.setMeterColor(ColorClass.FRICTION);
 				}
+				bUpdateMeter = true;
+				timer = Math.min(MAX_TIMER_MS, Math.round(1000 * (curTime - this.missedJumpTimer)));
+				if (timer === MAX_TIMER_MS) this.fadeOut();
+			}
+			if (bUpdateMeter) {
+				const fill = Math.min(timer * MS_2_DEG, 360).toFixed(2) - 360;
+				const start = this.missedJumpTimer ? -fill : 0;
+				this.groundboostMeter.style.clip = `radial(50% 50%, ${start}deg, ${fill}deg)`;
 
-				const val = Math.min(MAX_TIMER_MS, Math.round(1000 * (curTime - this.missedJumpTimer)));
-				const fill = Math.min(val * MS_2_DEG, 360).toFixed(2) - 360;
-
-				this.groundboostTime.text = val;
-				this.groundboostMeter.style.clip = `radial(50% 50%, ${-fill}deg, ${fill}deg)`;
-				if (val === MAX_TIMER_MS) this.fadeOut();
+				this.peakSpeed = Math.max(speed, this.peakSpeed);
+				this.updateTextColor(speed, timer);
+				this.groundboostLabel.text =
+					this.textMode === 2 ? Number(deltaSpeed).toFixed(0) : this.missedJumpTimer ? -timer : timer;
 			}
 		} else if (this.visible && !(timerFlags & TimerFlags.KNOCKBACK)) {
 			// Player no longer grounded, freeze meter and fade out
@@ -73,7 +91,17 @@ class Groundboost {
 		}
 	}
 
-	static setColor(color) {
+	static startGB(bCrashLand) {
+		this.visible = true;
+		this.startSpeed = this.getSize(MomentumPlayerAPI.GetVelocity());
+		this.peakSpeed = 0;
+		this.missedJumpTimer = 0;
+		this.container.RemoveClass('groundboost__container--hide');
+		this.setMeterColor(this.crashHlEnable && !bCrashLand ? ColorClass.SLICK : ColorClass.CRASH);
+		this.setTextColor(this.textColorMode === 2 ? LabelClass.GAIN : LabelClass.FLAT);
+	}
+
+	static setMeterColor(color) {
 		if (this.colorClass === color) return;
 
 		this.groundboostMeter.RemoveClass(this.colorClass);
@@ -81,13 +109,69 @@ class Groundboost {
 		this.groundboostMeter.AddClass(this.colorClass);
 	}
 
+	static updateTextColor(speed, timer) {
+		if (!this.textMode || !this.textColorMode) return;
+
+		switch (this.textColorMode) {
+			case 1:
+				if (!this.missedJumpTimer) {
+					this.setTextColor(timer <= IDEAL_END_MS ? LabelClass.GAIN : LabelClass.FLAT);
+				} else {
+					this.setTextColor(LabelClass.LOSS);
+				}
+				break;
+			case 2:
+				if (speed < this.peakSpeed && speed >= this.startSpeed) {
+					this.setTextColor(LabelClass.FLAT);
+				} else if (speed < this.startSpeed) {
+					this.setTextColor(LabelClass.LOSS);
+				}
+				break;
+			case 0:
+			default:
+				this.setTextColor(LabelClass.FLAT);
+				break;
+		}
+	}
+
+	static setTextColor(color) {
+		if (!this.textMode || !this.textColorMode || this.labelClass === color) return;
+
+		this.groundboostLabel.RemoveClass(this.labelClass);
+		this.labelClass = color;
+		this.groundboostLabel.AddClass(this.labelClass);
+	}
+
 	static fadeOut() {
 		this.container.AddClass('groundboost__container--hide');
 		this.visible = false;
 	}
 
+	static getSize(vec) {
+		return Math.sqrt(this.getSizeSquared(vec));
+	}
+
+	static getSizeSquared(vec) {
+		return vec.x * vec.x + vec.y * vec.y;
+	}
+
+	static onConfigChange() {
+		const groundboostConfig = DefragAPI.GetHUDGroundboostCFG();
+		this.overshootEnable = groundboostConfig.overshootEnable;
+		this.textMode = groundboostConfig.textMode;
+		this.textColorMode = groundboostConfig.textColorMode;
+		this.crashHlEnable = groundboostConfig.crashHlEnable;
+
+		if (!this.textMode) {
+			this.groundboostLabel.AddClass(LabelClass.HIDE);
+		} else {
+			this.groundboostLabel.RemoveClass(LabelClass.HIDE);
+		}
+	}
+
 	static {
 		$.RegisterEventHandler('ChaosHudProcessInput', $.GetContextPanel(), this.onUpdate.bind(this));
 		$.RegisterForUnhandledEvent('ChaosLevelInitPostEntity', this.onLoad.bind(this));
+		$.RegisterForUnhandledEvent('OnDefragHUDGroundboostChange', this.onConfigChange.bind(this));
 	}
 }

--- a/styles/hud/ground-boost.scss
+++ b/styles/hud/ground-boost.scss
@@ -27,6 +27,10 @@
 		}
 
 		&--slick {
+			wash-color: $white;
+		}
+
+		&--crash {
 			wash-color: $blue;
 		}
 	}
@@ -45,5 +49,21 @@
 		font-size: 20px;
 		font-weight: bold;
 		text-shadow: rgba(0, 0, 0, 0.5) 0px 1px 2px 2.5;
+
+		&--gain {
+			color: $blue;
+		}
+
+		&--flat {
+			color: $white;
+		}
+
+		&--loss {
+			color: $red;
+		}
+
+		&--hide {
+			visibility: collapse;
+		}
 	}
 }


### PR DESCRIPTION
Closes momentum-mod/game/issues/2046

~Required Red changes!~ Engine changes merged.

This pull request adds features and settings for the defrag groundboost indicator.
- Added setting for choosing label data
  - `mom_df_hud_gb_text_mode` 0 = OFF, 1 = Remaining time, 2 = Speed change
  - Mode 1 is default (same as previous behavior)
- Added setting for coloring label text
  - `mom_df_hud_gb_text_color_mode` 0 = OFF, 1 = Timer, 2 = Speed
  - Mode 0 is default (same as previous behavior)
- Added setting for showing when the player stayed on the ground too long
  - `mom_df_hud_gb_overshoot_enable`
  - Default is ON (same as previous behavior)
- Added setting for distinguishing crash landing from other slick states
  - `mom_df_hud_gb_crash_hl_enable`
  - Default is OFF (same as previous behavior)

I've tested this locally, and it seems stable enough to roll out for more player testing.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "Settings_Defrag_Groundboost_Title",
		"definition": "Groundboost Indicator"
	},
	{
		"term": "Settings_Defrag_Groundboost",
		"definition": "Show groundboost indicator"
	},
	{
		"term": "Settings_Defrag_Groundboost_Info",
		"definition": "Display HUD element for monitoring player no-friction state caused by weapon knockback or teleporter."
	},
	{
		"term": "Settings_Defrag_Groundboost_TextMode",
		"definition": "Label text mode"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextMode_Info",
		"definition": "Select the data to display in the groundboost indicator label.\n0 = Hide text\n1 = Remaining time\n2 = Speed change"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextMode_Type0",
		"definition": "Hide text"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextMode_Type1",
		"definition": "Remaining time"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextMode_Type2",
		"definition": "Speed change"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextColorMode",
		"definition": "Text colorize mode"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextColorMode_Info",
		"definition": "Select the data used for coloring text in the groundboost indicator label.\n0 = No color\n1 = Remaining time\n2 = Speed change"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextColorMode_Type0",
		"definition": "No color"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextColorMode_Type1",
		"definition": "Remaining time"
	},
	{
		"term": "Settings_Defrag_Groundboost_TextColorMode_Type2",
		"definition": "Speed change"
	},
	{
		"term": "Settings_Defrag_Groundboost_Overshoot",
		"definition": "Show overshoot"
	},
	{
		"term": "Settings_Defrag_Groundboost_Overshoot_Info",
		"definition": "Display time on the ground after no-friction state has ended as refilling the circular meter."
	},
	{
		"term": "Settings_Defrag_Groundboost_CrashHighlight",
		"definition": "Highlight crash landing"
	},
	{
		"term": "Settings_Defrag_Groundboost_CrashHighlight_Info",
		"definition": "Highlight meter when crash landing flag is applied. This flag extends the timer to max duration (250 ms). When both knockback and crash landing apply, the meter is blue. When only knockback is applied, the meter is white."
	}
]
```
