### PR TITLE
Feat/synchronizer improvements

### DIFF
--- a/layout/hud/ground-boost.xml
+++ b/layout/hud/ground-boost.xml
@@ -7,7 +7,7 @@
 	</scripts>
 
 	<MomHudGroundboost class="horizontal-align-center" alternateTicks="false">
-		<ConVarEnabler id="GroundboostContainer" class="groundboost__container groundboost__container--hide" convar="mom_df_hud_groundboost_enable" togglevisibility="true">
+		<ConVarEnabler id="GroundboostContainer" class="groundboost__container groundboost__container--hide" convar="mom_df_hud_gb_enable" togglevisibility="true">
 			<Image id="GroundboostBackground" class="groundboost__background-meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
 			<Image id="GroundboostMeter" class="groundboost__meter" src="file://{images}/hud/meter-ring.svg" textureheight="100" />
 			<Label id="GroundboostLabel" text="" class="groundboost__label" />

--- a/layout/pages/settings/interface.xml
+++ b/layout/pages/settings/interface.xml
@@ -608,6 +608,8 @@
 						<Label text="#Settings_Synchronizer_AveragingWindow_Mode4" value="20" id="buffer3" />
 					</ChaosSettingsEnumDropDown>
 
+					<ChaosSettingsSlider text="#Settings_Synchronizer_MinSpeed" min="50" max="250" convar="mom_hud_synchro_min_speed" displayprecision="0" infomessage="#Settings_Synchronizer_MinSpeed_Info" />
+
 					<ChaosSettingsEnumDropDown text="#Settings_Synchronizer_Stats_Mode" convar="mom_hud_synchro_stat_mode" infomessage="#Settings_Synchronizer_Stats_Mode_Info">
 						<Label id="mode0" text="#Common_Off" value="0" />
 						<Label id="mode1" text="#Settings_Synchronizer_StatsMode_Mode1" value="1" />

--- a/scripts/hud/ground-boost.js
+++ b/scripts/hud/ground-boost.js
@@ -65,15 +65,19 @@ class Groundboost {
 					this.startGB(timerFlags & TimerFlags.LANDING);
 				}
 				bUpdateMeter = true;
-			} else if (this.overshootEnable && this.visible) {
-				// Player is grounded and no longer has the friction flag
-				if (this.missedJumpTimer === 0) {
-					this.missedJumpTimer = curTime;
-					this.setMeterColor(ColorClass.FRICTION);
-				}
+			} else if (this.visible) {
 				bUpdateMeter = true;
-				timer = Math.min(MAX_TIMER_MS, Math.round(1000 * (curTime - this.missedJumpTimer)));
-				if (timer === MAX_TIMER_MS) this.fadeOut();
+				if (this.overshootEnable) {
+					// Player is grounded and no longer has the friction flag
+					if (this.missedJumpTimer === 0) {
+						this.missedJumpTimer = curTime;
+						this.setMeterColor(ColorClass.FRICTION);
+					}
+					timer = Math.min(MAX_TIMER_MS, Math.round(1000 * (curTime - this.missedJumpTimer)));
+					if (timer === MAX_TIMER_MS) this.fadeOut();
+				} else if (!timer) {
+					this.fadeOut();
+				}
 			}
 			if (bUpdateMeter) {
 				const fill = Math.min(timer * MS_2_DEG, 360).toFixed(2) - 360;


### PR DESCRIPTION
Closes momentum-mod/game/issues/2044

This pull request utilizes engine changes to the optimal yaw calculation for strafe synchronizer. There is also the addition of a minimum speed for calculating behavior of the bar portion of the hud element.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "Settings_Synchronizer_MinSpeed",
		"definition": "Minimum speed"
	},
	{
		"term": "Settings_Synchronizer_MinSpeed_Info",
		"definition": "Minimum speed required to show synchronizer bar feedback"
	}
]
```
