### PR TITLE
Fix map selector filters AGAIN

### DIFF
--- a/scripts/pages/map-selector/map-selector.js
+++ b/scripts/pages/map-selector/map-selector.js
@@ -20,7 +20,7 @@ class MapSelection {
 		/** @type {Panel} @static */
 		filtersPanel: $('#MapFilters'),
 		/** @type {Button} @static */
-		filtersToggle: $('#FilterToggle'),
+		// filtersToggle: $('#FilterToggle'),
 		/** @type {Button} @static */
 		completedFilterButton: $('#MapCompletedFilterButton'),
 		/** @type {Button} @static */
@@ -80,9 +80,9 @@ class MapSelection {
 
 			$.GetContextPanel().ApplyFilters();
 
-			if ($.persistentStorage.getItem('mapSelector.filtersToggled') ?? false) {
-				$.DispatchEvent('Activated', this.panels.filtersToggle, 'mouse');
-			}
+			// if ($.persistentStorage.getItem('mapSelector.filtersToggled') ?? false) {
+			// $.DispatchEvent('Activated', this.panels.filtersToggle, 'mouse');
+			// }
 
 			$.DispatchEvent('MapSelector_OnLoaded');
 		});


### PR DESCRIPTION
I did the last fix for filters in a rush and didn't test properly, this fixes a JS error getting brought up. I've been really half-assing this since the 0.10.0 version completely rewrites this system. Spent some time just now testing properly, including with persistent storage empty, seems okay now. Sorry about this!