### PR TITLE
vector stuff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2310,9 +2310,9 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
 				"braces": "^3.0.3",

--- a/scripts/util/math.ts
+++ b/scripts/util/math.ts
@@ -2,26 +2,18 @@ export function magnitude(vec: vec2 | vec3): number {
 	return Math.sqrt(sumOfSquares(vec));
 }
 
-export function magnitude2D(vec: vec2): number {
+export function magnitude2D(vec: vec2 | vec3): number {
 	return Math.sqrt(sumOfSquares2D(vec));
-}
-
-export function magnitude3D(vec: vec3): number {
-	return Math.sqrt(sumOfSquares3D(vec));
 }
 
 // Note: Math.hypot performs additional bounds checking on V8 which which makes it considerably
 // slower than below implementations.
-export function sumOfSquares2D(vec: vec2): number {
+export function sumOfSquares2D(vec: vec2 | vec3): number {
 	return vec.x ** 2 + vec.y ** 2;
 }
 
-export function sumOfSquares3D(vec: vec3): number {
-	return vec.x ** 2 + vec.y ** 2 + vec.z ** 2;
-}
-
 export function sumOfSquares(vec: vec2 | vec3): number {
-	return 'z' in vec ? vec.x ** 2 + vec.y ** 2 + vec.z ** 2 : vec.x ** 2 + vec.y ** 2;
+	return 'z' in vec ? vec.x ** 2 + vec.y ** 2 + vec.z ** 2 : sumOfSquares2D(vec);
 }
 
 /**


### PR DESCRIPTION
This pull request updates the vector functions in `math.ts` to be more flexible with respect to vectors in 2D/3D. 2D functions can be called on 3D vectors ignoring the z component. Base functions will handle either 2D or 3D vectors.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
