### PR TITLE
fix: refactor compass ticks

### DIFF
--- a/layout/hud/cgaz.xml
+++ b/layout/hud/cgaz.xml
@@ -43,10 +43,7 @@
 				<Label id="YawStat" class="cgaz-stats cgaz-stats__yaw" />
 			</Panel>
 		</ConVarEnabler>
-		<Panel id="CompassTicks" class="cgaz__container">
-			<Panel id="FullTick" class="cgaz-tick cgaz-tick__full" />
-			<Panel id="HalfTick" class="cgaz-tick cgaz-tick__half" />
-		</Panel>
+		<Panel id="CompassTicks" class="cgaz-tick__container" />
 		<Panel id="WindicatorArrow">
 			<ConVarEnabler class="full-height" convar="mom_df_hud_windicator_enable" togglevisibility="true">
 				<Image id="WindicatorArrowIcon" class="arrow__down" src="file://{images}/hud/cgaz-arrow.svg" textureheight="48" />

--- a/styles/hud/cgaz.scss
+++ b/styles/hud/cgaz.scss
@@ -34,19 +34,22 @@
 }
 
 .cgaz-tick {
-	border-left: 2px solid black;
-	border-right: 2px solid black;
-	//margin-left set in js for positioning
-	margin-right: -1px;
+	width: 2px;
+	transform: translatex(-1px);
 	vertical-align: top;
-	overflow: noclip noclip;
 
 	&__full {
-		height: 6px;
+		height: 100%;
 	}
 
 	&__half {
-		height: 3px;
+		height: 50%;
+	}
+
+	&__container {
+		//height set in js
+		width: 100%;
+		vertical-align: center;
 	}
 }
 


### PR DESCRIPTION
Closes momentum-mod/game/issues/2100

This pull request changes the behavior of the compass HUD element to match the most recent version of the defrag pitch helper.

Previously, compass ticks were created as left and right borders of a panel. Now ticks are individual panels with fixed width. This prevents border properties from misbehaving when the color is changed.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
