### PR TITLE
chore: Re-enable error cubemap dropdown

### DIFF
--- a/layout/pages/settings/video.xml
+++ b/layout/pages/settings/video.xml
@@ -183,14 +183,11 @@
 							<Label text="#Settings_TextureReplace_1" id="materrortype1" value="1" />
 						</ChaosSettingsEnumDropDown>
 
-						<!--
-						https://github.com/ChaosInitiative/Chaos-Source/issues/368
 						<ChaosSettingsEnumDropDown text="#Settings_TextureReplace_TypeCubemap" convar="mat_error_texture_type_cubemap" infomessage="#Settings_TextureReplace_TypeCubemap_Info">
 							<Label text="#Settings_TextureReplace_TypeCubemap_0" id="materrortypecubemap0" value="0"/>
 							<Label text="#Settings_TextureReplace_TypeCubemap_1" id="materrortypecubemap1" value="1"/>
 							<Label text="#Settings_TextureReplace_TypeCubemap_2" id="materrortypecubemap2" value="2"/>
 						</ChaosSettingsEnumDropDown>
-						-->
 
 						<ChaosSettingsEnumDropDown text="#Settings_TextureReplace_Advanced" convar="mat_error_texture_advanced" infomessage="#Settings_TextureReplace_Advanced_Info">
 							<Label text="#Settings_TextureReplace_Advanced_0" id="materroradv0" value="0" />


### PR DESCRIPTION
With https://github.com/StrataSource/Engine/issues/368 fixed, this can get re-enabled.
<!-- Describe what your pull request is doing here -->

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "",
		"definition": ""
	}
]
```
