### PR TITLE
hud customizer: Add resizing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -100,6 +100,11 @@ module.exports = {
 		// We don't need to be that petty about using types well in a repo like this.
 		'@typescript-eslint/explicit-function-return-type': 'off',
 		'@typescript-eslint/no-explicit-any': 'off',
-		'@typescript-eslint/no-inferrable-types': ['warn', { ignoreParameters: true }]
+		'@typescript-eslint/no-inferrable-types': ['warn', { ignoreParameters: true }],
+		// We don't have ESM modules! At all!! Namespaces are a nice alternative.
+		'@typescript-eslint/no-namespace': 'off',
+		// Applies when directly inside a namespace.
+		// Also we use strict mode so fucky scoping behaviour doesn't apply.
+		'no-inner-declarations': 'off'
 	}
 };

--- a/images/hudcustomizer/snap-off.svg
+++ b/images/hudcustomizer/snap-off.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+    <path fill="#fff" transform="rotate(-45 12 12)" d="M10.94 2.3H13.06V21.69H10.94z"/>
+    <path fill="#fff" transform="rotate(-135 12 12)" d="M10.94 2.3H13.06V21.69H10.94z"/>
+</svg>

--- a/images/hudcustomizer/snap-x-max.svg
+++ b/images/hudcustomizer/snap-x-max.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+	<path fill="#fff" d="M18 3H21V21H18z"/>
+</svg>

--- a/images/hudcustomizer/snap-x-mid.svg
+++ b/images/hudcustomizer/snap-x-mid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+	<path fill="#fff" d="M10.5 3H13.5V21H10.5z"/>
+</svg>

--- a/images/hudcustomizer/snap-x-min.svg
+++ b/images/hudcustomizer/snap-x-min.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+	<path fill="#fff" d="M3 3H6V21H3z"/>
+</svg>

--- a/images/hudcustomizer/snap-y-max.svg
+++ b/images/hudcustomizer/snap-y-max.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+    <path fill="#fff" d="M3,21v-3h18v3H3z" />
+</svg>

--- a/images/hudcustomizer/snap-y-mid.svg
+++ b/images/hudcustomizer/snap-y-mid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+	<path fill="#fff" d="M3,13.5v-3h18v3H3z" />
+</svg>

--- a/images/hudcustomizer/snap-y-min.svg
+++ b/images/hudcustomizer/snap-y-min.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+    <path fill="#fff" d="M3,6V3h18v3H3z" />
+</svg>

--- a/layout/hud/chat.xml
+++ b/layout/hud/chat.xml
@@ -16,7 +16,7 @@
 	<scripts>
 
 	</scripts>
-	<Panel class="hud-chat no-flow">
+	<Panel class="hud-chat">
 		<MomentumChat id="RaisedChat" class="full-width full-height" />
 		<ToastContainer id="LoweredChat" class="toast-chat" thinkwheninvisible="true" />
 	</Panel>

--- a/layout/hud/conc-cook-time.xml
+++ b/layout/hud/conc-cook-time.xml
@@ -6,7 +6,7 @@
 		<include src="file://{scripts}/hud/conc-cook-time.js" />
 	</scripts>
 
-	<MomHudConcCooktime class="horizontal-align-center">
+	<MomHudConcCooktime>
 		<Panel id="ConcCooktimeContainer" class="conccook">
 			<ProgressBar id="ConcCookMeter" class="horizontal-align-center progressbar-hudmeter" />
 			<Label id="ConcCookTime" text="" class="horizontal-align-center vertical-align-center text-align-center progressbar-hudmeter__label" />

--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -28,7 +28,7 @@
 				</Button>
 				<NumberEntry id="HudCustomizerGridSize" class="hud-customizer-settings__gridsize" min="4" max="12" onvaluechanged="HudCustomizer.updateGridSize()" />
 			</Panel>
-			<Panel id="HudCustomizerKnobContainer" class="hud-customizer__knob-container" hittest="false" />
+
 			<Panel id="HudCustomizerGrid" class="hud-customizer__grid" hittest="false" hittestchildren="false" />
 		</Panel>
 		

--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -3,6 +3,11 @@
 		<include src="file://{resources}/styles/main.scss" />
 	</styles>
 
+	<scripts>
+		<include src="file://{scripts}/common/layout.js" />
+		<include src="file://{scripts}/util/functions.js" />
+		<include src="file://{scripts}/hud/customizer.js" />
+	</scripts>
 
 	<Hud class="hud" hittest="false" useglobalcontext="false">
 		<!-- Non-interactive HUD elements have hit test disabled for efficiency -->
@@ -16,6 +21,15 @@
 			<MomHudReticle />
 		</Panel>
 
+		<Panel id="HudCustomizer" class="hud-customizer hud-customizer--disabled" hittest="false">
+			<Panel class="hud-customizer__settings">
+				<Button onactivate="HudCustomizer.disableEditing()">
+					<Image class="hud-customizer-settings__close" src="file://{images}/close.svg"/>
+				</Button>
+				<NumberEntry id="HudCustomizerGridSize" class="hud-customizer-settings__gridsize" min="4" max="12" onvaluechanged="HudCustomizer.updateGridSize()" />
+			</Panel>
+			<Panel id="HudCustomizerKnobContainer" class="hud-customizer__knob-container" hittest="false" />
+			<Panel id="HudCustomizerGrid" class="hud-customizer__grid" hittest="false" hittestchildren="false" />
 		</Panel>
 		
 		<HudTrickTracker id="TrickTracker" />
@@ -49,6 +63,38 @@
 
 		<HudLeaderboards id="Leaderboards" hittest="true" />
 
+		<Panel id="HudCustomizerVirtual" class="hud-customizer-virtual" draggable="true">
+			<Label id="HudCustomizerVirtualName" class="hud-customizer-virtual__name" />
+			<Panel id="HudCustomizerSnaps" class="hud-customizer-virtual-snaps" onmouseover="HudCustomizer.showSnapTooltip();" onmouseout="HudCustomizer.hideSnapTooltip();">
+				<Panel class="hud-customizer-virtual-snaps__row">
+					<RadioButton id="HudCustomizerSnapsXMin" class="hud-customizer-virtual-snaps__button" onactivate="HudCustomizer.setSnapMode(0, 1);" group="SnapX">
+						<Image class="hud-customizer-virtual-snaps__icon" src="file://{images}/hudcustomizer/snap-x-min.svg" texturewidth="32" textureheight="32" />
+					</RadioButton>
+					<RadioButton id="HudCustomizerSnapsXMid" class="hud-customizer-virtual-snaps__button" onactivate="HudCustomizer.setSnapMode(0, 2);" group="SnapX">
+						<Image class="hud-customizer-virtual-snaps__icon" src="file://{images}/hudcustomizer/snap-x-mid.svg" texturewidth="32" textureheight="32" />
+					</RadioButton>
+					<RadioButton id="HudCustomizerSnapsXMax" class="hud-customizer-virtual-snaps__button" onactivate="HudCustomizer.setSnapMode(0, 3);" group="SnapX">
+						<Image class="hud-customizer-virtual-snaps__icon" src="file://{images}/hudcustomizer/snap-x-max.svg" texturewidth="32" textureheight="32" />
+					</RadioButton>
+					<RadioButton id="HudCustomizerSnapsXOff" class="hud-customizer-virtual-snaps__button hud-customizer-virtual-snaps__button--last" onactivate="HudCustomizer.setSnapMode(0, 4);" group="SnapX">
+						<Image class="hud-customizer-virtual-snaps__icon" src="file://{images}/hudcustomizer/snap-off.svg" texturewidth="32" textureheight="32" />
+					</RadioButton>
+				</Panel>
+				<Panel class="hud-customizer-virtual-snaps__row hud-customizer-virtual-snaps__row--last">
+					<RadioButton id="HudCustomizerSnapsYMin" class="hud-customizer-virtual-snaps__button" onactivate="HudCustomizer.setSnapMode(1, 1);" group="SnapY">
+						<Image class="hud-customizer-virtual-snaps__icon" src="file://{images}/hudcustomizer/snap-y-min.svg" texturewidth="32" textureheight="32" />
+					</RadioButton>
+					<RadioButton id="HudCustomizerSnapsYMid" class="hud-customizer-virtual-snaps__button" onactivate="HudCustomizer.setSnapMode(1, 2);" group="SnapY">
+						<Image class="hud-customizer-virtual-snaps__icon" src="file://{images}/hudcustomizer/snap-y-mid.svg" texturewidth="32" textureheight="32" />
+					</RadioButton>
+					<RadioButton id="HudCustomizerSnapsYMax" class="hud-customizer-virtual-snaps__button" onactivate="HudCustomizer.setSnapMode(1, 3);" group="SnapY">
+						<Image class="hud-customizer-virtual-snaps__icon" src="file://{images}/hudcustomizer/snap-y-max.svg" texturewidth="32" textureheight="32" />
+					</RadioButton>
+					<RadioButton id="HudCustomizerSnapsYOff" class="hud-customizer-virtual-snaps__button hud-customizer-virtual-snaps__button--last" onactivate="HudCustomizer.setSnapMode(1, 4);" group="SnapY">
+						<Image class="hud-customizer-virtual-snaps__icon" src="file://{images}/hudcustomizer/snap-off.svg" texturewidth="32" textureheight="32" />
+					</RadioButton>
+				</Panel>
+			</Panel>
 		</Panel>
 
 		<!-- Make sure these are at the bottom to get the z-order right -->

--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -3,11 +3,12 @@
 		<include src="file://{resources}/styles/main.scss" />
 	</styles>
 
