### PR TITLE
fix: Range-color-profile-name.js not using the correct profile name

### DIFF
--- a/scripts/modals/popups/range-color-profile-name.js
+++ b/scripts/modals/popups/range-color-profile-name.js
@@ -14,7 +14,7 @@ class RangeColorProfileNamePopup {
 
 		let passed = true;
 		RangeColorProfileNamePopup.profileNames.every((profileName) => {
-			if (text === profileName) {
+			if (text.toUpperCase() === profileName.toUpperCase()) {
 				passed = false;
 				return false;
 			}

--- a/scripts/pages/settings/speedometer.js
+++ b/scripts/pages/settings/speedometer.js
@@ -737,7 +737,9 @@ class RangeColorProfiles {
 		UiToolkitAPI.ShowCustomLayoutPopupParameters(
 			'',
 			'file://{resources}/layout/modals/popups/range-color-profile-name.xml',
-			`profileNames=${this.profileObjectMap.keys()}&prefilledText=${prefilledText}&OKBtnText=${OKBtnText}&callback=${UiToolkitAPI.RegisterJSCallback(
+			`profileNames=${[
+				...this.profileObjectMap.keys()
+			]}&prefilledText=${prefilledText}&OKBtnText=${OKBtnText}&callback=${UiToolkitAPI.RegisterJSCallback(
 				callback
 			)}`
 		);


### PR DESCRIPTION
Range-color-profile-name.js was using a map iterator object as the profile name instead of the actual string name. Changed the input from a map to an array. Also added a check to make range profile names non case sensitive.

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
