### PR TITLE
fix: check for invalid speedometer names

### DIFF
--- a/layout/modals/popups/speedometer-select.xml
+++ b/layout/modals/popups/speedometer-select.xml
@@ -22,8 +22,9 @@
 		<Panel id="SpeedometerSelectContainer" class="flow-down horizontal-align-center">
 		</Panel>
 		<Panel class="row horizontal-align-center mt-4">
-			<TextEntry id="SpeedometerName" class="textentry" maxchars="255" placeholder="#Settings_Speedometer_Customname_Placeholder" text="" />
+			<TextEntry id="SpeedometerName" class="textentry" maxchars="255" placeholder="#Settings_Speedometer_Customname_Placeholder" text="" ontextentrysubmit="SpeedometerSelectPopup.onTextSubmitted()"/>
 		</Panel>
+		<Label id="InvalidNameLabel" class="text-m horizontal-align-center" text="#Settings_Speedometer_InvalidName" />
 		<Panel class="row horizontal-align-center mt-4 generic-popup__button-row">
 			<Button id="CancelButton" class="button mr-4" onactivate="UiToolkitAPI.CloseAllVisiblePopups();">
 				<Label class="button__text" text="#Common_Cancel" />

--- a/scripts/modals/popups/speedometer-select.js
+++ b/scripts/modals/popups/speedometer-select.js
@@ -3,20 +3,46 @@ class SpeedometerSelectPopup {
 	static container = $('#SpeedometerSelectContainer');
 	/** @static @type {TextEntry} */
 	static textEntry = $('#SpeedometerName');
+	/** @type {Label} @static */
+	static invalidNameLabel = $('#InvalidNameLabel');
 	static selected = 0;
+	static speedometerNames = [];
 
-	static onAddButtonPressed() {
+	static onTextSubmitted() {
+		if (!this.validateSpeedometerNames()) {
+			this.invalidNameLabel.visible = true;
+			return;
+		}
+
 		const callbackHandle = $.GetContextPanel().GetAttributeInt('callback', -1);
+
 		if (callbackHandle !== -1)
-			UiToolkitAPI.InvokeJSCallback(
-				callbackHandle,
-				SpeedometerSelectPopup.selected,
-				SpeedometerSelectPopup.textEntry.text
-			);
+			UiToolkitAPI.InvokeJSCallback(callbackHandle, SpeedometerSelectPopup.selected, this.textEntry.text);
 		UiToolkitAPI.CloseAllVisiblePopups();
 	}
 
+	static validateSpeedometerNames() {
+		const text = this.textEntry.text;
+		if (text === '' || text.includes(',')) return false;
+
+		if (this.speedometerNames.some((name) => text.toUpperCase() === name.toUpperCase())) return false;
+
+		return true;
+	}
+
+	static invalidNameSubmitted() {
+		SpeedometerSelectPopup.invalidNameLabel.visible = true;
+	}
+
+	static onAddButtonPressed() {
+		this.textEntry.Submit();
+	}
+
 	static init() {
+		SpeedometerSelectPopup.invalidNameLabel.visible = false;
+		SpeedometerSelectPopup.speedometerNames = $.GetContextPanel()
+			.GetAttributeString('speedometerNames', '')
+			.split(',');
 		for (const typeNum of Object.values(SpeedometerTypes)) {
 			const speedometer = $.CreatePanel('Panel', SpeedometerSelectPopup.container, '');
 			speedometer.LoadLayoutSnippet('speedometer-radiobutton');

--- a/scripts/pages/settings/speedometer.js
+++ b/scripts/pages/settings/speedometer.js
@@ -218,7 +218,11 @@ class Speedometers {
 		UiToolkitAPI.ShowCustomLayoutPopupParameters(
 			'',
 			'file://{resources}/layout/modals/popups/speedometer-select.xml',
-			`callback=${UiToolkitAPI.RegisterJSCallback((type, name) => this.addSpeedometerByType(type, name))}`
+			`speedometerNames=${this.detailObjectList
+				.map((x) => x.name)
+				.join(',')}&callback=${UiToolkitAPI.RegisterJSCallback((type, name) =>
+				this.addSpeedometerByType(type, name)
+			)}`
 		);
 	}
 


### PR DESCRIPTION
Deleting a speedometer with the same name as an existing speedometer results in an `underlying object` js exception. This is because `this.detailObject.findIndex()` inside `deleteSpeedometer()` deletes the first speedometer matching the name of the selected speedometer. I have changed `speedometer-select.js` to check for these invalid names (mostly used the same code from range-color-profile-name.js). This also makes it consistent with  deleting and adding range profiles.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "#Settings_Speedometer_InvalidName",
		"definition": "Invalid speedometer name!"
	}
]
```
