### PR TITLE
Display end-of-run graph time strings on y-axis

### DIFF
--- a/scripts/components/graphs/line-graph.js
+++ b/scripts/components/graphs/line-graph.js
@@ -23,6 +23,7 @@
  * @property {number} min - The minimum value on the axis
  * @property {number} interval - The intervals upon which to draw gridlines
  * @property {string} name - The name to draw on the side of the axis
+ * @property {boolean} timeBased - Whether or not the axis represents a length of time
  */
 
 /**
@@ -103,7 +104,26 @@ class LineGraph {
 				const offset = 'position: ' + (isX ? `${dist}px 0px 0px;` : `0px ${dist}px 0px;`);
 
 				// Linear interpolate to determine marker text, backwards for Y. Then round to precision and cast back to Number.
-				const markerValue = +(isX ? lineMin + j : lineMax + lineMin - j).toFixed(precision);
+				let markerValue = +(isX ? lineMin + j : lineMax + lineMin - j).toFixed(precision);
+				if (axis.timeBased) {
+					const extreme = Math.max(Math.abs(axis.min), Math.abs(axis.max));
+					const time = Math.abs(markerValue);
+
+					const sign = markerValue > 0 ? '+' : markerValue < 0 ? '-' : '';
+
+					const hours = Math.floor(time / 3600);
+					let minutes = Math.floor((time % 3600) / 60);
+					let seconds = (time % 3600) % 60;
+
+					if (time < 10 && extreme < 10) seconds = seconds.toFixed(precision);
+
+					markerValue = `${sign}${seconds}`;
+					if (extreme >= 60) {
+						if (extreme >= 3600 && minutes < 10) minutes = '0' + minutes;
+						if (seconds < 10) seconds = '0' + seconds;
+						markerValue = extreme >= 3600 ? `${sign}${hours}:${minutes}` : `${sign}${minutes}:${seconds}`;
+					}
+				}
 
 				// Create the marker label
 				$.CreatePanel('Label', markers, axisName + j, {

--- a/scripts/pages/end-of-run/end-of-run.js
+++ b/scripts/pages/end-of-run/end-of-run.js
@@ -385,7 +385,8 @@ class EndOfRun {
 				name: $.Localize('#Common_Zone'),
 				// Limit max zones we draw an axis for to 30
 				// todo: find interval equiv to this: lineCount: Math.min(numZones, 30),
-				interval: 1
+				interval: 1,
+				timeBased: false
 			},
 			{
 				min: min,
@@ -393,7 +394,8 @@ class EndOfRun {
 				name: $.Localize(
 					useStat ? comparisonSplits[0].statsComparisons[statIndex].name : '#Run_Stat_Name_Time'
 				),
-				interval: yInterval
+				interval: yInterval,
+				timeBased: !useStat
 			}
 		];
 

--- a/scripts/pages/end-of-run/end-of-run.js
+++ b/scripts/pages/end-of-run/end-of-run.js
@@ -327,8 +327,8 @@ class EndOfRun {
 			],
 			color: '#ffffffaa',
 			thickness: 2,
-			shadeBelowToOriginColor: '#ffffff66',
-			shadeAboveToOriginColor: '#ffffff66'
+			shadeBelowToOriginColor: '#ffffff33',
+			shadeAboveToOriginColor: '#ffffff33'
 		};
 
 		let max = 0;

--- a/styles/components/graphs/linegraph.scss
+++ b/styles/components/graphs/linegraph.scss
@@ -172,7 +172,7 @@
 			height: 16px;
 			transform: translateY(-6px) translateX(-6px);
 			text-align: right;
-			max-width: 20px;
+			max-width: 40px;
 		}
 	}
 }

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -601,7 +601,7 @@ $popup-button-font-size: 24px !default;
 // LINEGRAPH
 // ================
 
-$linegraph-axis-width: 24px;
+$linegraph-axis-width: 40px;
 
 // ================
 // TOAST


### PR DESCRIPTION
Closes momentum-mod/game/issues/1995

Made the time axis of the end of run graph use formatting based on the extents of the graph, using just seconds, `m:ss`, or `h:mm` where appropriate, and increased spacing slightly so that longer labels like `+mm:ss` don't shrink down.  
(Also, I used `$.Localize()` to check what stat is being compared and I'm not entirely sure if it's bad to do or not)
### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