-	<Hud hittest="false">
+
+	<Hud class="hud" hittest="false" useglobalcontext="false">
 		<!-- Non-interactive HUD elements have hit test disabled for efficiency -->
 
 		<!-- In world UI is first to make sure it shows up behind all "screen-looking" UI -->
-		<Panel id="HudInWorld" hittest="false" hittestchildren="false">
+		<Panel class="hud__in-world" hittest="false" hittestchildren="false">
 			<MomHudGhostEntities />
 			<MomHudConcEntities />
 			<MomHudDamageIndicator />
@@ -15,77 +16,39 @@
 			<MomHudReticle />
 		</Panel>
 
-		<!-- Center of screen HUD laid out vertically top-to-bottom -->
-		<Panel id="HudCenter" hittest="false" hittestchildren="false">
-
 		</Panel>
-
-		<!-- HUD anchored to top-left corner of screen, laid out vertically top-to-bottom -->
-		<Panel id="HudTopLeft" hittest="false" hittestchildren="false">
-			<HudTrickTracker />
-			<HudComparisons />
-		</Panel>
-
-		<!-- Anchored to below the center of the screen, laid out from top to bottom -->
-		<!-- misleading name, not 'bottom-center' but 'below center' -->
-		<Panel id="HudBottomCenter" hittest="false" hittestchildren="false">
-			<!-- Anchored on Bottom-center, laid out from top to bottom -->
-			<MomHudSynchronizer />
-			<MomHudSpeedometer />
-			<MomHudConcCooktime />
-			<MomHudStickyCharge />
-			<MomHudStickyCount />
-			<MomHudStatus />
-			<MomHudTimer />
-			<MomHudStrafeSync />
-			<MomHudGroundboost />
-			<HudHintText id="HudHintText" />
-		</Panel>
-
-		<!-- Anchored to the bottom-left corner of the screen, laid out from top to bottom -->
-		<Panel id="HudLowerLeft" hittest="false" hittestchildren="true">
-			<MomHudPowerupTimer />
-			<HudStaticMenu />
-			<MomHudChat />
-		</Panel>
-
-		<!-- Anchored on lower-right corner, laid out from top to bottom -->
-		<Panel id="HudBottomRight" hittest="false" hittestchildren="false">
-			<MomHudDFJump />
-			<MomHudAmmo />
-			<MomHudKeyPress />
-		</Panel>
-
-		<!-- Anchored in top right corner of screen, laid out from top-to-bottom -->
-		<Panel id="HudTopRight" hittest="false" hittestchildren="false">
-			<MomHudVersionInfo />
-			<MomHudMapInfo />
-			<MomHudSpecInfo />
-			<MomHudWeaponSelection />
-		</Panel>
+		
+		<HudTrickTracker id="TrickTracker" />
+		<HudComparisons id="Comparisons" customizable="true" />
+		<MomHudSynchronizer id="Syncronizer" customizable="true" />
+		<MomHudSpeedometer id="Speedometer" customizable="true" />
+		<MomHudConcCooktime id="ConcCooktime" customizable="true" />
+		<MomHudStickyCharge id="StickyCharge" customizable="true" />
+		<MomHudStickyCount id="StickyCount" customizable="true" />
+		<MomHudStatus id="Status" customizable="true" />
+		<MomHudTimer id="Timer" customizable="true" />
+		<MomHudStrafeSync id="StrafeSync" customizable="true" />
+		<MomHudGroundboost id="MomHudGroundboost" customizable="true" />
+		<HudHintText id="HudHintText"  customizable="true" />
+		<HudStaticMenu id="StaticMenu" customizable="true" />
+		<MomHudChat id="Chat" customizable="true" />
+		<MomHudKeyPress id="KeyPress" customizable="true" />
+		<MomHudVersionInfo id="VersionInfo" customizable="true" />
+		<MomHudMapInfo id="MapInfo" customizable="true" />
+		<MomHudWeaponSelection id="WeaponSelection" customizable="true" />
+		<MomHudSpecInfo id="SpecInfo" customizable="true" />
+		<TrickList id="TrickList" customizable="true" />
+		<HudShowPos id="ShowPos" customizable="true" />
+		<HudBoneCounts id="BoneCount" />
+		<MomHudSpectate id="Spectator" />
+		<MomHudJumpStats />
 
 		<HudBlurTarget id="HudBlur" blurrects="Leaderboards TrickList" class="hud-blur" hittest="false" hittestchildren="false">
 			<BackbufferImagePanel class="full" />
 		</HudBlurTarget>
 
-		<!-- HUD anchored to top center of screen, laid out vertically top-to-bottom
-		-  NOTE: Not really set up properly - HudTeamCounter should dynamically move
-		-        between HudTopCenter and HudBottomCenter, but instead it just moves
-		-        itself via code.  So nothing can go in here that should appear
-		-        while HudTeamCounter is visible
-		-->
-		<Panel id="HudTopCenter" hittest="false">
-			<HudShowPos />
-			<HudBoneCounts />
-			<MomHudSpectate id="Spectator" />
-			<MomHudJumpStats />
-		</Panel>
+		<HudLeaderboards id="Leaderboards" hittest="true" />
 
-		<TrickList id="TrickList" />
-
-		<!-- This container is here so we can move the leaderboard in and out of it during the end-of-match sequence -->
-		<Panel id="LeaderboardsContainer" class="full-width full-height" hittest="false" hittestchildren="true">
-			<HudLeaderboards id="Leaderboards" hittest="true" />
 		</Panel>
 
 		<!-- Make sure these are at the bottom to get the z-order right -->

--- a/layout/hud/map-info.xml
+++ b/layout/hud/map-info.xml
@@ -6,36 +6,60 @@
 		<include src="file://{scripts}/hud/map-info.js" />
 	</scripts>
 
-	<MomHudMapInfo class="hudmapinfo">
-		<ConVarEnabler class="flow-down full-width" convar="mom_hud_mapinfo_enable" togglevisibility="true">
+	<MomHudMapInfo class="hud-map-info">
+		<ConVarEnabler convar="mom_hud_mapinfo_enable" togglevisibility="true">
 
 			<ConVarEnabler class="full-width" convar="mom_hud_mapinfo_mapname_enable" togglevisibility="true">
-				<Label class="hudmapinfo__label horizontal-align-right" text="{s:mapname}" />
+				<Label class="hud-map-info__label horizontal-align-right" text="{s:mapname}" />
 			</ConVarEnabler>
 
 			<Panel id="CachedInfoContainer" class="flow-down width-fit-children horizontal-align-right vertical-align-center">
 
-				<ConVarEnabler class="flow-right width-fit-children horizontal-align-right" convar="mom_hud_mapinfo_author_enable" togglevisibility="true">
-					<Label class="hudmapinfo__label" text="#MapInfo_Author" />
+				<ConVarEnabler
+					class="flow-right width-fit-children horizontal-align-right"
+					convar="mom_hud_mapinfo_author_enable"
+					togglevisibility="true"
+				>
+					<Label class="hud-map-info__label" text="By: {s:author}" />
 				</ConVarEnabler>
 
 				<Panel class="flow-left width-fit-children horizontal-align-right vertical-align-center">
-					<ConVarEnabler class="flow-right width-fit-children horizontal-align-right" convar="mom_hud_mapinfo_numzones_enable" togglevisibility="true">
-						<ConVarEnabler class="width-fit-children horizontal-align-right" convar="mom_hud_mapinfo_zonetype_enable" togglevisibility="true">
-							<Label class="hudmapinfo__label" text=" " />
+					<ConVarEnabler
+						class="flow-right width-fit-children horizontal-align-right"
+						convar="mom_hud_mapinfo_numzones_enable"
+						togglevisibility="true"
+					>
+						<ConVarEnabler
+							class="width-fit-children horizontal-align-right"
+							convar="mom_hud_mapinfo_zonetype_enable"
+							togglevisibility="true"
+						>
+							<Label class="hud-map-info__label" text=" " />
 						</ConVarEnabler>
-						<Label id="NumzonesLabel" class="hudmapinfo__label" text="#MapInfo_Zones" />
+						<Label id="NumzonesLabel" class="hud-map-info__label" text="({d:numzones} Zones)" />
 					</ConVarEnabler>
 
-					<ConVarEnabler class="flow-right width-fit-children horizontal-align-right" convar="mom_hud_mapinfo_zonetype_enable" togglevisibility="true">
-						<ConVarEnabler class="width-fit-children horizontal-align-right" convar="mom_hud_mapinfo_tier_enable" togglevisibility="true">
-							<Label class="hudmapinfo__label" text=" - " />
+					<ConVarEnabler
+						class="flow-right width-fit-children horizontal-align-right"
+						convar="mom_hud_mapinfo_zonetype_enable"
+						togglevisibility="true"
+					>
+						<ConVarEnabler
+							class="width-fit-children horizontal-align-right"
+							convar="mom_hud_mapinfo_tier_enable"
+							togglevisibility="true"
+						>
+							<Label class="hud-map-info__label" text=" - " />
 						</ConVarEnabler>
-						<Label id="ZonetypeLabel" class="hudmapinfo__label" text="{s:zonetype}" />
+						<Label id="ZonetypeLabel" class="hud-map-info__label" text="{s:zonetype}" />
 					</ConVarEnabler>
 
-					<ConVarEnabler class="flow-right width-fit-children horizontal-align-right" convar="mom_hud_mapinfo_tier_enable" togglevisibility="true">
-						<Label id="TierLabel" class="hudmapinfo__label" text="#MapInfo_Tier" />
+					<ConVarEnabler
+						class="flow-right width-fit-children horizontal-align-right"
+						convar="mom_hud_mapinfo_tier_enable"
+						togglevisibility="true"
+					>
+						<Label id="TierLabel" class="hud-map-info__label" text="Tier {d:tier}" />
 					</ConVarEnabler>
 				</Panel>
 

