### PR TITLE
region visualization and misc QoL

### DIFF
--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -147,15 +147,15 @@
 						<SettingsSlider text="#Zoning_GridSnapSize" class="zoning__slider" min="1" max="64" percentage="false" convar="mom_zone_grid" />
 					</Panel>
 					<Panel id="PropertyTabs" class="tabs">
-						<RadioButton group="ZoningRegion" class="tabs__tab" selected="true" onactivate="ZoneMenu.showRegionMenu('Points')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionPoints_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+						<RadioButton group="ZoningRegion" class="tabs__tab" value="Points" selected="true" onactivate="ZoneMenu.showRegionMenu('Points')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionPoints_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 							<Image src="file://{images}/vector-square-close.svg" class="tabs__icon" textureheight="48" />
 						</RadioButton>
 						<Panel class="tabs__gap" />
-						<RadioButton group="ZoningRegion" class="tabs__tab" onactivate="ZoneMenu.showRegionMenu('Properties')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionProperties_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+						<RadioButton group="ZoningRegion" class="tabs__tab" value="Properties" onactivate="ZoneMenu.showRegionMenu('Properties')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionProperties_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 							<Image src="file://{images}/list-box-outline.svg" class="tabs__icon" textureheight="48" />
 						</RadioButton>
 						<Panel class="tabs__gap" />
