### PR TITLE
convar togglebuttons and two-click styling

### DIFF
--- a/images/vector-polyline.svg
+++ b/images/vector-polyline.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="#fff" d="M2 3V9H4.95L6.95 15H6V21H12V16.41L17.41 11H22V5H16V9.57L10.59 15H9.06L7.06 9H8V3M4 5H6V7H4M18 7H20V9H18M8 17H10V19H8Z" /></svg>

--- a/images/vector-two-click.svg
+++ b/images/vector-two-click.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 24 24" width="24" height="24">
+    <path fill="#fff" d="M16 4V2h6v6h-2v12H8v2H2v-6h2l0-12M16 8V6H6v10h2v2l10-0L18 8zm2-4v2h2V4zM4 18v2h2v-2z"/>
+</svg>

--- a/layout/hud/tab-menu.xml
+++ b/layout/hud/tab-menu.xml
@@ -59,12 +59,7 @@
 			</Panel>
 			
 			<Panel class="hud-tab-menu__enable-cursor">
-				<Button id="ZoningOpen" class="button horizontal-align-left" onactivate="GameInterfaceAPI.ConsoleCommand('mom_zone_edit 1');$.DispatchEvent('ZoneMenu_Show');" onmouseover="UiToolkitAPI.ShowTextTooltip('ZoningOpen', '#Zoning_ShowMenu_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
-					<Image class="button__icon" src="file://{images}/pencil-outline.svg" textureheight="24" />
-				</Button>
-				<Button id="ZoningClose" class="button horizontal-align-left" onactivate="GameInterfaceAPI.ConsoleCommand('mom_zone_edit 0');$.DispatchEvent('ZoneMenu_Hide');" onmouseover="UiToolkitAPI.ShowTextTooltip('ZoningClose', '#Zoning_HideMenu_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
-					<Image class="button__icon" src="file://{images}/pencil-off-outline.svg" textureheight="24" />
-				</Button>
+				<ToggleButton id="ZoningToggle" class="button horizontal-align-left hud-tab-menu__zoning-button" convar="mom_zone_edit" />
 				<Label class="hud-tab-menu__enable-cursor-tip" text="#HudTabMenu_EnableCursorTip"/> 
 			</Panel>
 		</Panel>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -161,9 +161,12 @@
 					</Panel>
 					<Panel id="PointsSection" class="zoning__region-details">
 						<Panel id="RegionPoints" class="zoning__property">
-							<Button class="button zoning__property-button" onactivate="ZoneMenu.pickCorners();">
-								<Label class="button__text" text="#Zoning_EditPoints" />
-							</Button>
+							<Panel class="zoning__region-property-container">
+								<ToggleButton id="TwoClickMode" class="zoning__two-click-button" convar="mom_zone_two_click" onmouseover="UiToolkitAPI.ShowTextTooltip('TwoClickMode', '#Zoning_TwoClickTogle_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();" />
+								<Button class="button zoning__property-button" onactivate="ZoneMenu.pickCorners();">
+									<Label class="button__text" text="#Zoning_EditPoints" />
+								</Button>
+							</Panel>
 						</Panel>
 						<Panel id="PointsList" class="zoning__region-points-list">
 						<!-- Populated in JS -->

--- a/scripts/hud/tab-menu.js
+++ b/scripts/hud/tab-menu.js
@@ -11,10 +11,6 @@ class HudTabMenu {
 		endOfRunContainer: $('#EndOfRunContainer'),
 		/** @type {Panel} @static */
 		zoningContainer: $('#ZoningContainer'),
-		/** @type {Panel} @static */
-		zoningOpenButton: $('#ZoningOpen'),
-		/** @type {Panel} @static */
-		zoningCloseButton: $('#ZoningClose'),
 		/** @type {Image} @static */
 		gamemodeImage: $('#HudTabMenuGamemodeImage'),
 		/** @type {Panel} @static */
@@ -46,20 +42,14 @@ class HudTabMenu {
 		this.panels.tabMenu.AddClass('hud-tab-menu--offset');
 		this.panels.leaderboardsContainer.AddClass('hud-tab-menu__leaderboards--hidden');
 		this.panels.endOfRunContainer.AddClass('hud-tab-menu__endofrun--hidden');
-
 		this.panels.zoningContainer.RemoveClass('hud-tab-menu__zoning--hidden');
-		this.panels.zoningOpenButton.AddClass('hud-tab-menu__zoning--hidden');
-		this.panels.zoningCloseButton.RemoveClass('hud-tab-menu__zoning--hidden');
 	}
 
 	static hideZoneMenu() {
 		this.panels.tabMenu.RemoveClass('hud-tab-menu--offset');
 		this.panels.leaderboardsContainer.RemoveClass('hud-tab-menu__leaderboards--hidden');
 		this.panels.endOfRunContainer.AddClass('hud-tab-menu__endofrun--hidden');
-
 		this.panels.zoningContainer.AddClass('hud-tab-menu__zoning--hidden');
-		this.panels.zoningOpenButton.RemoveClass('hud-tab-menu__zoning--hidden');
-		this.panels.zoningCloseButton.AddClass('hud-tab-menu__zoning--hidden');
 	}
 
 	static setMapData(isOfficial) {

--- a/styles/hud/tab-menu.scss
+++ b/styles/hud/tab-menu.scss
@@ -88,6 +88,20 @@
 		}
 	}
 
+	&__zoning-button {
+		height: $button-height;
+		width: height-percentage(100%);
+		background-position: center;
+		background-repeat: no-repeat;
+		background-image: url('file://{images}/pencil-outline.svg');
+		img-shadow: $button-icon-shadow;
+		wash-color: $button-text-color;
+
+		&:selected {
+			background-image: url('file://{images}/pencil-off-outline.svg');
+		}
+	}
+
 	&__enable-cursor {
 		border-top: 1px solid rgba(0, 0, 0, 0.4);
 		width: 100%;

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -273,6 +273,25 @@ $medium: 28px;
 		}
 	}
 
+	&__two-click-button {
+		height: $button-height;
+		width: height-percentage(100%);
+		background-position: center;
+		background-repeat: no-repeat;
+		background-image: url('file://{images}/vector-polyline.svg');
+		wash-color: $red;
+		tooltip-position: top;
+
+		&:selected {
+			background-image: url('file://{images}/vector-two-click.svg');
+			wash-color: $blue;
+		}
+
+		&:hover {
+			wash-color: $white;
+		}
+	}
+
 	&__dropdown {
 		width: 180px;
 	}


### PR DESCRIPTION
This pull request updates tabmenu and zoning UI to use new `ToggleButton` behavior. These menus no longer rely on `GameInterfaceAPI.ConsoleCommand()` or `GameInterfaceAPI.SetSettingBool()`.

Before removing draft tag, I'm looking for feedback on which icon to use for signifying that two-click mode is disabled. See discussion in #Zoning UI in momentum discord.

~~Depends on red panorama changes.~~ Red changes merged.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "Zoning_TwoClickTogle_Tooltip",
		"definition": "Toggle two-click point mode"
	}
]
```
