### PR TITLE
Start Christmas background on 18th instead of 25th

### DIFF
--- a/scripts/pages/main-menu/main-menu.js
+++ b/scripts/pages/main-menu/main-menu.js
@@ -266,7 +266,7 @@ class MainMenu {
 
 		// If it's xmas and you're using one of the default backgrounds, replace it with the xmas version
 		const date = new Date();
-		if (date.getMonth() === 11 && date.getDate() >= 25 && backgroundVar <= 1) {
+		if (date.getMonth() === 11 && date.getDate() >= 18 && backgroundVar <= 1) {
 			name = 'MomentumXmas';
 		} else {
 			// Using a switch as we're likely to add more of these in the future


### PR DESCRIPTION
Currently the background runs from 25th to 31st, feels a bit short. Figured starting a week earlier would be a bit better, 2 weeks feels reasonable.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