--- a/layout/hud/spec-info.xml
+++ b/layout/hud/spec-info.xml
@@ -14,7 +14,7 @@
 		</snippet>
 	</snippets>
 
-	<MomHudSpecInfo class="full-width flow-down" onload="HudSpecInfo.onLoad();">
+	<MomHudSpecInfo onload="HudSpecInfo.onLoad();">
 
 		<!-- So we can toggle visibility for the whole panel -->
 		<Panel id="SpecInfoContainer" class="hudspecinfo">

--- a/layout/hud/status.xml
+++ b/layout/hud/status.xml
@@ -8,7 +8,7 @@
 		<include src="file://{scripts}/hud/status.js" />
 	</scripts>
 
-	<MomHudStatus class="full-width" onload="HudStatus.onLoad();">
+	<MomHudStatus onload="HudStatus.onLoad();">
 		<ConVarEnabler class="hudstatus" convar="mom_hud_status_enable" togglevisibility="true">
 			<Label id="HudStatusLabel" class="hudstatus__label" text="" />
 		</ConVarEnabler>

--- a/layout/hud/sticky-charge.xml
+++ b/layout/hud/sticky-charge.xml
@@ -6,7 +6,7 @@
 		<include src="file://{scripts}/hud/sticky-charge.js" />
 	</scripts>
 
-	<MomHudStickyCharge class="horizontal-align-center">
+	<MomHudStickyCharge>
 		<Panel id="StickyChargeContainer" class="stickycharge horizontal-align-center">
 			<ProgressBar id="StickyChargeMeter" class="horizontal-align-center progressbar-hudmeter" />
 			<Label id="StickyChargeSpeed" text="" class="horizontal-align-center vertical-align-center text-align-center progressbar-hudmeter__label" />

--- a/layout/hud/sticky-count.xml
+++ b/layout/hud/sticky-count.xml
@@ -6,7 +6,7 @@
 		<include src="file://{scripts}/hud/sticky-count.js" />
 	</scripts>
 
-	<MomHudStickyCharge class="horizontal-align-center">
+	<MomHudStickyCharge>
 		<Panel id="StickyCountContainer" class="sticky-count horizontal-align-center flow-right" />
 	</MomHudStickyCharge>
 </root>

--- a/layout/hud/timer.xml
+++ b/layout/hud/timer.xml
@@ -8,10 +8,15 @@
 		<include src="file://{scripts}/hud/timer.js" />
 	</scripts>
 
-	<MomHudTimer class="full-width" onload="HudTimer.onLoad()">
-		<ConVarEnabler class="hudtimer" convar="mom_hud_timer_enable" togglevisibility="true">
-			<Label id="HudTimerTime" class="hudtimer__time hudtimer__time--inactive" text="{g:time:runtime}" />
-			<Label id="HudTimerComparison" class="hudtimer__comparison hudtimer__comparison--fadeout" text="{s:diffSymbol}{g:time:runtimediff}" visible="false" />
+	<MomHudTimer onload="HudTimer.onLoad()">
+		<ConVarEnabler class="hud-timer" convar="mom_hud_timer_enable" togglevisibility="true">
+			<Label id="HudTimerTime" class="hud-timer__time hud-timer__time--inactive" text="{g:time:runtime}" />
+			<Label
+				id="HudTimerComparison"
+				class="hud-timer__comparison hud-timer__comparison--fadeout"
+				text="{s:diffSymbol}{g:time:runtimediff}"
+				visible="false"
+			/>
 		</ConVarEnabler>
 	</MomHudTimer>
 </root>

--- a/layout/hud/weapon-selection.xml
+++ b/layout/hud/weapon-selection.xml
@@ -19,7 +19,7 @@
 		</snippet>
 	</snippets>
 
-	<MomHudWeaponSelection class="full-width">
+	<MomHudWeaponSelection>
 		<ConVarEnabler id="WeaponSelection" class="weaponselection" convar="mom_hud_weaponselection_enable" togglevisibility="true">
 		</ConVarEnabler>
 	</MomHudWeaponSelection>

--- a/scripts/common/layout.ts
+++ b/scripts/common/layout.ts
@@ -1,0 +1,96 @@
+/**
+ * Utility methods for handling normalised panel position and size.
+ * Could be ported to C++ in future.
+ */
+namespace LayoutUtil {
+	export type Size = [number, number];
+	export type Position = [number, number];
+
+	export function getPositionAndSize<P extends Panel>(panel: P): [Position, Size] {
+		return [
+			[panel.actualxoffset / panel.actualuiscale_x, panel.actualyoffset / panel.actualuiscale_y],
+			[panel.actuallayoutwidth / panel.actualuiscale_x, panel.actuallayoutheight / panel.actualuiscale_y]
+		];
+	}
+
+	export function setPositionAndSize<P extends Panel>(panel: P, [x, y]: Position, [width, height]: Size): P {
+		Object.assign(panel.style, {
+			position: `${x}px ${y}px 0px;`,
+			width: `${width}px;`,
+			height: `${height}px;`
+		});
+		return panel;
+	}
+
+	export function copyPositionAndSize<P1 extends Panel, P2 extends Panel>(sourcePanel: P1, targetPanel: P2): P2 {
+		setPositionAndSize(targetPanel, ...getPositionAndSize(sourcePanel));
+		return targetPanel;
+	}
+
+	export function getPosition<P extends Panel>(panel: P): Position {
+		return [panel.actualxoffset / panel.actualuiscale_x, panel.actualyoffset / panel.actualuiscale_y];
+	}
+
+	export function setPosition<P extends Panel>(panel: P, [x, y]: Position): P {
+		panel.style.position = `${x}px ${y}px 0px`;
+		return panel;
+	}
+
+	export function copyPosition<P1 extends Panel, P2 extends Panel>(sourcePanel: P1, targetPanel: P2): P2 {
+		setPosition(targetPanel, getPosition(sourcePanel));
+		return targetPanel;
+	}
+
+	export function getX<P extends Panel>(panel: P): number {
+		return panel.actualxoffset / panel.actualuiscale_x;
+	}
+
+	export function getY<P extends Panel>(panel: P) {
+		return panel.actualyoffset / panel.actualuiscale_y;
+	}
+
+	export function getSize<P extends Panel>(panel: P): Size {
+		return [panel.actuallayoutwidth / panel.actualuiscale_x, panel.actuallayoutheight / panel.actualuiscale_y];
+	}
+
+	export function setSize<P extends Panel>(panel: P, [width, height]: Position): P {
+		Object.assign(panel.style, {
+			width: `${width}px`,
+			height: `${height}px`
+		});
+		return panel;
+	}
+
+	export function copySize<P1 extends Panel, P2 extends Panel>(sourcePanel: P1, targetPanel: P2): P2 {
+		setSize(targetPanel, getSize(sourcePanel));
+		return targetPanel;
+	}
+
+	export function getWidth<P extends Panel>(panel: P) {
+		return panel.actuallayoutwidth / panel.actualuiscale_x;
+	}
+
+	export function setWidth<P extends Panel>(panel: P, width: number): P {
+		panel.style.width = `${width}px`;
+		return panel;
+	}
+
+	export function copyWidth<P1 extends Panel, P2 extends Panel>(sourcePanel: P1, targetPanel: P2): P2 {
+		setWidth(targetPanel, getWidth(sourcePanel));
+		return targetPanel;
+	}
+
+	export function getHeight<P extends Panel>(panel: P): number {
+		return panel.actuallayoutheight / panel.actualuiscale_y;
+	}
+
+	export function setHeight<P extends Panel>(panel: P, height: number): P {
+		panel.style.height = `${height}px`;
+		return panel;
+	}
+
+	export function copyHeight<P1 extends Panel, P2 extends Panel>(sourcePanel: P1, targetPanel: P2): P2 {
+		setHeight(targetPanel, getHeight(sourcePanel));
+		return targetPanel;
+	}
+}

--- a/scripts/hud/customizer.ts
+++ b/scripts/hud/customizer.ts
@@ -40,6 +40,31 @@ namespace HudCustomizer {
 		TOP_LEFT: 8
 	};
 
+	function getResizeVector(dir: number) {
+		return [
+			[0, -1],
+			[1, -1],
+			[1, 0],
+			[1, 1],
+			[0, 1],
+			[-1, 1],
+			[-1, 0],
+			[-1, -1]
+		][dir - 1];
+	}
+
+	enum DragMode {
+		MOVE = 0,
+		TOP = 1,
+		TOP_RIGHT = 2,
+		RIGHT = 3,
+		BOTTOM_RIGHT = 4,
+		BOTTOM = 5,
+		BOTTOM_LEFT = 6,
+		LEFT = 7,
+		TOP_LEFT = 8
+	}
+
 	// Tuple of X, Y axis snaps respectively
 	const DEFAULT_SNAP_MODES: Snaps = [SnapMode.OFF, SnapMode.OFF];
 	const DEFAULT_GRID_SIZE = 5;
