### PR TITLE
fix: Display zones and runs stats properly in leaderboards

### DIFF
--- a/scripts/hud/leaderboards.js
+++ b/scripts/hud/leaderboards.js
@@ -93,8 +93,8 @@ class HudLeaderboards {
 			'type',
 			$.Localize(data.mainTrack?.isLinear ? '#MapInfo_Type_Linear' : '#MapInfo_Type_Staged')
 		);
-		cp.SetDialogVariableInt('zones', data.mainTrack?.numZones);
-		cp.SetDialogVariableInt('numruns', data.stats?.completes);
+		cp.SetDialogVariableInt('numzones', data.mainTrack?.numZones);
+		cp.SetDialogVariableInt('runs', data.stats?.completes);
 	}
 
 	static close() {


### PR DESCRIPTION
This now says the number of zones and runs (current api doesn't have runs afaik). Before it said zones Zones and runs Runs.
![image](https://github.com/momentum-mod/panorama/assets/32750171/61030481-17ca-458e-95da-4eab8d9eee88)


### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below