### PR TITLE
fix: Replace Chaos reference in README.md with Strata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Momentum Mod](images/momentumLogo.svg)
 
-> _Momentum Mod's game User Interface files used by the Chaos Source Engine's Panorama UI framework._
+> _Momentum Mod's game User Interface files used by the Strata Source Engine's Panorama UI framework._
 
 # Structure
 


### PR DESCRIPTION
README.md contained a reference to Chaos. This was the only reference I could find (using the regex `[^<|/|"|']Chaos`) that wasn't code-related. Changing all the panel names (e.g. `ChaosSettingsSlider`) is a much bigger refactor and takes a ton of C++ work.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
