### PR TITLE
fix: Don't do cgaz updates on modes that aren't defrag

### DIFF
--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -121,17 +121,28 @@ class Cgaz {
 	static snapAccel = 0;
 	static bShouldUpdateStyles = false;
 
-	static onLoad() {
-		if (GameModeAPI.GetCurrentGameMode() !== GameMode.DEFRAG) return;
+	static updateHandle = null;
 
-		this.onAccelConfigChange();
-		this.onSnapConfigChange();
-		this.onPrimeConfigChange();
-		this.onProjectionChange();
-		this.onHudFovChange();
-		this.onSnapConfigChange();
-		this.onWindicatorConfigChange();
-		this.onCompassConfigChange();
+	static onLoad() {
+		if (GameModeAPI.GetCurrentGameMode() === GameMode.DEFRAG) {
+			this.updateHandle = $.RegisterEventHandler(
+				'ChaosHudProcessInput',
+				$.GetContextPanel(),
+				this.onUpdate.bind(this)
+			);
+
+			this.onAccelConfigChange();
+			this.onSnapConfigChange();
+			this.onPrimeConfigChange();
+			this.onProjectionChange();
+			this.onHudFovChange();
+			this.onSnapConfigChange();
+			this.onWindicatorConfigChange();
+			this.onCompassConfigChange();
+		} else if (this.updateHandle) {
+			$.UnregisterEventHandler('ChaosHudProcessInput', $.GetContextPanel(), this.updateHandle);
+			this.updateHandle = null;
+		}
 	}
 
 	static onProjectionChange() {
@@ -1333,8 +1344,6 @@ class Cgaz {
 	}
 
 	static {
-		$.RegisterEventHandler('ChaosHudProcessInput', $.GetContextPanel(), this.onUpdate.bind(this));
-
 		$.RegisterForUnhandledEvent('ChaosLevelInitPostEntity', this.onLoad.bind(this));
 		$.RegisterForUnhandledEvent('OnDefragHUDProjectionChange', this.onProjectionChange.bind(this));
 		$.RegisterForUnhandledEvent('OnDefragHUDFOVChange', this.onHudFovChange.bind(this));


### PR DESCRIPTION
I recently fixed some ConVar access debugging stuff and saw that cgaz's `onUpdate` is always running, even when not on the Defrag gamemode. Let me know if there's a more correct way to fix this.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

