### PR TITLE
Fix points edit with textentry

### DIFF
--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -458,10 +458,23 @@ class ZoneMenuHandler {
 	addPointToList(i: number, point: number[]) {
 		const newRegionPoint = $.CreatePanel('Panel', this.panels.pointsList, `Point ${i}`);
 		newRegionPoint.LoadLayoutSnippet('region-point');
-		newRegionPoint.FindChildTraverse<TextEntry>('PointX').text = point[0].toFixed(2);
-		newRegionPoint.FindChildTraverse<TextEntry>('PointY').text = point[1].toFixed(2);
+
 		const deleteButton = newRegionPoint.FindChildTraverse('DeleteButton');
 		deleteButton.SetPanelEvent('onactivate', () => this.deleteRegionPoint(newRegionPoint));
+
+		const xText = newRegionPoint.FindChildTraverse<TextEntry>('PointX');
+		xText.text = point[0].toFixed(2);
+		xText.SetPanelEvent('ontextentrysubmit', () => {
+			point[0] = Number.parseFloat(xText.text);
+			this.updateZones();
+		});
+
+		const yText = newRegionPoint.FindChildTraverse<TextEntry>('PointY');
+		yText.text = point[1].toFixed(2);
+		yText.SetPanelEvent('ontextentrysubmit', () => {
+			point[1] = Number.parseFloat(yText.text);
+			this.updateZones();
+		});
 	}
 
 	deleteRegionPoint(point: Panel) {

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -191,6 +191,7 @@ $medium: 28px;
 	&__slider {
 		margin: 0;
 		padding: 0;
+		border: 0px; //remove border from settings-slider
 
 		.settings-slider__title {
 			font-size: $small;


### PR DESCRIPTION
This PR fixes an issue with the new pano zoning UI. Points can now be edited after placement with the textentry panels for the respective point.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
