### PR TITLE
Defrag Prime Sight

### DIFF
--- a/layout/hud/cgaz.xml
+++ b/layout/hud/cgaz.xml
@@ -23,6 +23,12 @@
 			<Panel id="WindicatorZone" />
 		</ConVarEnabler>
 		<ConVarEnabler id="SnapContainer" class="cgaz__container" convar="mom_df_hud_snap_enable" togglevisibility="true" />
+		<ConVarEnabler id="PrimeContainer" class="cgaz__container" convar="mom_df_hud_prime_enable" togglevisibility="true" />
+		<Panel id="PrimeArrow">
+			<ConVarEnabler class="full-height" convar="mom_df_hud_prime_arrow_enable" togglevisibility="true">
+				<Image id="PrimeArrowIcon" class="arrow__down" src="file://{images}/hud/cgaz-arrow.svg" textureheight="48" />
+			</ConVarEnabler>
+		</Panel>
 		<Panel id="CompassArrow">
 			<ConVarEnabler class="full-height" convar="mom_df_hud_compass_mode" togglevisibility="true">
 				<Image id="CompassArrowIcon" class="arrow__up" src="file://{images}/hud/cgaz-arrow.svg" textureheight="48" />

--- a/layout/pages/settings/gameplay.xml
+++ b/layout/pages/settings/gameplay.xml
@@ -567,6 +567,72 @@
 
 				</Panel>
 
