### PR TITLE
Check game modes for mode-specific hud panels

### DIFF
--- a/layout/hud/cgaz.xml
+++ b/layout/hud/cgaz.xml
@@ -4,6 +4,7 @@
 	</styles>
 	<scripts>
 		<include src="file://{scripts}/common/gamemodes.js" />
+		<include src="file://{scripts}/util/register-for-gamemodes.js" />
 		<include src="file://{scripts}/util/math.js" />
 		<include src="file://{scripts}/util/colors.js" />
 		<include src="file://{scripts}/hud/cgaz.js" />

--- a/layout/hud/df-jump.xml
+++ b/layout/hud/df-jump.xml
@@ -3,6 +3,8 @@
 		<include src="file://{resources}/styles/main.scss" />
 	</styles>
 	<scripts>
+		<include src="file://{scripts}/common/gamemodes.js" />
+		<include src="file://{scripts}/util/register-for-gamemodes.js" />
 		<include src="file://{scripts}/common/buttons.js" />
 		<include src="file://{scripts}/hud/df-jump.js" />
 	</scripts>

--- a/layout/hud/ground-boost.xml
+++ b/layout/hud/ground-boost.xml
@@ -3,6 +3,8 @@
 		<include src="file://{resources}/styles/main.scss" />
 	</styles>
 	<scripts>
+		<include src="file://{scripts}/common/gamemodes.js" />
+		<include src="file://{scripts}/util/register-for-gamemodes.js" />
 		<include src="file://{scripts}/hud/ground-boost.js" />
 	</scripts>
 

--- a/layout/hud/jump-stats.xml
+++ b/layout/hud/jump-stats.xml
@@ -3,6 +3,8 @@
 		<include src="file://{resources}/styles/main.scss" />
 	</styles>
 	<scripts>
+		<include src="file://{scripts}/common/gamemodes.js" />
+		<include src="file://{scripts}/util/register-for-gamemodes.js" />
 		<include src="file://{scripts}/hud/jump-stats.js" />
 	</scripts>
 

--- a/layout/hud/synchronizer.xml
+++ b/layout/hud/synchronizer.xml
@@ -4,6 +4,7 @@
 	</styles>
 	<scripts>
 		<include src="file://{scripts}/common/gamemodes.js" />
+		<include src="file://{scripts}/util/register-for-gamemodes.js" />
 		<include src="file://{scripts}/util/math.js" />
 		<include src="file://{scripts}/util/colors.js" />
 		<include src="file://{scripts}/hud/synchronizer.js" />

--- a/scripts/hud/cgaz.js
+++ b/scripts/hud/cgaz.js
@@ -124,25 +124,14 @@ class Cgaz {
 	static updateHandle = null;
 
 	static onLoad() {
-		if (GameModeAPI.GetCurrentGameMode() === GameMode.DEFRAG) {
-			this.updateHandle = $.RegisterEventHandler(
-				'HudProcessInput',
-				$.GetContextPanel(),
-				this.onUpdate.bind(this)
-			);
-
-			this.onAccelConfigChange();
-			this.onSnapConfigChange();
-			this.onPrimeConfigChange();
-			this.onProjectionChange();
-			this.onHudFovChange();
-			this.onSnapConfigChange();
-			this.onWindicatorConfigChange();
-			this.onCompassConfigChange();
-		} else if (this.updateHandle) {
-			$.UnregisterEventHandler('HudProcessInput', $.GetContextPanel(), this.updateHandle);
-			this.updateHandle = null;
-		}
+		this.onAccelConfigChange();
+		this.onSnapConfigChange();
+		this.onPrimeConfigChange();
+		this.onProjectionChange();
+		this.onHudFovChange();
+		this.onSnapConfigChange();
+		this.onWindicatorConfigChange();
+		this.onCompassConfigChange();
 	}
 
 	static onProjectionChange() {
@@ -1267,7 +1256,20 @@ class Cgaz {
 	}
 
 	static {
-		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.onLoad.bind(this));
+		RegisterHUDPanelForGamemode({
+			gamemodes: [GameMode.DEFRAG],
+			context: this,
+			contextPanel: $.GetContextPanel(),
+			onLoad: this.onLoad,
+			handledEvents: [
+				{
+					event: 'HudProcessInput',
+					contextPanel: $.GetContextPanel(),
+					callback: this.onUpdate
+				}
+			]
+		});
+
 		$.RegisterForUnhandledEvent('OnDefragHUDProjectionChange', this.onProjectionChange.bind(this));
 		$.RegisterForUnhandledEvent('OnDefragHUDFOVChange', this.onHudFovChange.bind(this));
 		$.RegisterForUnhandledEvent('OnDefragHUDAccelChange', this.onAccelConfigChange.bind(this));

--- a/scripts/hud/df-jump.js
+++ b/scripts/hud/df-jump.js
@@ -49,9 +49,20 @@ class DFJump {
 	}
 
 	static {
-		$.RegisterEventHandler('DFJumpDataUpdate', this.container, this.onDFJumpUpdate.bind(this));
+		RegisterHUDPanelForGamemode({
+			gamemodes: [GameMode.DEFRAG],
+			context: this,
+			contextPanel: this.container,
+			onLoad: this.onLoad,
+			handledEvents: [
+				{
+					event: 'DFJumpDataUpdate',
+					contextPanel: this.container,
+					callback: this.onDFJumpUpdate
+				}
+			]
+		});
 
-		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.onLoad.bind(this));
 		$.RegisterForUnhandledEvent('DFJumpMaxDelayChanged', this.setMaxDelay.bind(this));
 	}
 }

