### PR TITLE
refactor: Update audio settings sliders

### DIFF
--- a/layout/pages/settings/audio.xml
+++ b/layout/pages/settings/audio.xml
@@ -31,21 +31,20 @@
 					</Panel>
 				</Panel>
 
-				<ChaosSettingsSlider text="#Settings_Volume_Game" min="0" max="1" percentage="true" convar="volume" hasdocspage="false" />
+				<ChaosSettingsSlider text="#Settings_Volume_Master" min="0" max="1" percentage="true" convar="volume" hasdocspage="false" />
 
 				<ChaosSettingsSlider text="#Settings_Volume_Music" min="0" max="1" percentage="true" convar="snd_volume_music" tags="music" hasdocspage="false" />
 
 				<ChaosSettingsSlider text="#Settings_Volume_Ambient" min="0" max="1" percentage="true" convar="snd_volume_ambient" tags="ambient" hasdocspage="false" />
 
-				<ChaosSettingsSlider text="#Settings_Volume_PlayerWeapon" min="0" max="1" percentage="true" convar="snd_volume_weapon_player" tags="weapon" hasdocspage="false" />
+				<ChaosSettingsSlider text="#Settings_Volume_Weapon" min="0" max="1" percentage="true" convar="snd_volume_weapon" tags="weapon" hasdocspage="false" />
 
-				<ChaosSettingsSlider text="#Settings_Volume_OverallWeapon" min="0" max="1" percentage="true" convar="snd_volume_weapon_overall" tags="overall" hasdocspage="false" />
+				<ChaosSettingsSlider text="#Settings_Volume_Movement" min="0" max="1" percentage="true" convar="snd_volume_footsteps" tags="movement,footsteps" hasdocspage="false" />
+
+				<ChaosSettingsSlider text="#Settings_Volume_Ghosts" min="0" max="1" percentage="true" convar="mom_snd_volume_ghosts" infomessage="#Settings_Volume_Ghost_Info" tags="ghosts" hasdocspage="false" />
 
 				<ChaosSettingsSlider text="#Settings_Volume_UI" min="0" max="1" percentage="true" convar="snd_volume_ui" tags="ui,interface" hasdocspage="false" />
 
-				<ChaosSettingsSlider text="#Settings_Volume_Physics" min="0" max="1" percentage="true" convar="snd_volume_physics" tags="physics" hasdocspage="false" />
-
-				<ChaosSettingsSlider text="#Settings_Volume_Footsteps" min="0" max="1" percentage="true" convar="snd_volume_footsteps" tags="footsteps" hasdocspage="false" />
 			</Panel>
 
 			<Panel class="settings-page__spacer" />


### PR DESCRIPTION
Updates Audio Settings page to work better with the sound system changes brae made a while ago.

- Rename "Game Volume" to "Master Volume" - clearest term for conveying that it affects everything.
- Removed "Player Weapon Volume", replaced with "Weapon Volume"
- Renamed "Overall Weapon Volume" to "Weapon Volume", fixed the convar to use correct one (`snd_volume_weapon`)
- Removed "Physics Volume" - nothing really uses this
- Added "Ghost Volume"

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings

```json
[
  {
    "term": "Settings_Volume_Master",
    "definition": "Master Volume"
  },
  {
    "term": "Settings_Volume_Movement",
    "definition": "Player Movement Volume"
  },
  {
    "term": "Settings_Volume_Weapon",
    "definition": "Weapon Volume"
  },
  {
    "term": "Settings_Volume_Ghost",
    "definition": "Ghost Volume"
  },
  {
    "term": "Settings_Volume_Ghost_Info",
    "definition": "Sounds made by online players and replay ghosts. These sounds are also scaled relative to Weapon Volume and Player Movement Volume respectively."
  }
]

```