+				<Panel class="settings-group__combo">
+
+					<Label class="settings-group__combo-header" text="#Settings_Defrag_PrimeSight_Title" />
+
+					<ChaosSettingsEnum text="#Settings_Defrag_PrimeSight_Enable" convar="mom_df_hud_prime_enable" infomessage="#Settings_Defrag_PrimeSight_Enable_Info" tags="prime,sight">
+						<RadioButton group="primeenable" text="#Common_Off" value="0" />
+						<RadioButton group="primeenable" text="#Common_On" value="1" />
+					</ChaosSettingsEnum>
+
+					<ConVarEnabler convar="mom_df_hud_prime_enable"  class="flow-down">
+						<ChaosSettingsSlider text="#Settings_Defrag_PrimeSight_Height" min="1" max="50" convar="mom_df_hud_prime_height" displayprecision="0" infomessage="#Settings_Defrag_PrimeSight_Height_Info" tags="prime,sight" />
+
+						<ChaosSettingsSlider text="#Settings_Defrag_PrimeSight_Offset" min="-200" max="200" convar="mom_df_hud_prime_offset" displayprecision="0" infomessage="#Settings_Defrag_PrimeSight_Offset_Info" tags="prime,sight" />
+
+						<ChaosSettingsSlider text="#Settings_Defrag_PrimeSight_MinSpeed" min="1" max="1000" convar="mom_df_hud_prime_min_speed" displayprecision="0" infomessage="#Settings_Defrag_PrimeSight_MinSpeed_Info" tags="prime,sight" />
+
+						<ChaosSettingsEnum text="#Settings_Defrag_PrimeSight_SizeByGain" convar="mom_df_hud_prime_heightgain_enable" infomessage="#Settings_Defrag_PrimeSight_SizeByGain_Info" tags="prime,sight">
+							<RadioButton group="primeheightgain" text="#Common_Off" value="0" />
+							<RadioButton group="primeheightgain" text="#Common_On" value="1" />
+						</ChaosSettingsEnum>
+
+						<ChaosSettingsEnum text="#Settings_Defrag_PrimeSight_ColorByGain" convar="mom_df_hud_prime_colorgain_enable" infomessage="#Settings_Defrag_PrimeSight_ColorByGain_Info" tags="prime,sight">
+							<RadioButton group="primecolorgain" text="#Common_Off" value="0" />
+							<RadioButton group="primecolorgain" text="#Common_On" value="1" />
+						</ChaosSettingsEnum>
+
+						<ChaosSettingsEnum text="#Settings_Defrag_PrimeSight_HighlightEnable" convar="mom_df_hud_prime_hl_enable" infomessage="#Settings_Defrag_PrimeSight_HighlightEnable_Info" tags="prime,sight">
+							<RadioButton group="primehlenable" text="#Common_Off" value="0" />
+							<RadioButton group="primehlenable" text="#Common_On" value="1" />
+						</ChaosSettingsEnum>
+
+						<ConVarEnabler convar="mom_df_hud_prime_hl_enable" class="flow-down">
+							<ConVarColorDisplay text="#Settings_Defrag_PrimeSight_HighlightColor" convar="mom_df_hud_prime_hl_color" infomessage="#Settings_Defrag_PrimeSight_HighlightColor_Info" tags="prime,sight" />
+
+							<ChaosSettingsSlider text="#Settings_Defrag_PrimeSight_HighlightBorder" min="0" max="10" convar="mom_df_hud_prime_hl_border" displayprecision="0" infomessage="#Settings_Defrag_PrimeSight_HighlightBorder_Info" tags="prime,sight" />
+						</ConVarEnabler>
+
+						<ChaosSettingsEnum text="#Settings_Defrag_PrimeSight_InactiveEnable" convar="mom_df_hud_prime_inactive_enable" infomessage="#Settings_Defrag_PrimeSight_InactiveEnable_Info" tags="prime,sight">
+							<RadioButton group="primeinactiveenable" text="#Common_Off" value="0" />
+							<RadioButton group="primeinactiveenable" text="#Common_On" value="1" />
+						</ChaosSettingsEnum>
+
+						<ConVarEnabler convar="mom_df_hud_prime_inactive_enable">
+							<ConVarColorDisplay text="#Settings_Defrag_PrimeSight_AltColor" convar="mom_df_hud_prime_alt_color" infomessage="#Settings_Defrag_PrimeSight_AltColor_Info" tags="prime,sight" />
+						</ConVarEnabler>
+
+						<ConVarColorDisplay text="#Settings_Defrag_PrimeSight_GainColor" convar="mom_df_hud_prime_gain_color" infomessage="#Settings_Defrag_PrimeSight_GainColor_Info" tags="prime,sight" />
+
+						<ConVarColorDisplay text="#Settings_Defrag_PrimeSight_LossColor" convar="mom_df_hud_prime_loss_color" infomessage="#Settings_Defrag_PrimeSight_LossColor_Info" tags="prime,sight" />
+
+						<ChaosSettingsEnum text="#Settings_Defrag_PrimeSight_ArrowEnable" convar="mom_df_hud_prime_arrow_enable" infomessage="#Settings_Defrag_PrimeSight_ArrowEnable_Info" tags="prime,sight">
+							<RadioButton group="primearrowenable" text="#Common_Off" value="0" />
+							<RadioButton group="primearrowenable" text="#Common_On" value="1" />
+						</ChaosSettingsEnum>
+						
+						<ConVarEnabler convar="mom_df_hud_prime_arrow_enable"  class="flow-down">
+							<ChaosSettingsSlider text="#Settings_Defrag_PrimeSight_ArrowSize" min="1" max="10" convar="mom_df_hud_prime_arrow_size" displayprecision="0" infomessage="#Settings_Defrag_PrimeSight_ArrowSize_Info" tags="prime,sight" />
+
+							<ConVarColorDisplay text="#Settings_Defrag_PrimeSight_ArrowColor" convar="mom_df_hud_prime_arrow_color" infomessage="#Settings_Defrag_PrimeSight_ArrowColor_Info" tags="prime,sight" />
+						</ConVarEnabler>
+
+						<!-- Trueness Mode -->
+					</ConVarEnabler>
+
+				</Panel>
+
 				<ChaosSettingsEnumDropDown text="#Settings_Defrag_ProjectionMode" convar="mom_df_hud_projection" infomessage="#Settings_Defrag_ProjectionMode_Info">
 					<Label id="projection0" text="#Settings_Defrag_ProjectionMode_Type0" value="0" />
 					<Label id="projection1" text="#Settings_Defrag_ProjectionMode_Type1" value="1" />

