### PR TITLE
zoning UI cleanup part 1

### DIFF
--- a/layout/hud/tab-menu.xml
+++ b/layout/hud/tab-menu.xml
@@ -52,8 +52,10 @@
 			<Panel class="hud-tab-menu__stats">
 			</Panel>
 			
-			<Panel class="hud-tab-menu__enable-cursor">
-				<ToggleButton id="ZoningToggle" class="button h-align-left hud-tab-menu__zoning-button" convar="mom_zone_edit" />
+			<Panel id="TabMenuFooter" class="hud-tab-menu__enable-cursor">
+				<ConVarEnabler convar="sv_cheats" class="v-align-center" togglevisibility="true">
+					<ToggleButton id="ZoningToggle" class="button hud-tab-menu__zoning-button" convar="mom_zone_edit" />
+				</ConVarEnabler>
 				<Label class="hud-tab-menu__enable-cursor-tip" text="#HudTabMenu_EnableCursorTip"/> 
 			</Panel>
 		</Panel>

--- a/layout/hud/tab-menu.xml
+++ b/layout/hud/tab-menu.xml
@@ -52,7 +52,7 @@
 			<Panel class="hud-tab-menu__stats">
 			</Panel>
 			
-			<Panel id="TabMenuFooter" class="hud-tab-menu__enable-cursor">
+			<Panel id="TabMenuFooter" class="hud-tab-menu__footer">
 				<ConVarEnabler convar="sv_cheats" class="v-align-center" togglevisibility="true">
 					<ToggleButton id="ZoningToggle" class="button hud-tab-menu__zoning-button" convar="mom_zone_edit" />
 				</ConVarEnabler>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -12,8 +12,8 @@
 			<Panel class="zoning__tracklist-track">
 				<Panel id="Entry" class="zoning__tracklist-course-entry">
 					<Button id="CollapseButton" class="zoning__collapse-button">
-						<Image id="TracklistCollapseIcon" class="button__icon zoning__collapse-icon zoning__icon-green" src="file://{images}/add.svg" />
-						<Image id="TracklistExpandIcon" class="button__icon zoning__collapse-icon zoning__icon-red hide" src="file://{images}/subtract.svg" />
+						<Image id="TracklistCollapseIcon" class="button__icon zoning__collapse-icon zoning__icon-green hide" src="file://{images}/add.svg" />
+						<Image id="TracklistExpandIcon" class="button__icon zoning__collapse-icon zoning__icon-red" src="file://{images}/subtract.svg" />
 					</Button>
 					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
 						<Label id="Name" class="zoning__tracklist-label" />
@@ -32,8 +32,8 @@
 			<Panel class="zoning__tracklist-segment">
 				<Panel id="Entry" class="zoning__tracklist-course-entry">
 					<Button id="CollapseButton" class="zoning__collapse-button">
-						<Image id="TracklistCollapseIcon" class="button__icon zoning__collapse-icon zoning__icon-green" src="file://{images}/add.svg" />
-						<Image id="TracklistExpandIcon" class="button__icon zoning__collapse-icon zoning__icon-red hide" src="file://{images}/subtract.svg" />
+						<Image id="TracklistCollapseIcon" class="button__icon zoning__collapse-icon zoning__icon-green hide" src="file://{images}/add.svg" />
+						<Image id="TracklistExpandIcon" class="button__icon zoning__collapse-icon zoning__icon-red" src="file://{images}/subtract.svg" />
 					</Button>
 					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
 						<Label id="Name" class="zoning__tracklist-label" />

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -146,9 +146,6 @@
 								</DropDown>
 							</Panel>
 					</Panel>
-					<Panel id="GridSlider" class="zoning__property">
-						<SettingsSlider text="#Zoning_GridSnapSize" class="zoning__slider" min="1" max="64" percentage="false" convar="mom_zone_grid" />
-					</Panel>
 					<Panel id="PropertyTabs" class="tabs">
 						<RadioButton group="ZoningRegion" class="tabs__tab" value="Points" selected="true" onactivate="ZoneMenuHandler.showRegionMenu('Points')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionPoints_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 							<Image src="file://{images}/vector-square-close.svg" class="tabs__icon" textureheight="48" />
@@ -234,6 +231,9 @@
 							</Panel>
 						</Panel>
 					</Panel>
+				</Panel>
+				<Panel id="GridSlider" class="zoning__property">
+					<SettingsSlider text="#Zoning_GridSnapSize" class="zoning__slider" min="1" max="64" percentage="false" convar="mom_zone_grid" />
 				</Panel>
 			</Panel>
 		</Panel>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -18,6 +18,9 @@
 					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
 						<Label id="Name" class="zoning__tracklist-label" />
 					</RadioButton>
+					<Button id="DeleteButton" class="zoning__tracklist-delete hide">
+						<Image class="zoning__tracklist-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
+					</Button>
 				</Panel>
 				<Panel id="ChildContainer" class="w-full flow-down">
 					<Panel id="SegmentContainer" class="zoning__list-container" />
@@ -35,6 +38,9 @@
 					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
 						<Label id="Name" class="zoning__tracklist-label" />
 					</RadioButton>
+					<Button id="DeleteButton" class="zoning__tracklist-delete hide">
+						<Image class="zoning__tracklist-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
+					</Button>
 				</Panel>
 				<Panel id="ChildContainer" class="w-full flow-down">
 					<Panel id="CheckpointContainer" class="zoning__list-container" />
