### PR TITLE
feat: add cm/360 sensitivity conversion

### DIFF
--- a/layout/pages/settings/input.xml
+++ b/layout/pages/settings/input.xml
@@ -4,6 +4,7 @@
 	</styles>
 	<scripts>
 		<include src="file://{resources}/scripts/pages/settings/page.js" />
+		<include src="file://{resources}/scripts/pages/settings/mouse-sensitivity.js" />
 	</scripts>
 
 	<Panel class="settings-page">
@@ -29,8 +30,21 @@
 						</TooltipPanel>
 					</Panel>
 				</Panel>
-
-				<ChaosSettingsSlider text="#Settings_Mouse_Sens" min="0.1" max="10" displayprecision="2" convar="sensitivity" tags="sensitivity" hasdocspage="false" />
+				
+				<Panel class="settings-group__combo">
+					<ChaosSettingsSlider text="#Settings_Mouse_Sens" min="0.1" max="10" displayprecision="2" convar="sensitivity" tags="sensitivity" hasdocspage="false" />
+				
+					<Panel class="settings-enum__values pr-2 pl-4 mb-1" onload="MouseSensitivity.loadSettings()">
+						<Label text="#Settings_DPI_Input" class="settings-enum__title" />
+						<TextEntry id="DPI" class="textentry settings-slider__textentry ml-4" maxchars="5" multiline="false" textmode="numeric" ontextentrychange="MouseSensitivity.saveDPI()" />
+							
+						<DropDown id="UnitSelection" class="dropdown ml-4" menuclass="dropdown-menu" oninputsubmit="MouseSensitivity.saveUnitSelection()">
+							<Label text="#Settings_Centimeters_Per_360" value="0" id="m_sens_cm" />
+							<Label text="#Settings_Inches_Per_360" value="1" id="m_sens_in" />
+						</DropDown>
+						<TextEntry id="UnitsPer360" class="textentry settings-slider__textentry ml-4" multiline="false" textmode="numeric" oninputsubmit="MouseSensitivity.setSensitivity()"/>
+					</Panel>
+				</Panel>
 
 				<Panel class="settings-group__combo">
 					<ChaosSettingsEnum text="#Settings_Mouse_Accel" convar="m_customaccel" hasdocspage="false" tags="acceleration">

--- a/scripts/pages/settings/mouse-sensitivity.js
+++ b/scripts/pages/settings/mouse-sensitivity.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const CM_CONVERSION_FACTOR = 2.54;
+
+class MouseSensitivity {
+	static panels = {
+		/** @type {TextEntry} @static */
+		dpi: $('#DPI'),
+		/** @type {DropDown} @static */
+		unitSelection: $('#UnitSelection'),
+		/** @type {TextEntry} @static */
+		unitsPer360: $('#UnitsPer360')
+	};
+
+	static calculateSensitivity() {
+		if (!this.panels.dpi.text) return;
+
+		const yaw = GameInterfaceAPI.GetSettingFloat('m_yaw');
+		const eDPI = this.panels.dpi.text * GameInterfaceAPI.GetSettingFloat('sensitivity');
+		let per360 = 360 / (eDPI * yaw);
+
+		if (this.panels.unitSelection.GetSelected().id === 'm_sens_cm') per360 *= CM_CONVERSION_FACTOR;
+
+		this.panels.unitsPer360.text = per360.toFixed(2);
+	}
+
+	static setSensitivity() {
+		if (!this.panels.dpi.text) return;
+
+		const yaw = GameInterfaceAPI.GetSettingFloat('m_yaw');
+		const eDPI = 360 / yaw / this.panels.unitsPer360.text;
+		let sensitivity = eDPI / this.panels.dpi.text;
+
+		if (this.panels.unitSelection.GetSelected().id === 'm_sens_cm') sensitivity *= CM_CONVERSION_FACTOR;
+
+		GameInterfaceAPI.SetSettingFloat('sensitivity', sensitivity);
+	}
+
+	static saveDPI() {
+		$.persistentStorage.setItem('settings.mouseDPI', this.panels.dpi.text);
+		this.calculateSensitivity();
+	}
+
+	static saveUnitSelection() {
+		$.persistentStorage.setItem('settings.mouseUnitSelector', this.panels.unitSelection.GetSelected().id);
+		this.calculateSensitivity();
+	}
+
+	static loadSettings() {
+		this.panels.dpi.text = $.persistentStorage.getItem('settings.mouseDPI');
+		this.panels.unitSelection.SetSelected($.persistentStorage.getItem('settings.mouseUnitSelector'));
+		this.calculateSensitivity();
+	}
+
+	static {
+		$.RegisterConVarChangeListener('sensitivity', this.calculateSensitivity.bind(this));
+	}
+}


### PR DESCRIPTION
Closes momentum-mod/game/issues/2047

This PR adds conversion from in-game sensitivity to cm/360 and in/360 ( and vice-versa )

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
  {
    "term": "Settings_DPI_Input",
    "definition": "Input DPI"
  },
  {
    "term": "Settings_Centimeters_Per_360",
    "definition": "cm/360"
  },
  {
    "term": "Settings_Inches_Per_360",
    "definition": "in/360" 
  }
]
```
