### PR TITLE
feat: Add mom_paint_color_from_normal setting

### DIFF
--- a/layout/pages/settings/gameplay.xml
+++ b/layout/pages/settings/gameplay.xml
@@ -94,6 +94,11 @@
 							<RadioButton group="paintlimit" text="#Common_Off" value="0" />
 							<RadioButton group="paintlimit" text="#Common_On" value="1" />
 						</ChaosSettingsEnum>
+
+						<ChaosSettingsEnum text="#Settings_Paint_ColorFromNormal" convar="mom_paint_color_from_normal" infomessage="#Settings_Paint_ColorFromNormal_Info" tags="color,angle">
+							<RadioButton group="paintanglecolor" text="#Common_Off" value="0" />
+							<RadioButton group="paintanglecolor" text="#Common_On" value="1" />
+						</ChaosSettingsEnum>
 					</Panel>
 				</Panel>
 			</Panel>


### PR DESCRIPTION
Closes https://github.com/momentum-mod/game/issues/951 (red has been merged already)

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)
```json
[
  {
    "term": "Settings_Paint_ColorFromNormal",
    "definition": "Set color from surface angle"
  },
  {
    "term": "Settings_Paint_ColorFromNormal_Info",
    "definition": "If enabled, the color of your paint changes based on the angle (normal) of the surface it's placed on, adding contrast to the edges of objects.\n\nUseful for highlighting any sharp edges, such as the spines of surf ramps."
  }
]
```
