### PR TITLE
September cleanup part 2

### DIFF
--- a/scripts/hud/comparisons.ts
+++ b/scripts/hud/comparisons.ts
@@ -36,6 +36,7 @@ class HudComparisonsHandler {
 	}
 
 	updateComparisons() {
+		/* TODO
 		const currentData = $.GetContextPanel<HudComparisons>().currentRunData;
 		const currentStats = $.GetContextPanel<HudComparisons>().currentRunStats;
 		const comparisonRun = RunComparisonsAPI.GetLoadedComparison();
@@ -139,5 +140,6 @@ class HudComparisonsHandler {
 						isFirst: true
 					}
 		);
+		*/
 	}
 }

--- a/scripts/hud/spec-info.ts
+++ b/scripts/hud/spec-info.ts
@@ -12,7 +12,7 @@ class HudSpecInfoHandler implements OnPanelLoad {
 	maxNames = GameInterfaceAPI.GetSettingInt('mom_hud_specinfo_names_count');
 
 	constructor() {
-		$.RegisterForUnhandledEvent('MomentumSpectatorTargetChanged', () => this.onSpectatorChanged());
+		$.RegisterForUnhandledEvent('ObserverTargetChanged', () => this.onSpectatorChanged());
 		$.RegisterForUnhandledEvent('MomentumSpectatorUpdate', () => this.onSpectatorChanged());
 		$.RegisterForUnhandledEvent('MomentumSpecListMaxNamesUpdate', (val) => {
 			this.maxNames = val;

--- a/scripts/hud/spectate.ts
+++ b/scripts/hud/spectate.ts
@@ -13,10 +13,11 @@ class HudSpectateHandler {
 		toggleReplayControls: $('#ToggleReplayControls')
 	};
 
+	/* TODO
 	constructor() {
-		$.RegisterForUnhandledEvent('MomentumSpectatorTargetChanged', (type: RunEntityType) =>
-			this.onSpectatorChanged(type)
-		);
+	$.RegisterForUnhandledEvent('MomentumSpectatorTargetChanged', (type: RunEntityType) =>
+		this.onSpectatorChanged(type)
+	);
 	}
 
 	onSpectatorChanged(type: RunEntityType) {
@@ -32,4 +33,5 @@ class HudSpectateHandler {
 			this.panels.indicatorWatchingReplay.visible = isReplay;
 		}
 	}
+	*/
 }

--- a/scripts/hud/speedometer.ts
+++ b/scripts/hud/speedometer.ts
@@ -89,9 +89,6 @@ class SpeedometerHandler {
 		$.RegisterEventHandler('OnSpeedometerUpdate', this.container, (deltaTime: float) =>
 			this.onSpeedometerUpdate(deltaTime)
 		);
-		$.RegisterForUnhandledEvent('OnMomentumZoneChange', (enter, linear, curZone, curTrack, timerState) =>
-			this.onZoneChange(enter, linear, curZone, curTrack, timerState)
-		);
 
 		// color profiles load before speedo settings, so listening to just the speedo settings load event should be enough
 		$.RegisterForUnhandledEvent('OnSpeedometerSettingsLoaded', (succ: boolean) => this.onSettingsUpdate(succ));
@@ -142,6 +139,7 @@ class SpeedometerHandler {
 		this.updateSpeedometersOfType(SpeedometerType.OVERALL_VELOCITY, velocity);
 	}
 
+	/* TODO: replace with updates based on new timer events
 	onZoneChange(enter: boolean, linear: boolean, curZone: int32, _curTrack: int32, timerState: TimerState_OLD) {
 		const startZone = curZone === 1;
 		if (enter && startZone) {
@@ -176,6 +174,7 @@ class SpeedometerHandler {
 			this.updateZoneSpeedometers(actualSpeedAbs, actualSpeedHoriz, false);
 		}
 	}
+	*/
 
 	resetSpeedometerFadeouts() {
 		for (const [type, speedometers] of this.speedometers) {

--- a/scripts/hud/sticky-charge.ts
+++ b/scripts/hud/sticky-charge.ts
@@ -16,13 +16,14 @@ class StickyChargeHandler {
 	};
 
 	constructor() {
-		$.RegisterEventHandler('OnChargeUpdate', this.panels.container, (speed, percentage) =>
-			this.onChargeUpdate(speed, percentage)
+		$.RegisterEventHandler('OnChargeUpdate', this.panels.container, (enabled, speed, percentage) =>
+			this.onChargeUpdate(enabled, speed, percentage)
 		);
-		$.RegisterEventHandler('OnChargeToggled', this.panels.container, (enabled) => this.onChargeToggled(enabled));
 	}
 
-	onChargeUpdate(speed: float, percentage: float) {
+	onChargeUpdate(enabled: boolean, speed: float, percentage: float) {
+		this.panels.chargeMeter.enabled = enabled;
+
 		const chargeUnit = this.panels.cp.stickyChargeUnitType;
 
 		let speedText;
@@ -39,11 +40,5 @@ class StickyChargeHandler {
 
 		this.panels.chargeSpeed.text = speedText;
 		this.panels.chargeMeter.value = percentage;
-	}
-
-	onChargeToggled(enabled: boolean) {
-		if (this.panels.chargeMeter.enabled !== enabled) {
-			this.panels.chargeMeter.enabled = enabled;
-		}
 	}
 }

--- a/scripts/hud/timer.ts
+++ b/scripts/hud/timer.ts
@@ -24,11 +24,6 @@ class HudTimerHandler {
 	constructor() {
 		$.RegisterEventHandler('HudProcessInput', this.panels.cp, () => this.onUpdate());
 		$.RegisterForUnhandledEvent('OnMomentumTimerStateChange', (arg1, arg2) => this.onTimerEvent(arg1, arg2));
-		$.RegisterForUnhandledEvent(
-			'OnMomentumZoneChange',
-			(entering, isLinear, currentZone, currentTrack, timerState) =>
-				this.onZoneChange(entering, isLinear, currentZone, currentTrack, timerState)
-		);
 		$.RegisterForUnhandledEvent('OnSaveStateUpdate', (count, current, usingMenu) =>
 			this.onSaveStateChange(count, current, usingMenu)
 		);
@@ -86,6 +81,7 @@ class HudTimerHandler {
 		this.panels.cp.SetDialogVariableFloat('runtime', MomentumTimerAPI.GetObservedTimerStatus().runTime);
 	}
 
+	/* TODO: replace with updates based on new timer events
 	onZoneChange(enter: any, linear: any, curZone: any, _curTrack: any, timerState: any) {
 		if (timerState === TimerState_OLD.NOT_RUNNING && enter && curZone === 1) {
 			// timer state is not reset on map finished until entering the start zone again (on reset)
@@ -121,6 +117,7 @@ class HudTimerHandler {
 
 		this.prevZone = curZone;
 	}
+	*/
 
 	forceHideComparison() {
 		this.panels.comparison.RemoveClass(FADEOUT_START_CLASS);

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -223,8 +223,6 @@ interface GlobalEventNameMap {
 	 */
 	Toast_Clear: (location?: import('util/toast-manager').ToastLocation) => void;
 
-	MomentumSpectatorTargetChanged: (type: import('common/timer').RunEntityType) => void;
-
 	MomentumSpectatorModeChanged: (mode: SpectateMode) => void;
 
 	MomentumSpecListMaxNamesUpdate: (maxNames: uint32) => void;
@@ -236,25 +234,11 @@ interface GlobalEventNameMap {
 	/** Called whgen lobby-wide spectator state changes */
 	MomentumSpectatorUpdate: () => void;
 
-	/**
-	 * TODO: changing with new zones/timer
-	 * @deprecated
-	 */
-	OnMomentumZoneChange: (
-		entering: boolean,
-		isLinear: boolean,
-		currentZone: int32,
-		currentTrack: int32,
-		timerState: import('common/timer').TimerState_OLD
-	) => void;
-
 	OnMomentumReplayStarted: () => void;
 
 	OnMomentumReplayStopped: () => void;
 
-	OnChargeUpdate: (speedInUps: float, percentageCharge: float) => void;
-
-	OnChargeToggled: (enabled: boolean) => void;
+	OnChargeUpdate: (chargeEnabled: boolean, speedInUps: float, percentageCharge: float) => void;
 
 	OnStickyPanelStateChanged: (
 		panel: Panel,

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -63,11 +63,7 @@ interface RangeColorDisplay extends AbstractPanel<'RangeColorDisplay'> {
 	SetColorNoEvent(color: color): void;
 }
 
-/** Only doing loose type since liable to change in near future. */
-interface HudComparisons extends AbstractHudPanel<'HudComparisons'> {
-	readonly currentRunData: any;
-	readonly currentRunStats: any;
-}
+interface HudComparisons extends AbstractHudPanel<'HudComparisons'> {}
 
 interface MomHudTabMenu extends AbstractHudPanel<'MomHudTabMenu'> {
 	forceCloseTabMenu(): void;


### PR DESCRIPTION
Changes to go with part 2 of the game code cleanup:

- Remove `MomentumSpectatorTargetChanged` in favor of generic `ObserverTargetChanged` (depends on https://github.com/StrataSource/pano-typed/pull/24)
- Remove `currentRunData` and `currentRunStats` from `HudComparisons` (replaced by `MomentumTimer::GetObservedTimerStatus()` and `GetObservedTimerRunSplits()`)
- Remove `OnMomentumZoneChange` (replaced by new timer events)
- Remove `OnChargeToggled` and add `enabled` value to `OnChargeUpdate`