### PR TITLE
prepare tab menu for upcoming in-game zoning UI

### DIFF
--- a/layout/hud/tab-menu.xml
+++ b/layout/hud/tab-menu.xml
@@ -51,6 +51,10 @@
 				<Frame src="file://{resources}/layout/pages/end-of-run/end-of-run.xml" hittest="true" hittestchildren="true" />
 			</Panel>
 
+			<Panel id="ZoningContainer" class="hud-tab-menu__zoning" hittestchildren="true">
+				<ZoneMenu id="ZoneMenu" />
+			</Panel>
+
 			<Panel class="hud-tab-menu__stats">
 			</Panel>
 			

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -1,0 +1,3 @@
+<root>
+	<Panel class="zoning" acceptsinput="true" acceptsfocus="true" />
+</root>


### PR DESCRIPTION
This pull request adds the requisite panels as skeletons for the upcoming zoning UI. Breaking changes were introduced in the engine-side code necessary for zone editing and UI. The empty panorama code introduced in this PR will be filled with zoning UI implementation in a future PR. The purpose of this MR is to add frontend changes necessary to prevent the 0.10 branch from breaking when merging such that the zoning UI can be tested on the 0.10 branch - potentially without red access.

Must be merged simultaneously with Red MR.