### PR TITLE
Fix map filters JS exception

### DIFF
--- a/scripts/pages/map-selector/map-selector.js
+++ b/scripts/pages/map-selector/map-selector.js
@@ -80,7 +80,7 @@ class MapSelection {
 
 			$.GetContextPanel().ApplyFilters();
 
-			if (($.persistentStorage.getItem('mapSelector.filtersToggled') ?? false) || filtersChanged) {
+			if ($.persistentStorage.getItem('mapSelector.filtersToggled') ?? false) {
 				$.DispatchEvent('Activated', this.panels.filtersToggle, 'mouse');
 			}
 


### PR DESCRIPTION
Fix a stupid JS exception, trying to access a var I deleted when disabling the filter save/load mechanism.