### PR TITLE
Add comment reminding devs to install the submodule

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 		"strict": true,
 		"noImplicitAny": false,
 		"typeRoots": ["./scripts/types/"],
-		"types": ["momentum"]
+		"types": ["momentum"] // If you error here, you don't have the submodule installed! (git submodule update --init --recursive)
 	},
 	"include": ["scripts/"],
 	"exclude": ["*.d.ts"]


### PR DESCRIPTION
Submodule doesn't install automatically when first cloning the repo - this comment reminds you if you need to do that
### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