--- a/scripts/hud/ground-boost.js
+++ b/scripts/hud/ground-boost.js
@@ -32,12 +32,9 @@ class Groundboost {
 
 	static onLoad() {
 		this.onConfigChange();
-
 		this.colorClass = ColorClass.SLICK;
 		this.groundboostMeter.AddClass(this.colorClass);
-
 		this.labelClass = LabelClass.FLAT;
-
 		this.container.AddClass('groundboost__container--hide');
 		this.visible = false;
 		this.missedJumpTimer = 0;
@@ -172,8 +169,20 @@ class Groundboost {
 	}
 
 	static {
-		$.RegisterEventHandler('HudProcessInput', $.GetContextPanel(), this.onUpdate.bind(this));
-		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.onLoad.bind(this));
+		RegisterHUDPanelForGamemode({
+			gamemodes: [GameMode.DEFRAG],
+			context: this,
+			contextPanel: $.GetContextPanel(),
+			onLoad: this.onLoad,
+			handledEvents: [
+				{
+					event: 'HudProcessInput',
+					contextPanel: $.GetContextPanel(),
+					callback: this.onUpdate
+				}
+			]
+		});
+
 		$.RegisterForUnhandledEvent('OnDefragHUDGroundboostChange', this.onConfigChange.bind(this));
 	}
 }

--- a/scripts/hud/jump-stats.js
+++ b/scripts/hud/jump-stats.js
@@ -130,9 +130,20 @@ class JumpStats {
 	}
 
 	static {
-		$.RegisterEventHandler('OnJumpStarted', this.container, this.onJump.bind(this));
+		RegisterHUDPanelForGamemode({
+			gamemodes: [GameMode.BHOP],
+			context: this,
+			contextPanel: this.container,
+			onLoad: this.onLoad,
+			handledEvents: [
+				{
+					event: 'OnJumpStarted',
+					contextPanel: this.container,
+					callback: this.onJump
+				}
+			]
+		});
 
-		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.onLoad.bind(this));
 		$.RegisterForUnhandledEvent('OnJumpStatsCFGChange', this.onConfigChange.bind(this));
 	}
 }

--- a/scripts/hud/synchronizer.js
+++ b/scripts/hud/synchronizer.js
@@ -33,7 +33,6 @@ class Synchronizer {
 
 	static onLoad() {
 		this.initializeSettings();
-
 		if (this.statMode) this.onJump(); // show stats if enabled
 	}
 
@@ -256,7 +255,25 @@ class Synchronizer {
 	}
 
 	static {
-		$.RegisterEventHandler('HudProcessInput', $.GetContextPanel(), this.onUpdate.bind(this));
+		RegisterHUDPanelForGamemode({
+			gamemodes: [GameMode.BHOP, GameMode.SURF],
+			context: this,
+			contextPanel: $.GetContextPanel(),
+			onLoad: this.onLoad,
+			handledEvents: [
+				{
+					event: 'HudProcessInput',
+					contextPanel: $.GetContextPanel(),
+					callback: this.onUpdate
+				}
+			],
+			unhandledEvents: [
+				{
+					event: 'OnJumpStarted',
+					callback: this.onJump
+				}
+			]
+		});
 
 		$.RegisterForUnhandledEvent('OnSynchroModeChanged', this.setDisplayMode.bind(this));
 		$.RegisterForUnhandledEvent('OnSynchroColorModeChanged', this.setColorMode.bind(this));
@@ -266,7 +283,5 @@ class Synchronizer {
 		$.RegisterForUnhandledEvent('OnSynchroMinSpeedChanged', this.setMinSpeed.bind(this));
 		$.RegisterForUnhandledEvent('OnSynchroStatModeChanged', this.setStatMode.bind(this));
 		$.RegisterForUnhandledEvent('OnSynchroStatColorModeChanged', this.setStatColorMode.bind(this));
-		$.RegisterForUnhandledEvent('OnJumpStarted', this.onJump.bind(this));
-		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.onLoad.bind(this));
 	}
 }


### PR DESCRIPTION
This pull request prevents some gamemode-specific hud elements from processing data outside of their intended modes

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below