### PR TITLE
Remove changelog from about section

### DIFF
--- a/layout/pages/drawer/about.xml
+++ b/layout/pages/drawer/about.xml
@@ -16,18 +16,8 @@
 			<Label class="about__description" html="true" text="#About_Description" />
 		</Panel>
 		<Panel class="about__main">
-			<Panel class="about__tabs tabs ">
-				<RadioButton id="CreditsButton" class="about__tab tabs__tab" group="AboutSections" selected="true" onactivate="About.switchSection('credits')">
-					<Label class="tabs__text" text="#About_Credits_Title" />
-				</RadioButton>
-				<RadioButton id="ChangelogButton" class="about__tab tabs__tab" group="AboutSections" onactivate="About.switchSection('changelog')">
-					<Label class="tabs__text" text="#About_Changelog_Title" />
-				</RadioButton>
-			</Panel>
 			<Panel class="about__section-container">
-				<Frame id="Credits" src="file://{resources}/layout/pages/drawer/credits.xml" class="about__section about-credits about__section--hidden" />
-				<Panel id="Changelog" class="about__section about__section--hidden">
-				</Panel>
+				<Frame id="Credits" src="file://{resources}/layout/pages/drawer/credits.xml" class="about__section about-credits" />
 			</Panel>
 		</Panel>
 	</Panel>

--- a/scripts/pages/drawer/about.js
+++ b/scripts/pages/drawer/about.js
@@ -1,37 +1,14 @@
-const CHANGELOG_FILE_PATH = 'panorama/data/changelog.vdf';
-
 class About {
-	static sections = {
-		/** @type {Panel} @static */
-		credits: $('#Credits'),
-		/** @type {Panel} @static */
-		changelog: $('#Changelog')
-	};
+	static credits = $('#Credits');
 
 	static onLoad() {
-		this.loadChangelog();
-
 		this.initCreditEvents();
-
-		this.switchSection('credits');
 
 		$.GetContextPanel().SetDialogVariable('version', MomentumAPI.GetVersionInfo().version);
 	}
 
-	static switchSection(section) {
-		const newSection = this.sections[section];
-
-		if (!newSection) return;
-
-		if (this.activeSection) this.activeSection.AddClass('about__section--hidden');
-
-		newSection.RemoveClass('about__section--hidden');
-
-		this.activeSection = newSection;
-	}
-
 	static initCreditEvents() {
-		for (const panel of this.sections.credits.FindChildrenWithClassTraverse('about-credits__name')) {
+		for (const panel of this.credits.FindChildrenWithClassTraverse('about-credits__name')) {
 			const name = panel.GetAttributeString('name', '');
 			const roles = panel.GetAttributeString('roles', '');
 			const bio = panel.GetAttributeString('bio', '');
@@ -67,29 +44,6 @@ class About {
 				)
 			);
 			panel.SetPanelEvent('onmouseout', () => UiToolkitAPI.HideCustomLayoutTooltip('CreditsTooltip'));
-		}
-	}
-
-	static loadChangelog() {
-		const changelogData = $.LoadKeyValuesFile(CHANGELOG_FILE_PATH);
-
-		for (const [version, versionData] of Object.entries(changelogData)) {
-			$.CreatePanel('Label', this.sections.changelog, '', {
-				class: 'about-changelog__version',
-				text: version
-			});
-
-			for (const [category, categoryData] of Object.entries(versionData)) {
-				$.CreatePanel('Label', this.sections.changelog, '', {
-					class: 'about-changelog__category',
-					text: category
-				});
-
-				$.CreatePanel('Label', this.sections.changelog, '', {
-					class: 'about-changelog__item',
-					text: ' • ' + Object.values(categoryData).join('\n • ')
-				});
-			}
 		}
 	}
 }

--- a/styles/pages/drawer/about.scss
+++ b/styles/pages/drawer/about.scss
@@ -51,10 +51,6 @@
 		flow-children: down;
 		overflow: squish scroll;
 		padding: 16px 24px;
-
-		&--hidden {
-			visibility: collapse;
-		}
 	}
 }
 
@@ -122,24 +118,5 @@
 				color: color.scale(map.get($roles, 'team'), $lightness: 50%);
 			}
 		}
-	}
-}
-
-.about-changelog {
-	&__version {
-		@include mixin.font-styles($use-header: true);
-		font-size: 36px;
-		margin-bottom: 6px;
-	}
-
-	&__category {
-		font-size: 18px;
-		font-weight: bold;
-		margin-left: 4px;
-	}
-
-	&__item {
-		font-size: 14px;
-		margin-bottom: 8px;
 	}
 }


### PR DESCRIPTION
Removes changelog from the about section in the drawer. It looks like this now. 
![image](https://github.com/momentum-mod/panorama/assets/32750171/e2e48839-56a8-43a9-935f-f7b558274d2d)


### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below