### PR TITLE
Tab menu toggle supporting changes

### DIFF
--- a/layout/pages/settings/input.xml
+++ b/layout/pages/settings/input.xml
@@ -133,7 +133,7 @@
 
 				<Label class="settings-group__subtitle" text="#Common_Multiplayer" />
 
-				<SettingsKeyBinder text="#Keybind_ToggleTimes" bind="+showtimes" tags="leaderboard,tab,times" />
+				<SettingsKeyBinder text="#Keybind_ToggleTimes" bind="mom_toggle_game_menu" tags="leaderboard,tab,times" />
 				<SettingsKeyBinder text="#Keybind_Chat_Message" bind="chat_open" tags="chat,talk" />
 
 				<Label class="settings-group__subtitle" text="#Settings_Keybinds_Utility" />

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -262,9 +262,6 @@ interface GlobalEventNameMap {
 	/** Fired when the HUD Leaderboards panel is closed */
 	HudTabMenu_Closed: () => void;
 
-	/** Fired when the HUD leaderboards panel gains mouse input */
-	HudTabMenu_OnMouseActive: () => void;
-
 	/** Fired when the HUD leaderboards panel should show the end of run panel */
 	EndOfRun_Show: (reason: import('common/timer').EndOfRunShowReason) => void;
 


### PR DESCRIPTION
Small supporting changes related to switching the tab menu to a toggle. The event was unused and is now removed as it does not apply to the toggle pattern.