### PR TITLE
Add comparisons to settings

### DIFF
--- a/layout/pages/settings/interface.xml
+++ b/layout/pages/settings/interface.xml
@@ -351,6 +351,24 @@
 			</Panel>
 
 			<Panel class="settings-page__spacer" />
+			
+			<Panel id="ComparisonsSubSection" class="settings-group">
+				<Panel class="settings-group__header">
+					<Label class="settings-group__title" text="#Settings_ComparisonsHUD_Title" tags="comparisons,stages,checkpoints,time,hud" />
+					<TooltipPanel class="settings-group__reset" tooltip="#Settings_General_Reset">
+						<Button class="button" onactivate="SettingsShared.resetSettings('ComparisonsSubSection');">
+							<Image class="button__icon" src="file://{images}/reset.svg" />
+						</Button>
+					</TooltipPanel>
+				</Panel>
+
+				<ChaosSettingsEnum text="#Settings_ComparisonsHUD_Enable" convar="mom_hud_comparisons_enable" infomessage="#Settings_ComparisonsHUD_Enable_Info">
+					<RadioButton group="showcomparisons" text="#Common_Off" value="0" />
+					<RadioButton group="showcomparisons" text="#Common_On" value="1" />
+				</ChaosSettingsEnum>
+			</Panel>
+
+			<Panel class="settings-page__spacer" />
 
 			<Panel id="WeaponSelSubSection" class="settings-group">
 				<Panel class="settings-group__header">

--- a/layout/pages/settings/settings.xml
+++ b/layout/pages/settings/settings.xml
@@ -139,7 +139,7 @@
 
 						<RadioButton id="InterfaceRadio" class="settings-nav__item" group="SettingsNav" onactivate="MainMenuSettings.navigateToTab('InterfaceSettings')">
 							<Label class="settings-nav__item-label" text="#Settings_Interface" />
-							<Panel class="settings-nav__subsection settings-nav__subsection--11 settings-nav__subsection--hidden">
+							<Panel class="settings-nav__subsection settings-nav__subsection--13 settings-nav__subsection--hidden">
 								<RadioButton id="UIRadio" class="settings-nav__subitem" group="SettingsSubNav" onactivate="MainMenuSettings.navigateToSubsection('InterfaceSettings', 'UISubSection')">
 									<Label class="settings-nav__subitem-label" text="#Settings_Menu_Title" />
 								</RadioButton>
@@ -157,6 +157,9 @@
 								</RadioButton>
 								<RadioButton id="KeypressRadio" class="settings-nav__subitem" group="SettingsSubNav" onactivate="MainMenuSettings.navigateToSubsection('InterfaceSettings', 'KeypressSubSection')">
 									<Label class="settings-nav__subitem-label" text="#Settings_KeypressHUD_Title" />
+								</RadioButton>
+								<RadioButton id="ComparisonsRadio" class="settings-nav__subitem" group="SettingsSubNav" onactivate="MainMenuSettings.navigateToSubsection('InterfaceSettings', 'ComparisonsSubSection')">
+									<Label class="settings-nav__subitem-label" text="#Settings_ComparisonsHUD_Title" />
 								</RadioButton>
 								<RadioButton id="WeaponSelRadio" class="settings-nav__subitem" group="SettingsSubNav" onactivate="MainMenuSettings.navigateToSubsection('InterfaceSettings', 'WeaponSelSubSection')">
 									<Label class="settings-nav__subitem-label" text="#Settings_WeaponSelection_Title" />

--- a/scripts/common/settings.js
+++ b/scripts/common/settings.js
@@ -57,6 +57,7 @@ const SettingsTabs = {
 			TimerSubSection: 'TimerRadio',
 			PlayerStatusSubSection: 'PlayerStatusRadio',
 			KeypressSubSection: 'KeypressRadio',
+			ComparisonsSubSection: 'ComparisonsRadio',
 			JumpStatsSubSection: 'JumpStatsRadio',
 			WeaponSelSubSection: 'WeaponSelRadio',
 			StrafeSyncSubSection: 'StrafeSyncRadio',


### PR DESCRIPTION
Adds mom_hud_comparisons_enable to settings under interface/hud

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "Settings_ComparisonsHUD_Title",
		"definition": "Comparisons"
	}
	{
		"term": "Settings_ComparisonsHUD_Enable",
		"definition": "Display comparisons"
	}
	{
		"term": "Settings_ComparisonsHUD_Enable_Info",
		"definition": "Show comparisons on the HUD upon completion of a stage/checkpoint"
	}
]
```