-						<RadioButton group="ZoningRegion" class="tabs__tab" onactivate="ZoneMenu.showRegionMenu('Teleport')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionTeleport_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+						<RadioButton group="ZoningRegion" class="tabs__tab" value="Teleport" onactivate="ZoneMenu.showRegionMenu('Teleport')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionTeleport_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 							<Image src="file://{images}/ray-start-arrow.svg" class="tabs__icon" textureheight="48" />
 						</RadioButton>
 					</Panel>

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -496,13 +496,17 @@ class ZoneMenu {
 		if (!this.selectedZone || !this.selectedZone.zone) return;
 
 		this.pointPick = PickType.corner;
+		const index = this.panels.regionSelect.GetSelected().GetAttributeInt('value', -1);
+		const region = this.selectedZone.zone.regions[index];
 		if (GameInterfaceAPI.GetSettingBool('mom_zone_two_click')) {
-			const index = this.panels.regionSelect.GetSelected().GetAttributeInt('value', -1);
-			this.selectedZone.zone.regions[index].points.length = 0;
+			region.points.length = 0;
 			this.panels.pointsList.RemoveAndDeleteChildren();
 		}
 		//@ts-expect-error function name
 		this.panels.zoningMenu.startPointPick(true);
+
+		//@ts-expect-error function name
+		this.panels.zoningMenu.setCornersFromRegion(region);
 	}
 
 	static addPointToList(i: number, point: number[]) {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -103,6 +103,7 @@ class ZoneMenu {
 		checkpointsOrdered: $('#CheckpointsOrdered')!.FindChild('CheckBox') as ToggleButton,
 		segmentName: $<TextEntry>('#SegmentName')!,
 		propertiesZone: $<Panel>('#ZoneProperties')!,
+		propertyTabs: $<Panel>('#PropertyTabs')!,
 		filterSelect: $<DropDown>('#FilterSelect')!,
 		volumeSelect: $<DropDown>('#VolumeSelect')!,
 		regionSelect: $<DropDown>('#RegionSelect')!,
@@ -184,7 +185,7 @@ class ZoneMenu {
 		this.teleDestList.unshift($.Localize('#Zoning_TPDest_None')!);
 		this.populateDropdown(this.teleDestList, this.panels.regionTPDest, '', true);
 
-		this.showRegionMenu('Points');
+		this.showRegionMenu('reset');
 
 		this.createTrackEntry(this.panels.trackList, this.mapZoneData.tracks.main, 'Main');
 
@@ -412,6 +413,7 @@ class ZoneMenu {
 		this.populateDropdown(zone.regions, this.panels.regionSelect, 'Region', true);
 		this.panels.regionSelect.SetSelectedIndex(0);
 		this.populateRegionProperties();
+		this.showRegionMenu('');
 	}
 
 	static populateSegmentProperties() {
@@ -1000,6 +1002,12 @@ class ZoneMenu {
 	}
 
 	static showRegionMenu(menu: string) {
+		const pointsTab = this.panels.propertyTabs.GetChild(0) as RadioButton;
+		if (menu === 'reset') {
+			pointsTab.SetSelected(true);
+		}
+		menu = menu || pointsTab.GetSelectedButton().GetAttributeString('value', 'Points');
+
 		this.panels.pointsSection.visible = menu === 'Points';
 		this.panels.propertiesSection.visible = menu === 'Properties';
 		this.panels.teleportSection.visible = menu === 'Teleport';

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -89,6 +89,9 @@ const PickType = {
 	teleDestYaw: 'teleDestYaw'
 };
 
+const FLT_MAX = 3.402823466e38;
+const DEFAULT_HEIGHT = 160;
+
 class ZoneMenu {
 	static panels = {
 		zoningMenu: $.GetContextPanel(),
@@ -356,8 +359,8 @@ class ZoneMenu {
 	static createRegion() {
 		return {
 			points: [] as number[][],
-			bottom: 0,
-			height: 0,
+			bottom: FLT_MAX,
+			height: DEFAULT_HEIGHT,
 			teleDestTargetname: ''
 		} as Region;
 	}
@@ -676,6 +679,10 @@ class ZoneMenu {
 				return;
 
 			case PickType.corner:
+				if (point.z < region.bottom) {
+					region.bottom = point.z;
+					this.panels.regionBottom.text = point.z.toFixed(2);
+				}
 				if (GameInterfaceAPI.GetSettingBool('mom_zone_two_click') && region.points.length === 1) {
 					region.points.push([region.points[0][0], point.y]);
 					this.addPointToList(region.points.length - 1, [region.points[0][0], point.y]);

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -131,7 +131,6 @@ class ZoneMenu {
 		zone: null as Zone | null
 	};
 	static mapZoneData: ZoneDef | null;
-	static backupZoneData: ZoneDef | null;
 	static filternameList: string[] | null;
 	static teleDestList: string[] | null;
 	static pointPick: string;
@@ -441,6 +440,8 @@ class ZoneMenu {
 
 		const filterIndex = this.panels.filterSelect.GetSelected()?.GetAttributeInt('value', 0);
 		this.selectedZone.zone.filtername = filterIndex ? this.filternameList[filterIndex] : '';
+
+		this.updateZones();
 	}
 
 	static populateRegionProperties() {
@@ -471,6 +472,8 @@ class ZoneMenu {
 		this.populateDropdown(this.selectedZone.zone.regions, this.panels.regionSelect, 'Region', true);
 		this.panels.regionSelect.SetSelectedIndex(this.selectedZone.zone.regions.length - 1);
 		this.populateRegionProperties();
+
+		this.updateZones();
 	}
 
 	static deleteRegion() {
@@ -482,6 +485,8 @@ class ZoneMenu {
 		this.selectedZone.zone?.regions.splice(index, 1);
 		this.panels.regionSelect.SetSelectedIndex(0);
 		this.populateRegionProperties();
+
+		this.updateZones();
 	}
 
 	static pickCorners() {
@@ -515,6 +520,8 @@ class ZoneMenu {
 		const index = this.panels.regionSelect.GetSelected().GetAttributeInt('value', -1);
 		this.selectedZone.zone?.regions[index].points.splice(n, 1);
 		point.DeleteAsync(0);
+
+		this.updateZones();
 	}
 
 	static pickBottom() {
@@ -530,6 +537,8 @@ class ZoneMenu {
 		const region = this.selectedZone.zone.regions[regionIndex];
 		const bottom = Number.parseFloat(this.panels.regionBottom.text);
 		region.bottom = Number.isNaN(bottom) ? 0 : bottom;
+
+		this.updateZones();
 	}
 
 	static pickHeight() {
@@ -545,6 +554,8 @@ class ZoneMenu {
 		const region = this.selectedZone.zone.regions[regionIndex];
 		const height = Number.parseFloat(this.panels.regionHeight.text);
 		region.height = Number.isNaN(height) ? 0 : height;
+
+		this.updateZones();
 	}
 
 	static pickSafeHeight() {
@@ -560,6 +571,8 @@ class ZoneMenu {
 		const region = this.selectedZone.zone.regions[regionIndex];
 		const height = Number.parseFloat(this.panels.regionSafeHeight.text);
 		region.safeHeight = Number.isNaN(height) ? 0 : height;
+
+		this.updateZones();
 	}
 
 	static pickTeleDestPos() {
@@ -623,6 +636,8 @@ class ZoneMenu {
 			this.panels.regionTPYaw.text = '';
 			this.setRegionTPDestTextEntriesActive(false);
 		}
+
+		this.updateZones();
 	}
 
 	static setRegionTeleDestOrientation() {
@@ -637,6 +652,8 @@ class ZoneMenu {
 
 		region.teleDestPos = [Number.isNaN(x) ? 0 : x, Number.isNaN(y) ? 0 : y, Number.isNaN(z) ? 0 : z];
 		region.teleDestYaw = Number.isNaN(yaw) ? 0 : yaw;
+
+		this.updateZones();
 	}
 
 	static setRegionTPDestTextEntriesActive(enable: boolean) {
@@ -698,10 +715,14 @@ class ZoneMenu {
 				this.panels.regionTPYaw.text = region.teleDestYaw.toFixed(2);
 				break;
 		}
+
+		this.updateZones();
 	}
 
 	static onPickCanceled() {
 		this.pointPick = PickType.none;
+
+		this.updateZones();
 	}
 
 	static addBonus() {
@@ -718,6 +739,8 @@ class ZoneMenu {
 			bonus,
 			`${$.Localize('#Zoning_Bonus')!} ${this.mapZoneData.tracks.bonuses.length}`
 		);
+
+		this.updateZones();
 	}
 
 	static addSegment() {
@@ -747,6 +770,8 @@ class ZoneMenu {
 			segment: newSegment,
 			zone: newSegment.checkpoints[0]
 		});
+
+		this.updateZones();
 	}
 
 	static addCheckpoint() {
@@ -775,6 +800,8 @@ class ZoneMenu {
 			segment: this.selectedZone.segment,
 			zone: newZone
 		});
+
+		this.updateZones();
 	}
 
 	static addEndZone() {
@@ -807,6 +834,8 @@ class ZoneMenu {
 				zone: endZone
 			});
 		}
+
+		this.updateZones();
 	}
 
 	static addCancelZone() {
@@ -839,6 +868,8 @@ class ZoneMenu {
 			segment: this.selectedZone.segment,
 			zone: newZone
 		});
+
+		this.updateZones();
 	}
 
 	static showAddMenu() {
@@ -911,17 +942,23 @@ class ZoneMenu {
 		//hack: this can be a little more surgical
 		this.panels.trackList.RemoveAndDeleteChildren();
 		this.initMenu();
+
+		this.updateZones();
 	}
 
 	static setMaxVelocity() {
 		if (!this.mapZoneData) return;
 		const velocity = Number.parseFloat(this.panels.maxVelocity.text);
 		this.mapZoneData.maxVelocity = !Number.isNaN(velocity) && velocity > 0 ? velocity : 0;
+
+		this.updateZones();
 	}
 
 	static setStageEndAtStageStarts() {
 		if (!this.isSelectionValid().track || !('stagesEndAtStageStarts' in this.selectedZone.track!)) return;
 		this.selectedZone.track.stagesEndAtStageStarts = this.panels.stagesEndAtStageStarts.checked;
+
+		this.updateZones();
 	}
 
 	static showDefragFlagMenu() {
@@ -977,21 +1014,29 @@ class ZoneMenu {
 		const trackPanel = this.panels.trackList.GetChild(1 + bonusIndex)!;
 		trackPanel.FindChildTraverse('CollapseButton')!.visible = false;
 		trackPanel.FindChildTraverse('ChildContainer')!.RemoveAndDeleteChildren();
+
+		this.updateZones();
 	}
 
 	static setLimitGroundSpeed() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.limitStartGroundSpeed = this.panels.limitGroundSpeed.checked;
+
+		this.updateZones();
 	}
 
 	static setCheckpointsOrdered() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.checkpointsOrdered = this.panels.checkpointsOrdered.checked;
+
+		this.updateZones();
 	}
 
 	static setCheckpointsRequired() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.checkpointsRequired = this.panels.checkpointsRequired.checked;
+
+		this.updateZones();
 	}
 
 	static setSegmentName() {
@@ -999,6 +1044,8 @@ class ZoneMenu {
 		this.selectedZone.segment!.name = this.panels.segmentName.text;
 		// feat: later
 		// update segment name in trasklist tree
+
+		this.updateZones();
 	}
 
 	static showRegionMenu(menu: string) {
@@ -1013,17 +1060,30 @@ class ZoneMenu {
 		this.panels.teleportSection.visible = menu === 'Teleport';
 	}
 
+	static updateZones() {
+		if (!this.mapZoneData) return;
+
+		//future: validation here
+
+		this.mapZoneData.dataTimestamp = Date.now();
+		//@ts-expect-error API name not recognized
+		MomentumTimerAPI.SetActiveZoneDefs(this.mapZoneData);
+	}
+
 	static saveZones() {
 		if (!this.mapZoneData) return;
 		this.mapZoneData.dataTimestamp = Date.now();
 		//@ts-expect-error API name not recognized
 		MomentumTimerAPI.SaveZoneDefs(this.mapZoneData);
-		// reload zones
 	}
 
 	static cancelEdit() {
 		this.panels.trackList.RemoveAndDeleteChildren();
 		this.mapZoneData = null;
+
+		//@ts-expect-error API name not recognized
+		MomentumTimerAPI.LoadZoneDefs();
+
 		this.initMenu();
 	}
 


### PR DESCRIPTION
This PR improves the following zoning UI features:
-  Ensure correct region menu is shown based on tab selection
-  Zoning edits only reset when "Cancel Edit" is clicked. Closing the zone menu no longer resets zone defs
-  Zones render changes as properties are modified
-  Newly created zones are initialized with default height
-  Picking a corner below the current region bottom updates the region bottom value
-  Point picking mode now shows visualization of region points before region is defined

Requires red changes to render zone visualization while picking points.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
