### PR TITLE
prime sight fixes

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -617,7 +617,7 @@ class Cgaz {
 					this.onPrimeConfigChange();
 				}
 
-				const targetAngle = Math.max(this.findFastAngle(dropSpeed, primeSightSpeed, primeSightAccel), 0);
+				const targetAngle = this.findFastAngle(dropSpeed, primeSightSpeed, primeSightAccel);
 				const boundaryAngle = this.findStopAngle(
 					primeSightAccel,
 					speedSquared,
@@ -942,6 +942,7 @@ class Cgaz {
 			Math.round(this.getSize(wishDir)) * (1 << Math.round(2 * Math.pow(cross, 2))) +
 			(Math.round(cross) > 0 ? 1 : 0);
 
+		const angleOffset = this.remapAngle(velAngle - wishAngle);
 		const targetOffset = this.remapAngle(velAngle - viewAngle);
 		const inputAngle = this.remapAngle(viewAngle - wishAngle) * this.getSizeSquared(wishDir);
 		const velocity = MomentumPlayerAPI.GetVelocity();
@@ -1101,7 +1102,7 @@ class Cgaz {
 	static findArrayInfimum(arr, val) {
 		let lower = 0;
 		let upper = arr.length - 1;
-		if (val < arr[0]) return upper;
+		if (val < arr[lower] || val > arr[upper]) return upper;
 
 		while (lower < upper) {
 			const i = Math.floor(0.5 * (lower + upper));
@@ -1111,7 +1112,7 @@ class Cgaz {
 				upper = i;
 			}
 		}
-		return lower - 1;
+		return (lower - 1 + arr.length) % arr.length;
 	}
 
 	/**
@@ -1125,8 +1126,8 @@ class Cgaz {
 	}
 
 	static findPrimeGain(zone, velocity, wishDir) {
-		const avgAngle = -0.5 * (zone.leftAngle + zone.rightAngle);
-		const zoneVector = this.rotateVector(wishDir, avgAngle);
+		const avgAngle = 0.5 * (zone.leftAngle + zone.rightAngle);
+		const zoneVector = this.rotateVector(wishDir, -avgAngle);
 		const snapProject = {
 			x: Math.round(zoneVector.x * this.primeAccel),
 			y: Math.round(zoneVector.y * this.primeAccel)

--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -1218,37 +1218,39 @@ class Cgaz {
 	}
 
 	static mapToScreenWidth(angle) {
-		const screenWidth = this.screenX / this.scale;
-
+		const sigFigs = 1000;
+		const num = sigFigs * this.screenX * 0.5;
+		const den = sigFigs * this.scale;
 		const overhang = 1.1;
 		if (Math.abs(angle) >= overhang * this.hFov) {
-			return (Math.sign(angle) > 0 ? overhang : 1 - overhang) * screenWidth;
+			return ((Math.sign(angle) > 0 ? overhang : 1 - overhang) * this.screenX) / this.scale;
 		}
 
 		switch (this.projection) {
 			case 0:
-				return Math.round((1 + Math.tan(angle) / Math.tan(this.hFov)) * screenWidth * 0.5);
+				return Math.round((1 + Math.tan(angle) / Math.tan(this.hFov)) * num) / den;
 			case 1:
-				return Math.round((1 + angle / this.hFov) * screenWidth * 0.5);
+				return Math.round((1 + angle / this.hFov) * num) / den;
 			case 2:
-				return Math.round((1 + Math.tan(angle * 0.5) / Math.tan(this.hFov * 0.5)) * screenWidth * 0.5);
+				return Math.round((1 + Math.tan(angle * 0.5) / Math.tan(this.hFov * 0.5)) * num) / den;
 		}
 	}
 
 	static mapToScreenHeight(angle) {
-		const screenHeight = this.screenY / this.scale;
-
+		const sigFigs = 1000;
+		const num = sigFigs * this.screenY * 0.5;
+		const den = sigFigs * this.scale;
 		if (Math.abs(angle) >= this.vFov) {
-			return Math.sign(angle) > 0 ? screenHeight : 0;
+			return Math.sign(angle) > 0 ? this.screenY / this.scale : 0;
 		}
 
 		switch (this.projection) {
 			case 0:
-				return Math.round((1 + Math.tan(angle) / Math.tan(this.vFov)) * screenHeight * 0.5);
+				return Math.round((1 + Math.tan(angle) / Math.tan(this.vFov)) * num) / den;
 			case 1:
-				return Math.round((1 + angle / this.vFov) * screenHeight * 0.5);
+				return Math.round((1 + angle / this.vFov) * num) / den;
 			case 2:
-				return Math.round((1 + Math.tan(angle * 0.5) / Math.tan(this.vFov * 0.5)) * screenHeight * 0.5);
+				return Math.round((1 + Math.tan(angle * 0.5) / Math.tan(this.vFov * 0.5)) * num) / den;
 		}
 	}
 

--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -1120,7 +1120,7 @@ class Cgaz {
 	 * @returns {Boolean}
 	 */
 	static shouldHighlight(zone) {
-		const center = 0.5 * this.screenX;
+		const center = (0.5 * this.screenX) / this.scale;
 		return zone.rightPx - center >= 0 && zone.leftPx - center <= 0;
 	}
 


### PR DESCRIPTION
Closes momentum-mod/game/issues/2078
Closes momentum-mod/game/issues/2079

This pull requests fixes a few bugs with the new prime sight hud for defrag.
- Highlighting now correctly selects the zone behind the crosshair at resolutions other than 1080p.
- The correct zone is shown when the zone wraps across -pi/pi (reported by lumia & panzer).

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