@@ -48,6 +54,9 @@
 					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
 						<Label id="Name" class="zoning__tracklist-label" />
 					</RadioButton>
+					<Button id="DeleteButton" class="zoning__tracklist-delete hide">
+						<Image class="zoning__tracklist-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
+					</Button>
 				</Panel>
 			</Panel>
 		</snippet>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -22,14 +22,23 @@
 						<Image class="zoning__tracklist-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
 					</Button>
 				</Panel>
-				<Panel id="ChildContainer" class="w-full flow-down">
-					<Panel id="SegmentContainer" class="zoning__list-container" />
-					<Panel id="EndZoneContainer" class="zoning__list-container" />
+				<Panel id="ChildContainer" class="zoning__list-container">
+					<Panel id="SegmentContainer" class="w-full flow-down" />
+					<Button id="AddSegmentButton" class="zoning__add-button">
+						<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewSegment" />
+					</Button>
+					<Panel id="EndZoneContainer" class="w-full flow-down" />
+					<Button id="AddEndZoneButton" class="zoning__add-button">
+						<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewEndZone" />
+					</Button>
 				</Panel>
+				<Button id="AddBonusButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addBonus()">
+					<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewBonus" />
+				</Button>
 			</Panel>
 		</snippet>
 		<snippet name="tracklist-segment">
-			<Panel class="zoning__tracklist-segment">
+			<Panel class="w-full flow-down">
 				<Panel id="Entry" class="zoning__tracklist-course-entry">
 					<Button id="CollapseButton" class="zoning__collapse-button">
 						<Image id="TracklistCollapseIcon" class="button__icon zoning__collapse-icon zoning__icon-green hide" src="file://{images}/add.svg" />
@@ -42,14 +51,20 @@
 						<Image class="zoning__tracklist-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
 					</Button>
 				</Panel>
-				<Panel id="ChildContainer" class="w-full flow-down">
-					<Panel id="CheckpointContainer" class="zoning__list-container" />
-					<Panel id="CancelContainer" class="zoning__list-container" />
+				<Panel id="ChildContainer" class="zoning__list-container">
+					<Panel id="CheckpointContainer" class="zoning__tracklist-checkpoint" />
+					<Button id="AddCheckpointButton" class="zoning__add-button">
+						<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewCheckpoint" />
+					</Button>
+					<Panel id="CancelContainer" class="zoning__tracklist-checkpoint" />
+					<Button id="AddCancelZoneButton" class="zoning__add-button">
+						<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewCancelZone" />
+					</Button>
 				</Panel>
 			</Panel>
 		</snippet>
 		<snippet name="tracklist-checkpoint">
-			<Panel class="zoning__tracklist-checkpoint">
+			<Panel class="w-full flow-down">
 				<Panel id="Entry" class="zoning__tracklist-course-entry">
 					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
 						<Label id="Name" class="zoning__tracklist-label" />
@@ -251,7 +266,7 @@
 				<Label class="button__text" text="#Zoning_Save" />
 			</Button>
 			<Button class="button ml-2 h-align-right" onactivate="ZoneMenuHandler.cancelEdit()">
-				<Label class="button__text" text="#Zoning_CancelEdit" />
+				<Label class="button__text" text="#Zoning_Discard" />
 			</Button>
 		</Panel>
 	</ZoneMenu>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -94,14 +94,6 @@
             	<!-- Populated in js -->
         	</Panel>
 		</Panel>
-		<Panel class="zoning__button-box">
-			<Button id="NewZoneButton" class="button button--blue ml-2 h-align-right" onactivate="ZoneMenuHandler.showAddMenu()">
-				<Label class="button__text" text="#Zoning_New" />
-			</Button>
-			<Button class="button button--red ml-2 h-align-right" onactivate="ZoneMenuHandler.showDeletePopup()">
-				<Label class="button__text" text="#Zoning_Delete" />
-			</Button>
-		</Panel>
 		<Label id="PropertiesLabel" class="zoning__header" text="#Zoning_PropertiesLabel" />
 		<Panel id="PropertiesContainer" class="zoning__menu-section">
 			<Panel id="TrackProperties" class="zoning__property-container">

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -86,7 +86,7 @@ class ZoneMenuHandler {
 		segment: null as Segment | null,
 		zone: null as Zone | null
 	};
-	deleteButton: Button | null;
+	activeDeleteButton: Button | null;
 	mapZoneData: MapZones | null;
 	filternameList: string[] | null;
 	teleDestList: string[] | null;
@@ -166,6 +166,7 @@ class ZoneMenuHandler {
 		if (this.panels.trackList?.GetChildCount()) {
 			this.panels.trackList.RemoveAndDeleteChildren();
 		}
+		this.activeDeleteButton = null;
 	}
 
 	toggleCollapse(container: GenericPanel, expandIcon: Image, collapseIcon: Image) {
@@ -415,9 +416,9 @@ class ZoneMenuHandler {
 		this.panels.propertiesSegment.visible = !validity.zone && validity.segment;
 		this.panels.propertiesZone.visible = validity.zone;
 
-		this.deleteButton?.SetHasClass('hide', true);
+		this.activeDeleteButton?.SetHasClass('hide', true);
 		deleteButton?.SetHasClass('hide', false);
-		this.deleteButton = deleteButton;
+		this.activeDeleteButton = deleteButton;
 
 		this.populateZoneProperties();
 		this.populateSegmentProperties();
@@ -959,7 +960,7 @@ class ZoneMenuHandler {
 			}
 		}
 
-		this.deleteButton = null;
+		this.activeDeleteButton = null;
 		//hack: this can be a little more surgical
 		this.panels.trackList.RemoveAndDeleteChildren();
 		this.initMenu();

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -911,31 +911,6 @@ class ZoneMenuHandler {
 		);
 	}
 
