### PR TITLE
console/autocomplete style tweaks

### DIFF
--- a/styles/controls/text-entry.scss
+++ b/styles/controls/text-entry.scss
@@ -64,9 +64,9 @@ TextEntryAutocomplete {
 	overflow: squish scroll;
 	z-index: 0;
 	opacity: 1;
-	max-height: 220px;
+	max-height: 250px;
 
-	box-shadow: fill #00000066 -3px -3px 6px 6px;
+	box-shadow: fill #00000066 2px 2px 4px 4px;
 
 	& Label {
 		width: 100%;
@@ -83,16 +83,12 @@ TextEntryAutocomplete {
 		border-top: 1px solid #00000066;
 		border-bottom: 1px solid #00000066;
 
-		transition-property: background-color;
-		transition-duration: 0.2s;
-		transition-timing-function: ease-in-out;
+		&:focus {
+			background-color: #585e62;
+		}
 
 		&:hover {
 			background-color: #018eec;
-		}
-
-		&:focus {
-			background-color: #585e62;
 		}
 	}
 }

--- a/styles/pages/console.scss
+++ b/styles/pages/console.scss
@@ -12,6 +12,7 @@
 		padding-left: 8px;
 		padding-right: 8px;
 		padding-bottom: 8px;
+		position: 15px 20px 0px;
 	}
 
 	&__inner {


### PR DESCRIPTION
- Offset initial console position from corner
- Remove autocomplete selection transitions to make nav snappier
- Fix autocomplete mouse hover color priority
- Make autocomplete shadow not obscure entry box
- Make autocomplete a bit taller

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