--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -148,9 +148,9 @@ class Cgaz {
 		this.applyClass(this.rightFastZone, FAST_CLASS);
 		this.applyClass(this.rightTurnZone, TURN_CLASS);
 		this.applyClass(this.accelSplitZone, NEUTRAL_CLASS);
-		this.applyClassBorder(this.leftMirrorZone, MIRROR_CLASS);
-		this.applyClassBorder(this.rightMirrorZone, MIRROR_CLASS);
-		this.applyClassBorder(this.mirrorSplitZone, MIRROR_CLASS);
+		this.applyClassBorder(this.leftMirrorZone, 2, MIRROR_CLASS);
+		this.applyClassBorder(this.rightMirrorZone, 2, MIRROR_CLASS);
+		this.applyClassBorder(this.mirrorSplitZone, 2, MIRROR_CLASS);
 
 		if (this.snapEnable) {
 			this.onSnapConfigChange();
@@ -213,7 +213,7 @@ class Cgaz {
 		);
 
 		WIN_ZONE_CLASS = new StyleObject(accelConfig.height, accelConfig.offset, this.windicatorColor);
-		this.applyClassBorder(this.windicatorZone, WIN_ZONE_CLASS);
+		this.applyClassBorder(this.windicatorZone, 2, WIN_ZONE_CLASS);
 	}
 
 	static onCompassConfigChange() {
@@ -804,10 +804,10 @@ class Cgaz {
 		panel.style.overflow = 'noclip noclip';
 	}
 
-	static applyClassBorder(panel, zoneClass) {
+	static applyClassBorder(panel, thickness, zoneClass) {
 		panel.style.height = this.NaNCheck(zoneClass.height, 0) + 'px';
-		panel.style.border = `2px solid ${zoneClass.color}`;
-		panel.style.padding = '-2px';
+		panel.style.border = `${thickness}px solid ${zoneClass.color}`;
+		panel.style.padding = `-${thickness}px`;
 		panel.style.verticalAlign = zoneClass.align;
 		panel.style.overflow = 'noclip noclip';
 	}

--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -718,9 +718,7 @@ class Cgaz {
 			this.updateZone(zones[i], left, right, 0, snapClass, this.snapSplitZone);
 
 			if (this.snapColorMode) {
-				const A = this.splitColorString(this.snapSlowColor);
-				const B = this.splitColorString(this.snapFastColor);
-				snapColor = this.getColorStringFromArray(this.colorLerp(A, B, alpha));
+				snapColor = this.colorLerp(this.snapSlowColor, this.snapFastColor, alpha);
 			}
 
 			let bHighlight = false;
@@ -940,8 +938,12 @@ class Cgaz {
 			.map((c, i) => (i === 3 ? Number.parseInt(c * 255) : Number.parseInt(c)));
 	}
 
-	static colorLerp(A, B, alpha) {
-		return A.map((Ai, i) => Ai + alpha * (B[i] - Ai));
+	static colorLerp(stringA, stringB, alpha) {
+		const arrayA = this.splitColorString(stringA);
+		const arrayB = this.splitColorString(stringB);
+		if (arrayA.length === 3) arrayA.push(255);
+		if (arrayB.length === 3) arrayB.push(255);
+		return this.getColorStringFromArray(arrayA.map((Ai, i) => Ai + alpha * (arrayB[i] - Ai)));
 	}
 
 	static {


### PR DESCRIPTION
Depends on Red changes for convars!

This pull request adds Prime Sight UI for Defrag. Prime Sight is a combination of the CGAZ and snap HUDs from Q3DF which shows the following information in real time:
- Which regions allow the player to gain speed
- How the potential gain from each zone compares with the maximum
- When it's favorable to switch strafe directions to maximize speed gain

Settings for the following features are included:
- Size (height) of the HUD tool
- Offset from center screen
- Minimum speed to draw the HUD
- Colors for indicating potential speed gain/loss
- Color for indicating diagonal strafe zones not currently in use
- Highlighting the zone representing the current movement calculation
- Color for highlighting current active zone
- Disabling the relative gain scaling for zone height
- Enabling an arrow to indicate the snapped direction of the current zone
- Size of the arrow
- Color of the arrow
** Note: trueness modifications (ground zones, A/D zones, jump/crouch) still WIP, but inaccessible from settings. The settings allow modification of fully complete features only.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
  {
    "term": "Settings_Defrag_PrimeSight_Title",
    "definition": "Prime sight HUD"
  },
  {
    "term": "Settings_Defrag_PrimeSight_Enable",
    "definition": "Enable prime sight"
  },
  {
    "term": "Settings_Defrag_PrimeSight_Enable_Info",
    "definition": "Enable prime sight hud. This tool shows how movement inputs and view direction interact when strafing. To gain speed optimally, aim the crosshair in the tallest rectangle."
  },
  {
    "term": "Settings_Defrag_PrimeSight_Height",
    "definition": "Height"
  },
  {
    "term": "Settings_Defrag_PrimeSight_Height_Info",
    "definition": "Height to draw prime sight hud in pixels  @ 1080p"
  },
  {
    "term": "Settings_Defrag_PrimeSight_Offset",
    "definition": "Offset"
  },
  {
    "term": "Settings_Defrag_PrimeSight_Offset_Info",
    "definition": "Offset from center screen in pixels  @ 1080p"
  },
  {
    "term": "Settings_Defrag_PrimeSight_MinSpeed",
    "definition": "Minimum Speed"
  },
  {
    "term": "Settings_Defrag_PrimeSight_MinSpeed_Info",
    "definition": "Minimum speed threshold for drawing prime sight hud"
  },
  {
    "term": "Settings_Defrag_PrimeSight_GainColor",
    "definition": "Gain color"
  },
  {
    "term": "Settings_Defrag_PrimeSight_GainColor_Info",
    "definition": "Color to represent active zones that will cause the player's speed to increase on the next frame"
  },
  {
    "term": "Settings_Defrag_PrimeSight_LossColor",
    "definition": "Loss color"
  },
  {
    "term": "Settings_Defrag_PrimeSight_LossColor_Info",
    "definition": "Color to represent active zones that will cause the player's speed to decrease on the next frame"
  },
  {
    "term": "Settings_Defrag_PrimeSight_AltColor",
    "definition": "Inactive color"
  },
  {
    "term": "Settings_Defrag_PrimeSight_InactiveEnable",
    "definition": "Show inactive zones"
  },
  {
    "term": "Settings_Defrag_PrimeSight_InactiveEnable_Info",
    "definition": "Draw diagonal strafe zones for directions not currently active based on movement input"
  },
  {
    "term": "Settings_Defrag_PrimeSight_AltColor_Info",
    "definition": "Color to represent zones not currently active based on movement input"
  },
  {
    "term": "Settings_Defrag_PrimeSight_HighlightEnable",
    "definition": "Highlight current zone"
  },
  {
    "term": "Settings_Defrag_PrimeSight_HighlightEnable_Info",
    "definition": "Outline the current zone that will influence the player's movement calculation"
  },
  {
    "term": "Settings_Defrag_PrimeSight_HighlightColor",
    "definition": "Highlight color"
  },
  {
    "term": "Settings_Defrag_PrimeSight_HighlightColor_Info",
    "definition": "Color used to outline the current active zone"
  },
  {
    "term": "Settings_Defrag_PrimeSight_HighlightBorder",
    "definition": "Highlight border"
  },
  {
    "term": "Settings_Defrag_PrimeSight_HighlightBorder_Info",
    "definition": "Highlight border thickness in pixels"
  },
  {
    "term": "Settings_Defrag_PrimeSight_SizeByGain",
    "definition": "Scale height by gain"
  },
  {
    "term": "Settings_Defrag_PrimeSight_SizeByGain_Info",
    "definition": "Toggle scaling of zones by speed gain potential"
  },
  {
    "term": "Settings_Defrag_PrimeSight_ColorByGain",
    "definition": "Color zones by gain"
  },
  {
    "term": "Settings_Defrag_PrimeSight_ColorByGain_Info",
    "definition": "Toggle coloring of zones by speed gain potential"
  },
  {
    "term": "Settings_Defrag_PrimeSight_ArrowEnable",
    "definition": "Arrow"
  },
  {
    "term": "Settings_Defrag_PrimeSight_ArrowEnable_Info",
    "definition": "Draw an arrow to show the snapped direction of the current zone"
  },
  {
    "term": "Settings_Defrag_PrimeSight_ArrowSize",
    "definition": "Arrow size"
  },
  {
    "term": "Settings_Defrag_PrimeSight_ArrowSize_Info",
    "definition": "Size of the prime sight arrow. Value represents arrow half-height in pixels @ 1080p"
  },
  {
    "term": "Settings_Defrag_PrimeSight_ArrowColor",
    "definition": "Arrow color"
  },
  {
    "term": "Settings_Defrag_PrimeSight_ArrowColor_Info",
    "definition": "Color to draw the prime sight arrow"
  }
]
```
