### PR TITLE
fix: always use /g in replaceAll using regexes

### DIFF
--- a/scripts/pages/settings/speedometer.js
+++ b/scripts/pages/settings/speedometer.js
@@ -328,7 +328,7 @@ class RangeColorObject {
 
 	static convertCSSToKV(color) {
 		const kvColor = color
-			.replaceAll(/[^\d,|]/, '')
+			.replaceAll(/[^\d,|]/g, '')
 			.split(',')
 			.map((x) => Number.parseInt(x));
 		kvColor[3] *= 255;


### PR DESCRIPTION
This was because of a unicorn linter rule that got added and me subsequently ballsing up the refactor to appease it.

Closes momentum-mod/game/issues/2104

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