@@ -48,6 +73,7 @@ namespace HudCustomizer {
 		components: {
 			[id: string]: {
 				position: LayoutUtil.Position;
+				size: LayoutUtil.Size;
 				snaps: [number, number];
 			};
 		};
@@ -60,6 +86,7 @@ namespace HudCustomizer {
 		panel: Panel;
 		snaps: Snaps;
 		position: LayoutUtil.Position;
+		size: LayoutUtil.Size;
 		properties?: Record<string, unknown>;
 	}
 
@@ -133,8 +160,7 @@ namespace HudCustomizer {
 		virtualName: $<Label>('#HudCustomizerVirtualName')!,
 		snaps: $('#HudCustomizerSnaps')!,
 		grid: $('#HudCustomizerGrid')!,
-		gridSize: $<NumberEntry>('#HudCustomizerGridSize')!,
-		knobContainer: $('#HudCustomizerKnobContainer')!
+		gridSize: $<NumberEntry>('#HudCustomizerGridSize')!
 	};
 
 	let components: Record<string, Component>;
@@ -147,11 +173,7 @@ namespace HudCustomizer {
 	let dragEndHandle: number | undefined;
 	let onThinkHandle: number | undefined;
 
-	// TODO: Unused. Didn't get very far with resize stuff, behaviour should be
-	// similar to dragging the virtual panel.
-	let knobDragStartHandle: number | undefined;
-	let knobDragEndHandle: number | undefined;
-	let knobOnThinkHandle: number | undefined;
+	let dragMode: DragMode | undefined;
 
 	let gridSize = 5;
 
@@ -179,6 +201,7 @@ namespace HudCustomizer {
 
 			saveData.components[id] = {
 				position: [posX, posY],
+				size: LayoutUtil.getSize(component.panel),
 				snaps: component.snaps
 			};
 		}
@@ -208,11 +231,15 @@ namespace HudCustomizer {
 		Object.values(ResizeDirection)
 			.filter((x) => !Number.isNaN(+x))
 			.forEach((dir) => {
-				resizeKnobs[dir] = $.CreatePanel('Button', panels.knobContainer, `Resize_${ResizeDirection[dir]}`, {
+				resizeKnobs[dir] = $.CreatePanel('Button', panels.customizer, `Resize_${ResizeDirection[dir]}`, {
 					class: 'hud-customizer__resize-knob',
 					draggable: true,
 					hittest: true
 				});
+				$.RegisterEventHandler('DragStart', resizeKnobs[dir], (...args) =>
+					onStartDrag(dir, resizeKnobs[dir], ...args)
+				);
+				$.RegisterEventHandler('DragEnd', resizeKnobs[dir], () => onEndDrag());
 			});
 
 		components = {};
@@ -222,7 +249,7 @@ namespace HudCustomizer {
 			.forEach((panel) => loadComponentPanel(layoutData?.components[panel.id], panel));
 	}
 
-	function loadComponentPanel(component: Pick<Component, 'position' | 'snaps'> | undefined, panel: Panel) {
+	function loadComponentPanel(component: Pick<Component, 'position' | 'size' | 'snaps'> | undefined, panel: Panel) {
 		if (component) {
 			for (const [i, snap] of component.snaps.entries()) {
 				if (!Object.values(SnapMode).includes(snap)) {
@@ -240,7 +267,7 @@ namespace HudCustomizer {
 				const isX = i === 0;
 				const max = isX ? 1920 : 1080;
 				const sf = snaps[i][component.snaps[i]].sizeFactor;
-				const panelLen = isX ? LayoutUtil.getWidth(panel) : LayoutUtil.getHeight(panel);
+				const panelLen = component.size[i];
 				let layoutLen = len - panelLen * sf;
 				const maxOOB = 16;
 
@@ -259,7 +286,7 @@ namespace HudCustomizer {
 				return layoutLen;
 			}) as LayoutUtil.Position;
 
-			LayoutUtil.setPosition(panel, layoutPos);
+			LayoutUtil.setPositionAndSize(panel, layoutPos, component.size);
 
 			components[panel.id] = {
 				panel,
@@ -294,6 +321,7 @@ namespace HudCustomizer {
 			components[panel.id] = {
 				panel,
 				position: LayoutUtil.getPosition(panel),
+				size: size,
 				snaps: DEFAULT_SNAP_MODES
 			};
 		}
@@ -325,21 +353,110 @@ namespace HudCustomizer {
 		$.UnregisterEventHandler('DragStart', panels.virtual, dragStartHandle);
 	}
 
-	function onComponentMouseOver(component: Component) {
-		if (activeComponent && activeComponent === component) return;
+	function onStartDrag(mode, displayPanel, _source, callback) {
+		if (!activeComponent) return;
 
-		activeComponent?.panel.RemoveClass('hud-customizable--active');
+		dragMode = mode;
 
-		activeComponent = component;
+		onThinkHandle = $.RegisterEventHandler('HudThink', $.GetContextPanel(), () => onDragThink());
 
-		activeComponent.panel.AddClass('hud-customizable--active');
+		if (mode !== DragMode.MOVE) {
+			callback.offsetX = 0;
+			callback.offsetY = 0;
+		}
 
-		const [[x, y], [width, height]] = LayoutUtil.getPositionAndSize(component.panel);
+		callback.displayPanel = displayPanel;
+		callback.removePositionBeforeDrop = false;
+	}
 
-		// Set the virtual panel's position and size to the component we just hovered over
-		LayoutUtil.setPositionAndSize(panels.virtual, [x, y], [width, height]);
-		LayoutUtil.setPositionAndSize(panels.knobContainer, [x, y], [width, height]);
+	function onEndDrag() {
+		if (!activeComponent) return;
 
+		onDragThink();
+
+		$.UnregisterEventHandler('HudThink', $.GetContextPanel(), onThinkHandle);
+
+		LayoutUtil.setPositionAndSize(panels.virtual, activeComponent.position, activeComponent.size);
+		updateResizeKnobs(activeComponent.position, activeComponent.size);
+
+		activeComponent.panel.RemoveClass('hud-customizable--dragging');
+		panels.virtual.RemoveClass('hud-customizer-virtual--dragging');
+
+		activeGridlines?.forEach((line) => line?.panel.RemoveClass('hud-customizer__gridline--highlight'));
+		activeGridlines = [undefined, undefined];
+
+		// TODO: this is just for testing
+		save();
+
+		dragMode = undefined;
+	}
+
+	function onDragThink() {
+		if (!activeComponent || dragMode === undefined) return;
+
+		let panelPos = activeComponent.position;
+		const panelSize = activeComponent.size;
+
+		const resizeDir = getResizeVector(dragMode);
+
+		if (dragMode === DragMode.MOVE) {
+			panelPos = LayoutUtil.getPosition(panels.virtual);
+		} else {
+			const knobPos = LayoutUtil.getPosition(resizeKnobs[dragMode]);
+			if (resizeDir[0] === 1) {
+				panelSize[0] = knobPos[0] - panelPos[0];
+			} else if (resizeDir[0] === -1) {
+				panelSize[0] += panelPos[0] - knobPos[0];
+				panelPos[0] = knobPos[0];
+			}
+
+			if (resizeDir[1] === 1) {
+				panelSize[1] = knobPos[1] - panelPos[1];
+			} else if (resizeDir[1] === -1) {
+				panelSize[1] += panelPos[1] - knobPos[1];
+				panelPos[1] = knobPos[1];
+			}
+		}
+
+		const stupidFontSizeThing = Math.min(panelSize[1] / 2, panelSize[0] / 2);
+		panels.virtualName.style.fontSize = stupidFontSizeThing;
+
+		updateResizeKnobs(panelPos, panelSize);
+		LayoutUtil.setPositionAndSize(panels.virtual, panelPos, panelSize);
+
+		// snapping
+		if (dragMode === DragMode.MOVE) {
+			for (const axis of Axes) {
+				const isX = axis === 0;
+
+				if (activeComponent.snaps[axis] !== SnapMode.OFF) {
+					const sizeFactor = snaps[axis][activeComponent.snaps[axis]].sizeFactor;
+
+					const offset = panelSize[axis] * sizeFactor;
+
+					const gridline = getNearestGridLine(axis, sizeFactor);
+					const activeGridline = activeGridlines[axis];
+
+					if (gridline) panelPos[axis] = gridline.offset - offset;
+					if (gridline !== activeGridline) {
+						if (activeGridline) activeGridline.panel.RemoveClass('hud-customizer__gridline--highlight');
+						if (gridline) {
+							gridline.panel.AddClass('hud-customizer__gridline--highlight');
+							activeGridlines[axis] = gridline;
+						}
+					}
+				}
+			}
+		}
+
+		activeComponent.position = panelPos;
+		activeComponent.size = panelSize;
+		LayoutUtil.setPositionAndSize(activeComponent.panel, activeComponent.position, activeComponent.size);
+	}
+
+	function updateResizeKnobs(position, size) {
+		const width = size[0];
+		const height = size[1];
 		const halfWidth = width / 2;
 		const halfHeight = height / 2;
 		let plusX, plusY;
@@ -379,10 +496,25 @@ namespace HudCustomizer {
 					break;
 			}
 
-			$.Msg({ x, y, width, height, dir, plusX, plusY });
-
-			LayoutUtil.setPosition(knob, [plusX, plusY]);
+			LayoutUtil.setPosition(knob, [position[0] + plusX, position[1] + plusY]);
 		}
+	}
+
+	function onComponentMouseOver(component: Component) {
+		if (activeComponent && activeComponent === component) return;
+
+		activeComponent?.panel.RemoveClass('hud-customizable--active');
+
+		activeComponent = component;
+
+		activeComponent.panel.AddClass('hud-customizable--active');
+
+		const [position, size] = LayoutUtil.getPositionAndSize(component.panel);
+
+		// Set the virtual panel's position and size to the component we just hovered over
+		LayoutUtil.setPositionAndSize(panels.virtual, position, size);
+
+		updateResizeKnobs(position, size);
 
 		// This is going to be weird to localise, but I guess we could do it, probably in V2 when we can
 		// define the locale string in the `customisable` XML property.
@@ -397,96 +529,19 @@ namespace HudCustomizer {
 		panels.virtualName.style.fontSize = stupidFontSizeThing;
 
 		snaps[0][activeComponent.snaps[0]].button.SetSelected(true);
-		snaps[1][activeComponent.snaps[1]].button.SetSelected(true); 
+		snaps[1][activeComponent.snaps[1]].button.SetSelected(true);
 
 		if (dragStartHandle) {
 			$.UnregisterEventHandler('DragStart', panels.virtual, dragStartHandle);
 		}
+		if (dragEndHandle) {
+			$.UnregisterEventHandler('DragEnd', panels.virtual, dragEndHandle);
+		}
 
-		dragStartHandle = $.RegisterEventHandler('DragStart', panels.virtual, (...args) => onStartDrag(...args));
-	}
-
-	function onStartDrag(_source, callback) {
-		if (!activeComponent) return;
-
-		callback.displayPanel = panels.virtual;
-		callback.removePositionBeforeDrop = false;
-
-		// These aren't actually related to one-another in XML hierarchy so need to handle two classes
-		activeComponent.panel.AddClass('hud-customizable--dragging');
-		panels.virtual.AddClass('hud-customizer-virtual--dragging');
-
-		$.UnregisterEventHandler('DragStart', panels.virtual, dragStartHandle);
-
-		onThinkHandle = $.RegisterEventHandler('HudThink', $.GetContextPanel(), () => onDragThink());
-
+		dragStartHandle = $.RegisterEventHandler('DragStart', panels.virtual, (...args) =>
+			onStartDrag(DragMode.MOVE, panels.virtual, ...args)
+		);
 		dragEndHandle = $.RegisterEventHandler('DragEnd', panels.virtual, () => onEndDrag());
-	}
-
-	function onDragThink() {
-		if (!activeComponent) return;
-
-		const oldPosition = [0, 0];
-		const newPosition: LayoutUtil.Position = [0, 0];
-
-		for (const axis of Axes) {
-			const isX = axis === 0;
-
-			if (activeComponent.snaps[axis] === SnapMode.OFF) {
-				newPosition[axis] = isX ? LayoutUtil.getX(panels.virtual) : LayoutUtil.getY(panels.virtual);
-			} else {
-				const sizeFactor = snaps[axis][activeComponent.snaps[axis]].sizeFactor;
-
-				const offset = isX
-					? (activeComponent.panel.actuallayoutwidth * sizeFactor) / scaleX
-					: (activeComponent.panel.actuallayoutheight * sizeFactor) / scaleY;
-
-				const gridline = getNearestGridLine(axis, sizeFactor);
-				const activeGridline = activeGridlines[axis];
-
-				if (activeGridline) oldPosition[axis] = activeGridline.offset - offset;
-				if (gridline) newPosition[axis] = gridline.offset - offset;
-
-				if (gridline !== activeGridline) {
-					if (activeGridline) activeGridline.panel.RemoveClass('hud-customizer__gridline--highlight');
-					if (gridline) {
-						gridline.panel.AddClass('hud-customizer__gridline--highlight');
-						activeGridlines[axis] = gridline;
-
-						newPosition[axis] = gridline.offset - offset;
-					}
-				}
-			}
-		}
-
-		if (newPosition[0] !== oldPosition[1] || newPosition[1] !== oldPosition[1]) {
-			LayoutUtil.setPosition(activeComponent.panel, newPosition);
-			LayoutUtil.setPosition(panels.knobContainer, newPosition);
-		}
-	}
-
-	function onEndDrag() {
-		if (!activeComponent) return;
-
-		$.UnregisterEventHandler('DragEnd', panels.virtual, dragEndHandle);
-		$.UnregisterEventHandler('HudThink', $.GetContextPanel(), onThinkHandle);
-
-		dragStartHandle = $.RegisterEventHandler('DragStart', panels.virtual, (...args) => onStartDrag(...args));
-
-		dragEndHandle = undefined;
-		onThinkHandle = undefined;
-
-		activeComponent.panel.RemoveClass('hud-customizable--dragging');
-		panels.virtual.RemoveClass('hud-customizer-virtual--dragging');
-
-		LayoutUtil.copyPositionAndSize(activeComponent.panel, panels.virtual);
-
-		activeGridlines?.forEach((line) => line?.panel.RemoveClass('hud-customizer__gridline--highlight'));
-
-		activeGridlines = [undefined, undefined];
-
-		// TODO: this is just for testing
-		save();
 	}
 
 	function getNearestGridLine(axis: Axis, sizeFactor: number): Gridline {
@@ -499,14 +554,14 @@ namespace HudCustomizer {
 						1920,
 						(panels.virtual.actualxoffset + panels.virtual.actuallayoutwidth * sizeFactor) / scaleX
 					)
-			  )
+				)
 			: Math.max(
 					0,
 					Math.min(
 						1080,
 						(panels.virtual.actualyoffset + panels.virtual.actuallayoutheight * sizeFactor) / scaleY
 					)
-			  );
+				);
 
 		const glIndex = Math.round((relativeOffset / (isX ? 1920 : 1080)) * gridlines[axis].length);
 
@@ -552,7 +607,7 @@ namespace HudCustomizer {
 		if (newSize !== gridSize) {
 			gridSize = newSize;
 			createGridLines();
-		} 
+		}
 	}
 
 	export function setSnapMode(axis: keyof Axis, mode: SnapMode): void {

--- a/scripts/hud/customizer.ts
+++ b/scripts/hud/customizer.ts
@@ -1,0 +1,583 @@
+// I'm trying something new here and using a namespace to escape the namespace pollution nightmare currently have
+// In short, TypeScript seems to put stuff that doesn't include `import`/`export`s in the global namespace,
+// and using those is impossible since pure V8 doesn't have an import/module system.
+
+// The below `Axis` enum is breaking compiles because we have some fucking JSDOC (!) typedef in linegraph.js
+// that overlaps with this one. So, I'm using a namespace (which just gets compiled to an IIFE for scope isolation)
+// and not using a static class - that was essentially just playing the role of an IIFE anyway!
+
+// Not sure if this is what we'll stick with it, but seems good for now.
+
+namespace HudCustomizer {
+	enum Axis {
+		X = 0,
+		Y = 1
+	}
+
+	const Axes = [Axis.X, Axis.Y] as const;
+
+	type Snaps = [SnapMode, SnapMode];
+
+	/**
+	 * The four different snapping behaviours
+	 * For a horizontal panel, min and max are left and right respectively, for vertical, top and bottom
+	 */
+	enum SnapMode {
+		MIN = 1,
+		MID = 2,
+		MAX = 3,
+		OFF = 4
+	}
+
+	const ResizeDirection = {
+		TOP: 1,
+		TOP_RIGHT: 2,
+		RIGHT: 3,
+		BOTTOM_RIGHT: 4,
+		BOTTOM: 5,
+		BOTTOM_LEFT: 6,
+		LEFT: 7,
+		TOP_LEFT: 8
+	};
+
+	// Tuple of X, Y axis snaps respectively
+	const DEFAULT_SNAP_MODES: Snaps = [SnapMode.OFF, SnapMode.OFF];
+	const DEFAULT_GRID_SIZE = 5;
+
+	interface HudConfig {
+		components: {
+			[id: string]: {
+				position: LayoutUtil.Position;
+				snaps: [number, number];
+			};
+		};
+		settings: {
+			gridSize: number;
+		};
+	}
+
+	interface Component {
+		panel: Panel;
+		snaps: Snaps;
+		position: LayoutUtil.Position;
+		properties?: Record<string, unknown>;
+	}
+
+	interface Gridline {
+		panel: Panel;
+		offset: number;
+	}
+
+	type GridlineForAxis = [Gridline[], Gridline[]];
+
+	const snaps: Record<
+		Axis,
+		Record<
+			SnapMode,
+			{
+				name: string;
+				button: RadioButton;
+				sizeFactor: number;
+			}
+		>
+	> = {
+		[Axis.X]: {
+			[SnapMode.MIN]: {
+				name: 'Left',
+				button: $<RadioButton>('#HudCustomizerSnapsXMin')!,
+				sizeFactor: 0
+			},
+			[SnapMode.MID]: {
+				name: 'Center',
+				button: $<RadioButton>('#HudCustomizerSnapsXMid')!,
+				sizeFactor: 0.5
+			},
+			[SnapMode.MAX]: {
+				name: 'Right',
+				button: $<RadioButton>('#HudCustomizerSnapsXMax')!,
+				sizeFactor: 1
+			},
+			[SnapMode.OFF]: {
+				name: 'None',
+				button: $<RadioButton>('#HudCustomizerSnapsXOff')!,
+				sizeFactor: 0
+			}
+		},
+		[Axis.Y]: {
+			[SnapMode.MIN]: {
+				name: 'Top',
+				button: $<RadioButton>('#HudCustomizerSnapsYMin')!,
+				sizeFactor: 0
+			},
+			[SnapMode.MID]: {
+				name: 'Center',
+				button: $<RadioButton>('#HudCustomizerSnapsYMid')!,
+				sizeFactor: 0.5
+			},
+			[SnapMode.MAX]: {
+				name: 'Bottom',
+				button: $<RadioButton>('#HudCustomizerSnapsYMax')!,
+				sizeFactor: 1
+			},
+			[SnapMode.OFF]: {
+				name: 'None',
+				button: $<RadioButton>('#HudCustomizerSnapsYOff')!,
+				sizeFactor: 0
+			}
+		}
+	};
+
+	const panels = {
+		customizer: $('#HudCustomizer')!,
+		virtual: $('#HudCustomizerVirtual')!,
+		virtualName: $<Label>('#HudCustomizerVirtualName')!,
+		snaps: $('#HudCustomizerSnaps')!,
+		grid: $('#HudCustomizerGrid')!,
+		gridSize: $<NumberEntry>('#HudCustomizerGridSize')!,
+		knobContainer: $('#HudCustomizerKnobContainer')!
+	};
+
+	let components: Record<string, Component>;
+	let gridlines: GridlineForAxis;
+	let activeComponent: Component | undefined;
+	let activeGridlines: [Gridline | undefined, Gridline | undefined];
+	let resizeKnobs: Record<keyof typeof ResizeDirection, Button>;
+
+	let dragStartHandle: number | undefined;
+	let dragEndHandle: number | undefined;
+	let onThinkHandle: number | undefined;
+
+	// TODO: Unused. Didn't get very far with resize stuff, behaviour should be
+	// similar to dragging the virtual panel.
+	let knobDragStartHandle: number | undefined;
+	let knobDragEndHandle: number | undefined;
+	let knobOnThinkHandle: number | undefined;
+
+	let gridSize = 5;
+
+	const scaleX = $.GetContextPanel().actualuiscale_x;
+	const scaleY = $.GetContextPanel().actualuiscale_y;
+
+	$.RegisterForUnhandledEvent('HudChat_Show', () => enableEditing());
+	$.RegisterForUnhandledEvent('HudChat_Hide', () => disableEditing());
+
+	function save() {
+		const saveData: HudConfig = {
+			settings: { gridSize: gridSize },
+			components: {}
+		};
+
+		for (const [id, component] of Object.entries(components)) {
+			const posX = fixFloatingImprecision(
+				LayoutUtil.getX(component.panel) +
+					LayoutUtil.getWidth(component.panel) * snaps[0][component.snaps[0]].sizeFactor
+			);
+			const posY = fixFloatingImprecision(
+				LayoutUtil.getX(component.panel) +
+					LayoutUtil.getHeight(component.panel) * snaps[1][component.snaps[1]].sizeFactor
+			);
+
+			saveData.components[id] = {
+				position: [posX, posY],
+				snaps: component.snaps
+			};
+		}
+
+		HudCustomizerAPI.SaveLayoutFromJS(saveData);
+	}
+
+	function load() {
+		gridlines = [[], []];
+		activeGridlines = [undefined, undefined];
+		activeComponent = undefined;
+
+		let layoutData: HudConfig;
+		try {
+			layoutData = HudCustomizerAPI.GetLayout() as HudConfig;
+		} catch {
+			$.Warning('HudCustomizer: Failed to parse layout file!');
+			return;
+		}
+
+		gridSize = layoutData?.settings?.gridSize ?? 5;
+		panels.gridSize.value = gridSize;
+
+		createGridLines();
+
+		resizeKnobs = {} as any;
+		Object.values(ResizeDirection)
+			.filter((x) => !Number.isNaN(+x))
+			.forEach((dir) => {
+				resizeKnobs[dir] = $.CreatePanel('Button', panels.knobContainer, `Resize_${ResizeDirection[dir]}`, {
+					class: 'hud-customizer__resize-knob',
+					draggable: true,
+					hittest: true
+				});
+			});
+
+		components = {};
+		$.GetContextPanel()
+			.Children()
+			.filter((panel) => panel.GetAttributeString('customizable', '') === 'true')
+			.forEach((panel) => loadComponentPanel(layoutData?.components[panel.id], panel));
+	}
+
+	function loadComponentPanel(component: Pick<Component, 'position' | 'snaps'> | undefined, panel: Panel) {
+		if (component) {
+			for (const [i, snap] of component.snaps.entries()) {
+				if (!Object.values(SnapMode).includes(snap)) {
+					$.Warning(`HudCustomizer: Invalid snap values ${snap}, setting to default.`);
+					component.snaps[i] = DEFAULT_SNAP_MODES[i];
+				}
+			}
+
+			const layoutPos = component.position.map((len, i) => {
+				if (Number.isNaN(len)) {
+					$.Warning(`HudCustomizer: Loaded invalid position ${len}, setting to 0.`);
+					len = 0;
+				}
+
+				const isX = i === 0;
+				const max = isX ? 1920 : 1080;
+				const sf = snaps[i][component.snaps[i]].sizeFactor;
+				const panelLen = isX ? LayoutUtil.getWidth(panel) : LayoutUtil.getHeight(panel);
+				let layoutLen = len - panelLen * sf;
+				const maxOOB = 16;
+
+				if (layoutLen < 0 && layoutLen + panelLen < maxOOB) {
+					$.Warning(
+						`HudCustomizer: Panel ${panel.id} is too far off-screen (X = ${layoutLen}), nudging on-screen.`
+					);
+					layoutLen = 0;
+				} else if (layoutLen + panelLen > max - maxOOB) {
+					$.Warning(
+						`HudCustomizer: Panel ${panel.id} is too far off-screen (Y = ${layoutLen}), nudging on-screen.`
+					);
+					layoutLen = max - panelLen;
+				}
+
+				return layoutLen;
+			}) as LayoutUtil.Position;
+
+			LayoutUtil.setPosition(panel, layoutPos);
+
+			components[panel.id] = {
+				panel,
+				...component
+			};
+		} else {
+			const size = LayoutUtil.getSize(panel);
+
+			if (
+				size[0] > 1920 ||
+				size[1] > 1080 ||
+				(size[0] === 1920 && size[1] > 1080 / 2) ||
+				(size[1] === 1080 && size[0] > 1920 / 2)
+			) {
+				$.Warning(
+					`HudCustomizer: Found an unrecognised HUD panel ${panel.paneltype} with stupid big dimensions, ignoring.\n` +
+						`\tWidth: ${size[0]}\tHeight: ${size[1]}` +
+						`\tPosition: [${LayoutUtil.getPosition(panel).join(', ')}]).`
+				);
+				return;
+			}
+
+			// TODO: This approach isn't right. If the component wasn't found in hud.kv3, it's probably a new HUD
+			// component that was added after the user first launched then closed the game, generating hud.kv3 for the
+			// first time. So use the new HudCustomizerAPI.GetDefaultLayout and see if a matching component is in there,
+			// and if it is, use those values. Only if it's not found in there should we do the below stuff.
+
+			$.Msg(
+				"HudCustomizer: Found a customizable HUD element that isn't stored, initialising with default values."
+			);
+
+			components[panel.id] = {
+				panel,
+				position: LayoutUtil.getPosition(panel),
+				snaps: DEFAULT_SNAP_MODES
+			};
+		}
+	}
+
+	export function enableEditing() {
+		// Onload calls load() too early so have to do this
+		// TODO: I don't know why the above is the case, clearly shitty behaviour, fiugure it out!
+		if (!components || Object.keys(components).length === 0) {
+			load();
+		}
+
+		panels.customizer.AddClass('hud-customizer--enabled');
+
+		for (const component of Object.values(components)) {
+			component.panel.AddClass('hud-customizable');
+			component.panel.SetPanelEvent('onmouseover', () => onComponentMouseOver(component));
+		}
+	}
+
+	export function disableEditing() {
+		panels.customizer.RemoveClass('hud-customizer--enabled');
+
+		for (const component of Object.values(components)) {
+			component.panel.RemoveClass('hud-customizable');
+			component.panel.ClearPanelEvent('onmouseover');
+		}
+
+		$.UnregisterEventHandler('DragStart', panels.virtual, dragStartHandle);
+	}
+
+	function onComponentMouseOver(component: Component) {
+		if (activeComponent && activeComponent === component) return;
+
+		activeComponent?.panel.RemoveClass('hud-customizable--active');
+
+		activeComponent = component;
+
+		activeComponent.panel.AddClass('hud-customizable--active');
+
+		const [[x, y], [width, height]] = LayoutUtil.getPositionAndSize(component.panel);
+
+		// Set the virtual panel's position and size to the component we just hovered over
+		LayoutUtil.setPositionAndSize(panels.virtual, [x, y], [width, height]);
+		LayoutUtil.setPositionAndSize(panels.knobContainer, [x, y], [width, height]);
+
+		const halfWidth = width / 2;
+		const halfHeight = height / 2;
+		let plusX, plusY;
+		for (const [dir, knob] of Object.entries(resizeKnobs)) {
+			switch (+dir) {
+				case ResizeDirection.TOP:
+					plusX = halfWidth;
+					plusY = 0;
+					break;
+				case ResizeDirection.TOP_RIGHT:
+					plusX = width;
+					plusY = 0;
+					break;
+				case ResizeDirection.RIGHT:
+					plusX = width;
+					plusY = halfHeight;
+					break;
+				case ResizeDirection.BOTTOM_RIGHT:
+					plusX = width;
+					plusY = height;
+					break;
+				case ResizeDirection.BOTTOM:
+					plusX = halfWidth;
+					plusY = height;
+					break;
+				case ResizeDirection.BOTTOM_LEFT:
+					plusX = 0;
+					plusY = height;
+					break;
+				case ResizeDirection.LEFT:
+					plusX = 0;
+					plusY = halfHeight;
+					break;
+				case ResizeDirection.TOP_LEFT:
+					plusX = 0;
+					plusY = 0;
+					break;
+			}
+
+			$.Msg({ x, y, width, height, dir, plusX, plusY });
+
+			LayoutUtil.setPosition(knob, [plusX, plusY]);
+		}
+
+		// This is going to be weird to localise, but I guess we could do it, probably in V2 when we can
+		// define the locale string in the `customisable` XML property.
+		panels.virtualName.text = activeComponent.panel.id;
+		// TODO: This text looks TERRIBLE. Better to just have a constant size text for every component
+		// place text above component (left-aligned)
+		const stupidFontSizeThing = Math.min(
+			LayoutUtil.getHeight(activeComponent.panel) / 2,
+			LayoutUtil.getWidth(activeComponent.panel) / 2
+		);
+
+		panels.virtualName.style.fontSize = stupidFontSizeThing;
+
+		snaps[0][activeComponent.snaps[0]].button.SetSelected(true);
+		snaps[1][activeComponent.snaps[1]].button.SetSelected(true); 
+
+		if (dragStartHandle) {
+			$.UnregisterEventHandler('DragStart', panels.virtual, dragStartHandle);
+		}
+
+		dragStartHandle = $.RegisterEventHandler('DragStart', panels.virtual, (...args) => onStartDrag(...args));
+	}
+
+	function onStartDrag(_source, callback) {
+		if (!activeComponent) return;
+
+		callback.displayPanel = panels.virtual;
+		callback.removePositionBeforeDrop = false;
+
+		// These aren't actually related to one-another in XML hierarchy so need to handle two classes
+		activeComponent.panel.AddClass('hud-customizable--dragging');
+		panels.virtual.AddClass('hud-customizer-virtual--dragging');
+
+		$.UnregisterEventHandler('DragStart', panels.virtual, dragStartHandle);
+
+		onThinkHandle = $.RegisterEventHandler('HudThink', $.GetContextPanel(), () => onDragThink());
+
+		dragEndHandle = $.RegisterEventHandler('DragEnd', panels.virtual, () => onEndDrag());
+	}
+
+	function onDragThink() {
+		if (!activeComponent) return;
+
+		const oldPosition = [0, 0];
+		const newPosition: LayoutUtil.Position = [0, 0];
+
+		for (const axis of Axes) {
+			const isX = axis === 0;
+
+			if (activeComponent.snaps[axis] === SnapMode.OFF) {
+				newPosition[axis] = isX ? LayoutUtil.getX(panels.virtual) : LayoutUtil.getY(panels.virtual);
+			} else {
+				const sizeFactor = snaps[axis][activeComponent.snaps[axis]].sizeFactor;
+
+				const offset = isX
+					? (activeComponent.panel.actuallayoutwidth * sizeFactor) / scaleX
+					: (activeComponent.panel.actuallayoutheight * sizeFactor) / scaleY;
+
+				const gridline = getNearestGridLine(axis, sizeFactor);
+				const activeGridline = activeGridlines[axis];
+
+				if (activeGridline) oldPosition[axis] = activeGridline.offset - offset;
+				if (gridline) newPosition[axis] = gridline.offset - offset;
+
+				if (gridline !== activeGridline) {
+					if (activeGridline) activeGridline.panel.RemoveClass('hud-customizer__gridline--highlight');
+					if (gridline) {
+						gridline.panel.AddClass('hud-customizer__gridline--highlight');
+						activeGridlines[axis] = gridline;
+
+						newPosition[axis] = gridline.offset - offset;
+					}
+				}
+			}
+		}
+
+		if (newPosition[0] !== oldPosition[1] || newPosition[1] !== oldPosition[1]) {
+			LayoutUtil.setPosition(activeComponent.panel, newPosition);
+			LayoutUtil.setPosition(panels.knobContainer, newPosition);
+		}
+	}
+
+	function onEndDrag() {
+		if (!activeComponent) return;
+
+		$.UnregisterEventHandler('DragEnd', panels.virtual, dragEndHandle);
+		$.UnregisterEventHandler('HudThink', $.GetContextPanel(), onThinkHandle);
+
+		dragStartHandle = $.RegisterEventHandler('DragStart', panels.virtual, (...args) => onStartDrag(...args));
+
+		dragEndHandle = undefined;
+		onThinkHandle = undefined;
+
+		activeComponent.panel.RemoveClass('hud-customizable--dragging');
+		panels.virtual.RemoveClass('hud-customizer-virtual--dragging');
+
+		LayoutUtil.copyPositionAndSize(activeComponent.panel, panels.virtual);
+
+		activeGridlines?.forEach((line) => line?.panel.RemoveClass('hud-customizer__gridline--highlight'));
+
+		activeGridlines = [undefined, undefined];
+
+		// TODO: this is just for testing
+		save();
+	}
+
+	function getNearestGridLine(axis: Axis, sizeFactor: number): Gridline {
+		const isX = axis === Axis.X;
+
+		const relativeOffset = isX
+			? Math.max(
+					0,
+					Math.min(
+						1920,
+						(panels.virtual.actualxoffset + panels.virtual.actuallayoutwidth * sizeFactor) / scaleX
+					)
+			  )
+			: Math.max(
+					0,
+					Math.min(
+						1080,
+						(panels.virtual.actualyoffset + panels.virtual.actuallayoutheight * sizeFactor) / scaleY
+					)
+			  );
+
+		const glIndex = Math.round((relativeOffset / (isX ? 1920 : 1080)) * gridlines[axis].length);
+
+		return gridlines[axis][glIndex];
+	}
+
+	function createGridLines(): void {
+		panels.grid.RemoveAndDeleteChildren();
+
+		const numXLines = 2 ** gridSize;
+		const numYLines = Math.floor(numXLines * (9 / 16));
+
+		gridlines = [[], []];
+		activeGridlines = [undefined, undefined];
+
+		for (const axis of Axes) {
+			const isX = axis === 0;
+			const numLines = isX ? numXLines : numYLines;
+			const totalLength = isX ? 1920 : 1080;
+
+			gridlines[axis] = Array.from({ length: numLines }, (_, i) => {
+				const offset = totalLength * (i / numLines);
+
+				let cssClass = `hud-customizer__gridline hud-customizer__gridline--${isX ? 'x' : 'y'}`;
+				if (i === numLines / 2) cssClass += ' hud-customizer__gridline--mid';
+				if (i === 0 || i === numLines) cssClass += 'hud-customizer__gridline--edge';
+
+				const gridline = $.CreatePanel('Panel', panels.grid, '', { class: cssClass });
+
+				LayoutUtil.setPosition(gridline, isX ? [offset, 0] : [0, offset]);
+
+				return {
+					panel: gridline,
+					offset
+				};
+			});
+		}
+	}
+
+	export function updateGridSize(): void {
+		const newSize = panels.gridSize.value;
+
+		if (newSize !== gridSize) {
+			gridSize = newSize;
+			createGridLines();
+		} 
+	}
+
+	export function setSnapMode(axis: keyof Axis, mode: SnapMode): void {
+		if (!activeComponent) return;
+
+		activeComponent.snaps[axis] = mode;
+		showSnapTooltip();
+	}
+
+	export function showSnapTooltip(): void {
+		if (!activeComponent) return;
+
+		UiToolkitAPI.ShowTextTooltip(
+			panels.snaps.id,
+			'<b><i>Snapping Mode</i></b>\n' +
+				`Horizontal: <b>${snaps[0][activeComponent.snaps[0]].name}</b>\n` +
+				`Vertical: <b>${snaps[1][activeComponent.snaps[1]].name}</b>`
+		);
+	}
+
+	export function hideSnapTooltip(): void {
+		UiToolkitAPI.HideTextTooltip();
+	}
+
+	function fixFloatingImprecision(n: number) {
+		return +n.toPrecision(3);
+	}
+}

--- a/styles/components/chat.scss
+++ b/styles/components/chat.scss
@@ -12,7 +12,7 @@
 	&__history-wrapper {
 		height: 100%;
 		width: 100%;
-		margin: 8px;
+		margin-bottom: 8px;
 		padding: 8px 0;
 
 		&:hover {
@@ -35,7 +35,7 @@
 
 	&__input-container {
 		width: 100%;
-		margin: 0 8px 6px 8px;
+		margin-bottom: 6px;
 		flow-children: right;
 	}
 

--- a/styles/components/number-entry.scss
+++ b/styles/components/number-entry.scss
@@ -25,7 +25,7 @@
 
 	&__button {
 		height: 100%;
-		width: height-percentage(100%);
+		// width: height-percentage(100%);
 		background-color: rgba(0, 0, 0, 0.4);
 
 		transition-property: background-color, wash-color;

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -570,7 +570,7 @@ $progressbar-shadow: rgba(0, 0, 0, 0.5) 0px 0px 3px 0px !default;
 $tooltip-background: $gray-200 !default;
 $tooltip-padding: 8px 12px !default;
 $tooltip-radius: 4px !default;
-$tooltip-margin: 0px;
+$tooltip-margin: 4px;
 
 $tooltip-title-use-header-font: true !default;
 $tooltip-title-font-size: 36px !default;

--- a/styles/hud/chat.scss
+++ b/styles/hud/chat.scss
@@ -1,5 +1,5 @@
 .hud-chat {
 	flow-children: none;
-	margin-left: 15px;
-	margin-bottom: 15px;
+	width: 576px;
+	height: 324px;
 }

--- a/styles/hud/hud.scss
+++ b/styles/hud/hud.scss
@@ -63,6 +63,7 @@
 	height: 100%;
 
 	visibility: collapse;
+    z-index: 1000;
 
 	&--enabled {
 		visibility: visible;
@@ -120,20 +121,14 @@
 		}
 	}
 
-	&__knob-container {
-		overflow: noclip;
-		border: 2px solid orange;
-	}
-
 	&__resize-knob {
-		width: 8px;
-		height: 8px;
-		transform: translateX(-4px) translateY(-4px);
+		width: 16px;
+		height: 16px;
+		transform: translateX(-8px) translateY(-8px);
 		border-radius: 50%;
 		background-color: rgba(255, 255, 255, 0.8);
 		border: 1px solid rgba(0, 0, 0, 0.2);
 		box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.4);
-		z-index: 1000;
 
 		transition-property: border, box-shadow, background-color;
 		transition-timing-function: ease-in-out;

--- a/styles/hud/hud.scss
+++ b/styles/hud/hud.scss
@@ -1,11 +1,15 @@
-/* styles for the Chaos Hud */
 
-Hud,
-#PopupManager,
-#TooltipManager,
-#ContextMenuManager {
+.hud {
 	width: 100%;
 	height: 100%;
+	flow-children: none;
+
+	&__in-world,
+	&__reticle {
+		width: 100%;
+		height: 100%;
+	}
+}
 }
 
 .hud-blur {

--- a/styles/hud/hud.scss
+++ b/styles/hud/hud.scss
@@ -1,3 +1,6 @@
+@use '../config' as *;
+@use '../abstract/mixin';
+@use 'sass:color';
 
 .hud {
 	width: 100%;
@@ -10,6 +13,243 @@
 		height: 100%;
 	}
 }
+
+.hud-customizable {
+	$border-len: 1px;
+	border: $border-len solid rgba($blue, 0.7);
+	box-shadow: 0px 0px 16px 0px rgba(0, 0, 0, 0.7);
+
+	&--active {
+		animation: HudCustomizableActivePulse 1s ease-in-out 0s infinite normal forwards;
+
+		box-shadow: 0px 0px 16px 0px rgba(0, 0, 0, 1);
+
+		@at-root {
+			@keyframes HudCustomizableActivePulse {
+				0% {
+					border: $border-len solid rgba($green, 0.7);
+				}
+				50% {
+					border: $border-len solid rgba($green, 1);
+				}
+				100% {
+					border: $border-len solid rgba($green, 0.7);
+				}
+			}
+		}
+	}
+
+	&--dragging {
+		animation: HudCustomizableDraggingPulse 1s ease-in-out 0s infinite normal forwards;
+
+		@at-root {
+			@keyframes HudCustomizableDraggingPulse {
+				0% {
+					border: $border-len solid rgba($red, 1);
+				}
+				50% {
+					border: $border-len solid rgba(color.scale($red, $saturation: 20%, $lightness: -10%), 1);
+				}
+				100% {
+					border: $border-len solid rgba($red, 1);
+				}
+			}
+		}
+	}
+}
+
+.hud-customizer {
+	width: 100%;
+	height: 100%;
+
+	visibility: collapse;
+
+	&--enabled {
+		visibility: visible;
+	}
+
+	&__settings {
+		align: right top;
+		margin-right: 32px;
+		margin-top: 32px;
+		flow-children: right;
+		padding: 8px;
+		background-color: rgba(0, 0, 0, 0.8);
+		border-radius: 2px;
+		border: 1px solid rgba(255, 255, 255, 0.1);
+	}
+
+	&__grid {
+		width: 100%;
+		height: 100%;
+	}
+
+	&__gridline {
+		$this: &;
+		$color: rgb(255, 255, 255);
+
+		background-color: rgba(255, 255, 255, 0.05);
+		transition: background-color 0.05s ease-out 0s;
+
+		&--edge {
+			background-color: none;
+		}
+
+		&--x {
+			margin-left: -1px;
+			width: 1px;
+			height: 100%;
+		}
+
+		&--y {
+			margin-top: -1px;
+			width: 100%;
+			height: 1px;
+		}
+
+		&--highlight {
+			background-color: rgba($color, 0.3);
+		}
+
+		&--center {
+			background-color: rgba($color, 0.1);
+
+			&#{$this}--highlight {
+				background-color: rgba($color, 1);
+			}
+		}
+	}
+
+	&__knob-container {
+		overflow: noclip;
+		border: 2px solid orange;
+	}
+
+	&__resize-knob {
+		width: 8px;
+		height: 8px;
+		transform: translateX(-4px) translateY(-4px);
+		border-radius: 50%;
+		background-color: rgba(255, 255, 255, 0.8);
+		border: 1px solid rgba(0, 0, 0, 0.2);
+		box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.4);
+		z-index: 1000;
+
+		transition-property: border, box-shadow, background-color;
+		transition-timing-function: ease-in-out;
+		transition-duration: 0.1s;
+
+		&:hover {
+			background-color: rgba(200, 200, 200, 1);
+			border: 1px solid rgba(0, 0, 0, 0.4);
+			box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.9);
+		}
+	}
+}
+
+.hud-customizer-settings {
+	&__close {
+		vertical-align: center;
+		width: 16px;
+		height: 16px;
+	}
+
+	&__gridsize {
+		width: 92px;
+	}
+}
+
+.hud-customizer-virtual {
+	$root: &;
+
+	border: 1px solid rgb(225, 0, 255);
+	overflow: noclip;
+
+	&--dragging {
+		& > .hud-customizer-virtual-snaps {
+			opacity: 0;
+			transition: opacity 0.05s ease-in 0s;
+		}
+	}
+
+	&__name {
+		align: center center;
+		@include mixin.font-styles($use-header: true);
+		opacity: 0.3;
+
+		#{$root}--dragging & {
+			opacity: 0;
+			transition: opacity 0.05s ease-in 0s;
+		}
+	}
+}
+
+.hud-customizer-virtual-snaps {
+	$root: &;
+	width: fit-children;
+	height: fit-children;
+
+	horizontal-align: right;
+	flow-children: down;
+
+	margin: 2px;
+	border-radius: 2px;
+	border: 1px solid rgba(0, 0, 0, 0.9);
+
+	opacity: 0.7;
+	transition: opacity 0.1s ease-in-out 0s;
+
+	&:hover {
+		opacity: 1;
+	}
+
+	tooltip-position: bottom;
+
+	&__row {
+		width: fit-children;
+		height: fit-children;
+		flow-children: right;
+		border-bottom: 1px solid rgba(0, 0, 0, 0.95);
+
+		&--last {
+			border-bottom: 0px solid none;
+		}
+	}
+
+	&__button {
+		width: 16px;
+		height: 16px;
+		background-color: rgba(0, 0, 0, 0.8);
+
+		transition: background-color 0.075s ease-in-out 0s;
+
+		&--last {
+			border-right: 0px solid none;
+		}
+
+		&:selected {
+			background-color: rgba(90, 90, 90, 0.5);
+
+			& > #{$root}__icon {
+				opacity: 1;
+			}
+		}
+
+		&:hover {
+			background-color: rgba(99, 99, 99, 0.5);
+		}
+	}
+
+	&__icon {
+		width: 100%;
+		height: 100%;
+		padding: 0px;
+		opacity: 0.5;
+	}
+}
+
+MomHudGhostEntities {
+	position: 100px 200px 0px;
 }
 
 .hud-blur {

--- a/styles/hud/key-press.scss
+++ b/styles/hud/key-press.scss
@@ -1,6 +1,5 @@
 .keypress {
 	flow-children: down;
-	margin: 35px;
 
 	// TODO: strafe keys are not implemented!
 	&__unimplemented {

--- a/styles/hud/map-info.scss
+++ b/styles/hud/map-info.scss
@@ -1,12 +1,10 @@
 @use '../config' as *;
 @use '../abstract/mixin';
 
-.hudmapinfo {
-	margin: 0 5px 5px 5px;
+.hud-map-info {
 	flow-children: down;
 	width: 350px;
 	height: fit-children;
-	align: right center;
 
 	&__label {
 		@include mixin.font-styles($use-header: true);

--- a/styles/hud/speedometer.scss
+++ b/styles/hud/speedometer.scss
@@ -1,8 +1,6 @@
 @use '../config' as *;
 
 .speedometers {
-	margin: 6px 0px 6px 0;
-	align: center center;
 	flow-children: down;
 }
 

--- a/styles/hud/timer.scss
+++ b/styles/hud/timer.scss
@@ -1,7 +1,7 @@
 @use '../config' as *;
 @use '../abstract/mixin';
 
-@keyframes timerFailedAnim {
+@keyframes TimerFailedAnim {
 	from {
 		color: $timer-color-inactive;
 	}
@@ -13,11 +13,10 @@
 	}
 }
 
-.hudtimer {
-	margin: 6px 0px 6px 0;
+.hud-timer {
 	flow-children: down;
-	width: 100%;
-	align: center center;
+	width: fit-children;
+	height: fit-children;
 
 	&__time {
 		@include mixin.font-styles($use-header: false);
@@ -33,10 +32,12 @@
 		&--inactive {
 			color: $timer-color-inactive;
 		}
+
 		&--failed {
-			animation-name: timerFailedAnim;
+			animation-name: TimerFailedAnim;
 			animation-duration: 1s;
 		}
+
 		&--finished {
 			color: $timer-color-finished;
 		}

--- a/styles/modals/tooltips/tooltip.scss
+++ b/styles/modals/tooltips/tooltip.scss
@@ -113,7 +113,7 @@
 	}
 
 	@each $dir in ('top', 'right', 'bottom', 'right') {
-		&__#{$dir}-arrow {
+		#{$root}--arrow &__#{$dir}-arrow {
 			background-image: url('file://{images}/tooltips/#{$dir}-arrow.svg');
 
 			#{$root}.#{function.capitalize($dir)}ArrowVisible & {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 		"rootDir": "scripts/",
 		"outDir": "script_dist/",
 		"alwaysStrict": true,
-		"isolatedModules": true,
+		"isolatedModules": false,
 		"allowJs": true,
 		"strict": true,
 		"noImplicitAny": false,


### PR DESCRIPTION
Added resizing to the hud editor.

Most hud elements aren't resized properly, but the chat works.
There's a new size property that needs to be added to the hud_default.kv3

### Checks

-   [X] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [X] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [X] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [X] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [X] All changes requested in review have been `fixup`ed into my original commits.
-   [X] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below