-	/*showAddMenu() {
-		UiToolkitAPI.ShowSimpleContextMenu('NewZoneButton', '', [
-			{
-				label: $.Localize('#Zoning_Bonus'),
-				jsCallback: () => this.addBonus()
-			},
-			{
-				label: $.Localize('#Zoning_Segment'),
-				jsCallback: () => this.addSegment()
-			},
-			{
-				label: $.Localize('#Zoning_Checkpoint'),
-				jsCallback: () => this.addCheckpoint()
-			},
-			{
-				label: $.Localize('#Zoning_EndZone'),
-				jsCallback: () => this.addEndZone(this.selectedZone.track)
-			},
-			{
-				label: $.Localize('#Zoning_CancelZone'),
-				jsCallback: () => this.addCancelZone()
-			}
-		]);
-	}*/
-
 	showDeletePopup() {
 		UiToolkitAPI.ShowGenericPopupTwoOptionsBgStyle(
 			$.Localize('#Zoning_Delete'),

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -262,7 +262,7 @@ class ZoneMenuHandler {
 		} else {
 			addSegmentButton.SetPanelEvent('onactivate', () => this.addSegment());
 		}
-		addEndZoneButton.SetPanelEvent('onactivate', () => this.addEndZone());
+		addEndZoneButton.SetPanelEvent('onactivate', () => this.addEndZone(entry));
 		if (entry.zones.end) {
 			addEndZoneButton.SetHasClass('hide', true);
 		}
@@ -859,36 +859,35 @@ class ZoneMenuHandler {
 		this.updateZones();
 	}
 
-	addEndZone() {
+	addEndZone(track: MainTrack | BonusTrack) {
+		// TODO: fix this seleciton logic
 		if (!this.mapZoneData || !this.isSelectionValid().track) return;
 		if (this.isSelectionValid().defragBonus) {
 			$.Warning('Defrag Bonus must share zones with Main track!');
 			return;
 		}
 		const endZone = this.createZone();
-		this.selectedZone.track.zones.end = endZone;
+		track.zones.end = endZone;
 
 		let trackPanel: Panel;
-		if (this.selectedZone.track === this.mapZoneData.tracks.main) {
+		if (track === this.mapZoneData.tracks.main) {
 			trackPanel = this.panels.trackList.GetChild(0);
 		} else {
-			const bonusId = this.mapZoneData.tracks.bonuses.indexOf(this.selectedZone.track);
+			const bonusId = this.mapZoneData.tracks.bonuses.indexOf(track);
 			trackPanel = this.panels.trackList.GetChild(1 + bonusId);
 		}
 		const endZoneContainer = trackPanel.FindChildTraverse('EndZoneContainer');
 		const oldEnd = endZoneContainer.GetChild(0);
 		if (oldEnd) {
 			const selectButton = oldEnd.FindChildTraverse('SelectButton');
-			selectButton.SetPanelEvent('onactivate', () =>
-				this.updateSelection(this.selectedZone.track, null, endZone)
-			);
+			selectButton.SetPanelEvent('onactivate', () => this.updateSelection(track, null, endZone));
 		} else {
 			this.addTracklistEntry(
 				endZoneContainer,
 				$.Localize('#Zoning_EndZone'),
 				TracklistSnippet.CHECKPOINT,
 				{
-					track: this.selectedZone.track,
+					track: track,
 					segment: null,
 					zone: endZone
 				},
@@ -898,7 +897,7 @@ class ZoneMenuHandler {
 
 		trackPanel.FindChildTraverse('AddEndZoneButton').SetHasClass('hide', true);
 
-		this.updateSelection(this.selectedZone.track, null, endZone);
+		this.updateSelection(track, null, endZone);
 
 		this.updateZones();
 	}
@@ -961,7 +960,7 @@ class ZoneMenuHandler {
 			},
 			{
 				label: $.Localize('#Zoning_EndZone'),
-				jsCallback: () => this.addEndZone()
+				jsCallback: () => this.addEndZone(this.selectedZone.track)
 			},
 			{
 				label: $.Localize('#Zoning_CancelZone'),

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -740,6 +740,15 @@ class ZoneMenuHandler {
 			`${$.Localize('#Zoning_Bonus')} ${this.mapZoneData.tracks.bonuses.length}`
 		);
 
+		const newBonusPanel = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses.length);
+		const segmentContainer = newBonusPanel.FindChildTraverse('SegmentContainer');
+		const checkpointContainer = segmentContainer.FindChildTraverse('CheckpointContainer');
+		const selectButton = checkpointContainer.FindChildTraverse<ToggleButton>('SelectButton');
+
+		selectButton.SetSelected(true);
+
+		this.updateSelection(bonus, bonus.zones.segments[0], bonus.zones.segments[0].checkpoints[0]);
+
 		this.updateZones();
 	}
 
@@ -765,11 +774,20 @@ class ZoneMenuHandler {
 			segment: newSegment,
 			zone: null
 		});
-		this.addTracklistEntry(list, $.Localize('#Zoning_Start_Stage'), TracklistSnippet.CHECKPOINT, {
-			track: this.selectedZone.track,
-			segment: newSegment,
-			zone: newSegment.checkpoints[0]
-		});
+		const checkpointContainer = childContainer.FindChildTraverse<Panel>('CheckpointContainer');
+		this.addTracklistEntry(
+			checkpointContainer,
+			$.Localize('#Zoning_Start_Stage'),
+			TracklistSnippet.CHECKPOINT,
+			{
+				track: this.selectedZone.track,
+				segment: newSegment,
+				zone: newSegment.checkpoints[0]
+			},
+			true
+		);
+
+		this.updateSelection(this.selectedZone.track, newSegment, newSegment.checkpoints[0]);
 
 		this.updateZones();
 	}
@@ -795,11 +813,19 @@ class ZoneMenuHandler {
 		const selectedSegment = trackPanel.FindChildTraverse('SegmentContainer').GetChild(segmentIndex);
 		const checkpointsList = selectedSegment.FindChildTraverse('CheckpointContainer');
 		const id = `${$.Localize('#Zoning_Checkpoint')} ${this.selectedZone.segment.checkpoints.length - 1}`;
-		this.addTracklistEntry(checkpointsList, id, TracklistSnippet.CHECKPOINT, {
-			track: this.selectedZone.track,
-			segment: this.selectedZone.segment,
-			zone: newZone
-		});
+		this.addTracklistEntry(
+			checkpointsList,
+			id,
+			TracklistSnippet.CHECKPOINT,
+			{
+				track: this.selectedZone.track,
+				segment: this.selectedZone.segment,
+				zone: newZone
+			},
+			true
+		);
+
+		this.updateSelection(this.selectedZone.track, this.selectedZone.segment, newZone);
 
 		this.updateZones();
 	}
@@ -828,12 +854,20 @@ class ZoneMenuHandler {
 				this.updateSelection(this.selectedZone.track, null, endZone)
 			);
 		} else {
-			this.addTracklistEntry(endZoneContainer, $.Localize('#Zoning_EndZone'), TracklistSnippet.CHECKPOINT, {
-				track: this.selectedZone.track,
-				segment: null,
-				zone: endZone
-			});
+			this.addTracklistEntry(
+				endZoneContainer,
+				$.Localize('#Zoning_EndZone'),
+				TracklistSnippet.CHECKPOINT,
+				{
+					track: this.selectedZone.track,
+					segment: null,
+					zone: endZone
+				},
+				true
+			);
 		}
+
+		this.updateSelection(this.selectedZone.track, null, endZone);
 
 		this.updateZones();
 	}
@@ -863,11 +897,19 @@ class ZoneMenuHandler {
 		const selectedSegment = trackPanel.FindChildTraverse('SegmentContainer').GetChild(segmentIndex);
 		const cancelList = selectedSegment.FindChildTraverse('CancelContainer');
 		const id = `${$.Localize('#Zoning_CancelZone')} ${this.selectedZone.segment.cancel.length}`;
-		this.addTracklistEntry(cancelList, id, TracklistSnippet.CHECKPOINT, {
-			track: this.selectedZone.track,
-			segment: this.selectedZone.segment,
-			zone: newZone
-		});
+		this.addTracklistEntry(
+			cancelList,
+			id,
+			TracklistSnippet.CHECKPOINT,
+			{
+				track: this.selectedZone.track,
+				segment: this.selectedZone.segment,
+				zone: newZone
+			},
+			true
+		);
+
+		this.updateSelection(this.selectedZone.track, this.selectedZone.segment, newZone);
 
 		this.updateZones();
 	}

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -35,6 +35,36 @@ enum RegionMenu {
 	RESET = 'Reset'
 }
 
+export enum PickType {
+	NONE = 0,
+	CORNER = 1,
+	BOTTOM = 2,
+	HEIGHT = 3,
+	SAFE_HEIGHT = 4,
+	TELE_DEST_POS = 5,
+	TELE_DEST_YAW = 6
+}
+
+export enum RegionRenderMode {
+	NONE = 0,
+	START = 1,
+	START_WITH_SAFE_HEIGHT = 2,
+	TRACK_SWITCH = 3,
+	END = 4,
+	MAJOR_CHECKPOINT = 5,
+	MINOR_CHECKPOINT = 6,
+	CANCEL = 7
+}
+
+export enum RegionPolygonProblem {
+	INVALID_INPUT = -1,
+	NONE = 0,
+	POINTS_TOO_CLOSE = 1,
+	ANGLE_TOO_SMALL = 2,
+	COLINEAR_POINTS = 3,
+	SELF_INTERSECTING = 4
+}
+
 @PanelHandler()
 class ZoneMenuHandler {
 	readonly panels = {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -266,8 +266,6 @@ class ZoneMenuHandler {
 			collapseButton.SetPanelEvent('onactivate', () =>
 				this.toggleCollapse(childContainer, expandIcon, collapseIcon)
 			);
-
-			this.toggleCollapse(childContainer, expandIcon, collapseIcon);
 		}
 
 		const selectButton = newTracklistPanel.FindChildTraverse<ToggleButton>('SelectButton');

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -195,6 +195,8 @@ class ZoneMenuHandler {
 		if (!this.mapZoneData || this.panels.trackList.GetChildCount() === 0) {
 			this.initMenu();
 		}
+
+		this.drawZones();
 	}
 
 	hideZoneMenu() {
@@ -458,6 +460,8 @@ class ZoneMenuHandler {
 		this.populateZoneProperties();
 		this.populateSegmentProperties();
 		this.populateTrackProperties();
+
+		this.drawZones();
 	}
 
 	populateZoneProperties() {
@@ -497,7 +501,7 @@ class ZoneMenuHandler {
 		const filterIndex = this.panels.filterSelect.GetSelected()?.GetAttributeInt('value', 0);
 		this.selectedZone.zone.filtername = filterIndex ? this.filternameList[filterIndex] : '';
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	populateRegionProperties() {
@@ -533,7 +537,7 @@ class ZoneMenuHandler {
 		this.panels.regionSelect.SetSelectedIndex(this.selectedZone.zone.regions.length - 1);
 		this.populateRegionProperties();
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	deleteRegion() {
@@ -546,7 +550,7 @@ class ZoneMenuHandler {
 		this.panels.regionSelect.SetSelectedIndex(0);
 		this.populateRegionProperties();
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	teleportToRegion() {
@@ -583,14 +587,14 @@ class ZoneMenuHandler {
 		xText.text = point[0].toFixed(2);
 		xText.SetPanelEvent('ontextentrysubmit', () => {
 			point[0] = Number.parseFloat(xText.text);
-			this.updateZones();
+			this.drawZones();
 		});
 
 		const yText = newRegionPoint.FindChildTraverse<TextEntry>('PointY');
 		yText.text = point[1].toFixed(2);
 		yText.SetPanelEvent('ontextentrysubmit', () => {
 			point[1] = Number.parseFloat(yText.text);
-			this.updateZones();
+			this.drawZones();
 		});
 	}
 
@@ -602,7 +606,7 @@ class ZoneMenuHandler {
 		this.selectedZone.zone?.regions[index].points.splice(n, 1);
 		point.DeleteAsync(0);
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	pickBottom() {
@@ -618,7 +622,7 @@ class ZoneMenuHandler {
 		const bottom = Number.parseFloat(this.panels.regionBottom.text);
 		region.bottom = Number.isNaN(bottom) ? 0 : bottom;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	pickHeight() {
@@ -634,7 +638,7 @@ class ZoneMenuHandler {
 		const height = Number.parseFloat(this.panels.regionHeight.text);
 		region.height = Number.isNaN(height) ? 0 : height;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	pickSafeHeight() {
@@ -650,7 +654,7 @@ class ZoneMenuHandler {
 		const height = Number.parseFloat(this.panels.regionSafeHeight.text);
 		region.safeHeight = Number.isNaN(height) ? 0 : height;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	pickTeleDestPos() {
@@ -702,7 +706,7 @@ class ZoneMenuHandler {
 			this.setRegionTPDestTextEntriesActive(false);
 		}
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	setRegionTeleDestOrientation() {
@@ -718,7 +722,7 @@ class ZoneMenuHandler {
 		region.teleDestPos = [Number.isNaN(x) ? 0 : x, Number.isNaN(y) ? 0 : y, Number.isNaN(z) ? 0 : z];
 		region.teleDestYaw = Number.isNaN(yaw) ? 0 : yaw;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	setRegionTPDestTextEntriesActive(enable: boolean) {
@@ -791,7 +795,7 @@ class ZoneMenuHandler {
 				break;
 		}
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	onPickCanceled() {
@@ -804,7 +808,7 @@ class ZoneMenuHandler {
 			if (region.points.length > 2 && region.height === 0) this.pickHeight();
 		}
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	addBonus() {
@@ -1000,7 +1004,7 @@ class ZoneMenuHandler {
 		this.panels.trackList.RemoveAndDeleteChildren();
 		this.initMenu();
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	setMaxVelocity() {
@@ -1008,14 +1012,14 @@ class ZoneMenuHandler {
 		const velocity = Number.parseFloat(this.panels.maxVelocity.text);
 		this.mapZoneData.maxVelocity = !Number.isNaN(velocity) && velocity > 0 ? velocity : 0;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	setStageEndAtStageStarts() {
 		if (!this.isSelectionValid().track || !('stagesEndAtStageStarts' in this.selectedZone.track)) return;
 		this.selectedZone.track.stagesEndAtStageStarts = this.panels.stagesEndAtStageStarts.checked;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	showDefragFlagMenu() {
@@ -1072,28 +1076,28 @@ class ZoneMenuHandler {
 		// keep select button aligned with other tracks
 		trackPanel.FindChildTraverse('Entry').SetHasClass('zoning__tracklist-checkpoint', true);
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	setLimitGroundSpeed() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.limitStartGroundSpeed = this.panels.limitGroundSpeed.checked;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	setCheckpointsOrdered() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.checkpointsOrdered = this.panels.checkpointsOrdered.checked;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	setCheckpointsRequired() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.checkpointsRequired = this.panels.checkpointsRequired.checked;
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	setSegmentName() {
@@ -1102,7 +1106,7 @@ class ZoneMenuHandler {
 		// feat: later
 		// update segment name in trasklist tree
 
-		this.updateZones();
+		this.drawZones();
 	}
 
 	showRegionMenu(menu?: RegionMenu) {
@@ -1117,13 +1121,55 @@ class ZoneMenuHandler {
 		this.panels.teleportSection.visible = menu === RegionMenu.TELEPORT;
 	}
 
-	updateZones() {
+	drawZones() {
 		if (!this.mapZoneData) return;
+		if (!this.selectedZone) return;
 
-		// future: validation here
+		const renderRegions: ZoneEditorRegion[] = [];
 
-		this.mapZoneData.dataTimestamp = Date.now();
-		MomentumTimerAPI.SetActiveZoneDefs(this.mapZoneData);
+		const validity = this.isSelectionValid();
+		const regionIndex = validity.zone ? this.panels.regionSelect.GetSelected().GetAttributeInt('value', -1) : -1;
+
+		for (const [segmentNumber, segment] of this.selectedZone.track.zones.segments.entries()) {
+			if (segment.checkpoints.length > 0) {
+				for (const [checkpointNumber, checkpoint] of segment.checkpoints.entries()) {
+					for (const region of checkpoint.regions) {
+						renderRegions.push({
+							region: region,
+							renderMode:
+								checkpointNumber === 0
+									? segmentNumber === 0
+										? RegionRenderMode.START
+										: RegionRenderMode.MAJOR_CHECKPOINT
+									: RegionRenderMode.MINOR_CHECKPOINT,
+							editing: validity.zone && region === this.selectedZone.zone.regions[regionIndex]
+						});
+					}
+				}
+			}
+			if (segment.cancel && segment.cancel.length > 0) {
+				for (const cancel of segment.cancel) {
+					for (const region of cancel.regions) {
+						renderRegions.push({
+							region: region,
+							renderMode: RegionRenderMode.CANCEL,
+							editing: validity.zone && region === this.selectedZone.zone.regions[regionIndex]
+						});
+					}
+				}
+			}
+		}
+		if (this.selectedZone.track.zones.end && this.selectedZone.track.zones.end.regions.length > 0) {
+			for (const region of this.selectedZone.track.zones.end.regions) {
+				renderRegions.push({
+					region: region,
+					renderMode: RegionRenderMode.END,
+					editing: validity.zone && region === this.selectedZone.zone.regions[regionIndex]
+				});
+			}
+		}
+
+		this.panels.zoningMenu.drawRegions(renderRegions);
 	}
 
 	saveZones() {
@@ -1133,12 +1179,13 @@ class ZoneMenuHandler {
 	}
 
 	cancelEdit() {
+		this.activeDeleteButton = null;
 		this.panels.trackList.RemoveAndDeleteChildren();
 		this.mapZoneData = null;
 
-		MomentumTimerAPI.LoadZoneDefs();
-
+		MomentumTimerAPI.LoadZoneDefs(false);
 		this.initMenu();
+		this.drawZones();
 	}
 
 	isSelectionValid() {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -164,10 +164,10 @@ class ZoneMenuHandler {
 		container.SetHasClass('hide', !shouldExpand);
 		expandIcon.SetHasClass('hide', !shouldExpand);
 		collapseIcon.SetHasClass('hide', shouldExpand);
-		const parent = container.GetParent();
+		/*const parent = container.GetParent();
 		if (parent && parent.HasClass('zoning__tracklist-segment')) {
 			parent.SetHasClass('zoning__tracklist-segment--dark', shouldExpand);
-		}
+		}*/
 	}
 
 	createTrackEntry(parent: GenericPanel, entry: MainTrack | BonusTrack, name: string) {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -6,6 +6,7 @@ const FORMAT_VERSION = 1;
 
 const FLT_MAX = 3.402823466e38;
 const DEFAULT_HEIGHT = 160;
+const ANGLE_SNAP = 15;
 
 export interface EntityList {
 	filter: string[];
@@ -792,8 +793,8 @@ class ZoneMenuHandler {
 				break;
 
 			case PickType.TELE_DEST_YAW:
-				region.teleDestYaw = MomentumPlayerAPI.GetAngles().y;
-				this.panels.regionTPYaw.text = region.teleDestYaw.toFixed(2);
+				region.teleDestYaw = Math.floor(MomentumPlayerAPI.GetAngles().y / ANGLE_SNAP + 0.5) * ANGLE_SNAP;
+				this.panels.regionTPYaw.text = region.teleDestYaw.toFixed(0);
 				break;
 		}
 

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -204,6 +204,8 @@ class ZoneMenuHandler {
 			this.panels.trackList.RemoveAndDeleteChildren();
 		}
 		this.activeDeleteButton = null;
+
+		MomentumTimerAPI.SetActiveZoneDefs(this.mapZoneData);
 	}
 
 	toggleCollapse(container: GenericPanel, expandIcon: Image, collapseIcon: Image) {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -1091,6 +1091,8 @@ class ZoneMenuHandler {
 		const trackPanel = this.panels.trackList.GetChild(1 + bonusIndex);
 		trackPanel.FindChildTraverse('CollapseButton').visible = false;
 		trackPanel.FindChildTraverse('ChildContainer').RemoveAndDeleteChildren();
+		// keep select button aligned with other tracks
+		trackPanel.FindChildTraverse('Entry').SetHasClass('zoning__tracklist-checkpoint', true);
 
 		this.updateZones();
 	}

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -28,16 +28,6 @@ enum DefragFlags {
 	BFG = 1 << 5
 }
 
-enum PickType {
-	NONE,
-	CORNER,
-	BOTTOM,
-	HEIGHT,
-	SAFE_HEIGHT,
-	TELE_DEST_POS,
-	TELE_DEST_YAW
-}
-
 enum RegionMenu {
 	POINTS = 'Points',
 	PROPERTIES = 'Properties',
@@ -574,7 +564,7 @@ class ZoneMenuHandler {
 			region.points.length = 0;
 			this.panels.pointsList.RemoveAndDeleteChildren();
 		}
-		this.panels.zoningMenu.startPointPick(true);
+		this.panels.zoningMenu.startPointPick(this.pointPick);
 
 		this.panels.zoningMenu.setCornersFromRegion(region);
 	}
@@ -614,7 +604,7 @@ class ZoneMenuHandler {
 
 	pickBottom() {
 		this.pointPick = PickType.BOTTOM;
-		this.panels.zoningMenu.startPointPick(false);
+		this.panels.zoningMenu.startPointPick(this.pointPick);
 	}
 
 	setRegionBottom() {
@@ -630,7 +620,7 @@ class ZoneMenuHandler {
 
 	pickHeight() {
 		this.pointPick = PickType.HEIGHT;
-		this.panels.zoningMenu.startPointPick(false);
+		this.panels.zoningMenu.startPointPick(this.pointPick);
 	}
 
 	setRegionHeight() {
@@ -646,7 +636,7 @@ class ZoneMenuHandler {
 
 	pickSafeHeight() {
 		this.pointPick = PickType.SAFE_HEIGHT;
-		this.panels.zoningMenu.startPointPick(false);
+		this.panels.zoningMenu.startPointPick(this.pointPick);
 	}
 
 	setRegionSafeHeight() {
@@ -662,12 +652,12 @@ class ZoneMenuHandler {
 
 	pickTeleDestPos() {
 		this.pointPick = PickType.TELE_DEST_POS;
-		this.panels.zoningMenu.startPointPick(false);
+		this.panels.zoningMenu.startPointPick(this.pointPick);
 	}
 
 	pickTeleDestYaw() {
 		this.pointPick = PickType.TELE_DEST_YAW;
-		this.panels.zoningMenu.startPointPick(false);
+		this.panels.zoningMenu.startPointPick(this.pointPick);
 	}
 
 	updateRegionTPDest() {

--- a/scripts/types-mom/apis.d.ts
+++ b/scripts/types-mom/apis.d.ts
@@ -256,7 +256,7 @@ declare namespace MomentumTimerAPI {
 	function SaveZoneDefs(zoneDefs: Zones): void;
 
 	/** Load ZoneDefs from newzones file */
-	function LoadZoneDefs(): void;
+	function LoadZoneDefs(useLocal: boolean): boolean;
 }
 
 declare namespace MapCacheAPI {

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -167,8 +167,18 @@ interface ZoneEditorLimits {
 	MAX_ZONES_ALL_TRACKS: number;
 }
 
+declare const enum PickType {
+	NONE = 0,
+	CORNER = 1,
+	BOTTOM = 2,
+	HEIGHT = 3,
+	SAFE_HEIGHT = 4,
+	TELE_DEST_POS = 5,
+	TELE_DEST_YAW = 6
+}
+
 interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {
-	startPointPick(multiPick: boolean): void;
+	startPointPick(mode: PickType): void;
 
 	getEntityList(): import('pages/zoning/zoning').EntityList;
 

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -132,29 +132,9 @@ interface MomHudDFJump extends AbstractHudPanel<'MomHudDFJump'> {}
 
 interface MomHudSynchronizer extends AbstractHudPanel<'MomHudSynchronizer'> {}
 
-declare const enum RegionRenderMode {
-	NONE = 0,
-	START = 1,
-	START_WITH_SAFE_HEIGHT = 2,
-	TRACK_SWITCH = 3,
-	END = 4,
-	MAJOR_CHECKPOINT = 5,
-	MINOR_CHECKPOINT = 6,
-	CANCEL = 7
-}
-
-declare const enum RegionPolygonProblem {
-	INVALID_INPUT = -1,
-	NONE = 0,
-	POINTS_TOO_CLOSE = 1,
-	ANGLE_TOO_SMALL = 2,
-	COLINEAR_POINTS = 3,
-	SELF_INTERSECTING = 4
-}
-
 interface ZoneEditorRegion {
 	region: import('common/web').Region;
-	renderMode: RegionRenderMode;
+	renderMode: import('pages/zoning/zoning').RegionRenderMode;
 	editing: boolean;
 }
 
@@ -167,18 +147,8 @@ interface ZoneEditorLimits {
 	MAX_ZONES_ALL_TRACKS: number;
 }
 
-declare const enum PickType {
-	NONE = 0,
-	CORNER = 1,
-	BOTTOM = 2,
-	HEIGHT = 3,
-	SAFE_HEIGHT = 4,
-	TELE_DEST_POS = 5,
-	TELE_DEST_YAW = 6
-}
-
 interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {
-	startPointPick(mode: PickType): void;
+	startPointPick(mode: import('pages/zoning/zoning').PickType): void;
 
 	getEntityList(): import('pages/zoning/zoning').EntityList;
 
@@ -188,7 +158,10 @@ interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {
 
 	drawRegions(editorRegions: ZoneEditorRegion[]): void;
 
-	validateRegionPolygon(points: import('common/web').Vector2D[], closed: boolean): RegionPolygonProblem;
+	validateRegionPolygon(
+		points: import('common/web').Vector2D[],
+		closed: boolean
+	): import('pages/zoning/zoning').RegionPolygonProblem;
 
 	getZoningLimits(): ZoneEditorLimits;
 }

--- a/styles/hud/tab-menu.scss
+++ b/styles/hud/tab-menu.scss
@@ -24,6 +24,10 @@
 		margin: 32px;
 		horizontal-align: left;
 		vertical-align: top;
+
+		& > .hud-tab-menu__wrapper > .hud-tab-menu__header {
+			visibility: collapse;
+		}
 	}
 
 	&__wrapper {

--- a/styles/hud/tab-menu.scss
+++ b/styles/hud/tab-menu.scss
@@ -91,6 +91,9 @@
 	&__zoning-button {
 		height: $button-height;
 		width: height-percentage(100%);
+		margin: 2px;
+		horizontal-align: left;
+		vertical-align: center;
 		background-position: center;
 		background-repeat: no-repeat;
 		background-image: url('file://{images}/pencil-outline.svg');
@@ -102,7 +105,7 @@
 		}
 	}
 
-	&__enable-cursor {
+	&__footer {
 		border-top: 1px solid rgba(0, 0, 0, 0.4);
 		width: 100%;
 		padding-right: 24px;

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -1,6 +1,7 @@
 @use '../../config' as *;
 @use 'sass:color';
 
+$smaller: 12px;
 $small: 16px;
 $medium: 28px;
 
@@ -59,17 +60,18 @@ $medium: 28px;
 	}
 
 	&__tracklist-button {
-		padding: 3px 5px;
+		margin: 2px 2px;
+		padding: 2px 4px;
 
 		&:selected {
-			padding: 2px 4px;
+			margin: 1px 1px;
 			background-color: $light-200;
 			border: 1px solid $gray-800;
 			border-radius: 6px;
 		}
 
 		&:hover {
-			padding: 2px 4px;
+			margin: 1px 1px;
 			border: 1px solid $gray-800;
 			border-radius: 6px;
 		}
@@ -95,32 +97,40 @@ $medium: 28px;
 		}
 	}
 
+	&__add-button {
+		width: fit-children;
+		horizontal-align: left;
+		flow-children: right;
+		margin: 2px 20px;
+		padding: 2px 4px;
+
+		> Image {
+		}
+	}
+
 	&__tracklist-track {
 		width: 100%;
-		margin-bottom: 1px;
-		padding: 2px 6px;
 		flow-children: down;
 	}
 
 	&__tracklist-label {
 		font-size: $small;
+
+		&--add {
+			font-size: $smaller;
+			font-style: italic;
+			color: $gray-800;
+		}
 	}
 
 	&__tracklist-segment {
 		width: 100%;
-		margin-bottom: 1px;
-		padding: 2px 4px;
-		border-radius: 6px;
 		flow-children: down;
-
-		&--dark {
-			//background-color: $dark-100;
-		}
 	}
 
 	&__tracklist-checkpoint {
 		width: 100%;
-		margin: 2px 0px;
+		margin: 0px 18px;
 		flow-children: down;
 	}
 
@@ -131,8 +141,7 @@ $medium: 28px;
 
 	&__list-container {
 		width: 100%;
-		margin-left: 12px;
-		padding-left: 8px;
+		margin-left: 18px;
 		flow-children: down;
 	}
 

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -94,7 +94,7 @@ $medium: 28px;
 		flow-children: down;
 
 		&--dark {
-			background-color: $dark-700;
+			//background-color: $dark-100;
 		}
 	}
 

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -60,20 +60,18 @@ $medium: 28px;
 	}
 
 	&__tracklist-button {
-		margin: 2px 2px;
+		margin: 1px 1px;
 		padding: 2px 4px;
+		border: 1px none;
+		border-radius: 6px;
 
 		&:selected {
-			margin: 1px 1px;
 			background-color: $light-200;
 			border: 1px solid $gray-800;
-			border-radius: 6px;
 		}
 
 		&:hover {
-			margin: 1px 1px;
 			border: 1px solid $gray-800;
-			border-radius: 6px;
 		}
 	}
 

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -75,6 +75,26 @@ $medium: 28px;
 		}
 	}
 
+	&__tracklist-delete {
+		vertical-align: center;
+		height: 16px;
+		tooltip-position: bottom;
+		transition: background-color 0.1s ease-in 0s;
+
+		&__icon {
+			height: 100%;
+			width: height-percentage(100%);
+			vertical-align: center;
+			horizontal-align: center;
+			img-shadow: $button-icon-shadow;
+			wash-color: $red;
+
+			&:hover {
+				wash-color: $white;
+			}
+		}
+	}
+
 	&__tracklist-track {
 		width: 100%;
 		margin-bottom: 1px;


### PR DESCRIPTION
This pull request implements several changes being tracked here:
https://github.com/momentum-mod/game/issues/2122

This can likely be reviewed by changes rather than by commit, but the history is preserved in case reviewers would like to see how this PR relates to the checklists in issue 2122.

REQUIRES SIMULTANEOUS RED CHANGES

Main changes:
- Only allow zoning UI to be opened when `sv_cheats` is enabled
- Styling improvements to tab menu related to zoning (hide header, padding, footer contents)
- Zoning UI styling improvements (bg colors, padding, indentation)
- Reworked add/delete functionality
  - Buttons inline within tracklist tree
  - Add buttons no longer selection dependent (add checkpoint to arbitrary segment)
- UX improvement for placing corners, set zone height
- Better communication between UI and engine for point placement state

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
