### PR TITLE
fix: null coalesce settings.mouseDPI to empty string

### DIFF
--- a/scripts/pages/settings/mouse-sensitivity.js
+++ b/scripts/pages/settings/mouse-sensitivity.js
@@ -47,7 +47,7 @@ class MouseSensitivity {
 	}
 
 	static loadSettings() {
-		this.panels.dpi.text = $.persistentStorage.getItem('settings.mouseDPI');
+		this.panels.dpi.text = $.persistentStorage.getItem('settings.mouseDPI') ?? '';
 		this.panels.unitSelection.SetSelected($.persistentStorage.getItem('settings.mouseUnitSelector'));
 		this.calculateSensitivity();
 	}


### PR DESCRIPTION
If `settings.mouseDPI` is missing, this returns `null` which is gets stringified to `"null"`, and shows up in UI. Just coalescing to an empty string looks fine.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
