### PR TITLE
fix: incorporate engine changes to haste time calculation

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -280,7 +280,7 @@ class Cgaz {
 		const accel = lastMoveData.acceleration;
 		const maxAccel = accel * maxSpeed * tickInterval;
 
-		if (lastMoveData.hasteEndTime < 0 || lastMoveData.hasteEndTime > MomentumMovementAPI.GetCurrentTime()) {
+		if (lastMoveData.hasteTime) {
 			if (this.snapAccel !== HASTE_ACCEL) {
 				this.snapAccel = HASTE_ACCEL;
 				MAX_GROUND_SPEED = HASTE_SPEED;

--- a/scripts/hud/ground-boost.js
+++ b/scripts/hud/ground-boost.js
@@ -53,7 +53,7 @@ class Groundboost {
 		const timerFlags = lastMoveData.defragTimerFlags;
 		const curTime = MomentumMovementAPI.GetCurrentTime();
 		const speed = this.getSize(MomentumPlayerAPI.GetVelocity());
-		const deltaSpeed = speed - this.peakSpeed;
+		const deltaSpeed = speed - this.startSpeed;
 		let bUpdateMeter = false;
 
 		// Only toggle visibility on if the player is grounded
@@ -98,7 +98,7 @@ class Groundboost {
 	static startGB(bCrashLand) {
 		this.visible = true;
 		this.startSpeed = this.getSize(MomentumPlayerAPI.GetVelocity());
-		this.peakSpeed = 0;
+		this.peakSpeed = this.startSpeed;
 		this.missedJumpTimer = 0;
 		this.container.RemoveClass('groundboost__container--hide');
 		this.setMeterColor(this.crashHlEnable && !bCrashLand ? ColorClass.SLICK : ColorClass.CRASH);


### PR DESCRIPTION
Closes momentum-mod/game/issues/2058

This pull request updates UI logic to match recent changes to how haste is tracked by the engine. Instead of storing an ending timestamp, an integer value is passed as `lastMoveData.hasteTime` to communicate the number of milliseconds of haste remaining (-1 for unlimited haste).

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
