### PR TITLE
Linear map checkpoints

### DIFF
--- a/scripts/common/timer.ts
+++ b/scripts/common/timer.ts
@@ -199,9 +199,10 @@ export function generateSegmentComparisonSplit(
 		comparisonRunSplits.segments[segmentIndex].subsegments[subsegmentIndex].timeReached;
 	const baseSplitTime = getSplitSegmentTime(baseRunSplits, segmentIndex, subsegmentIndex);
 	const comparisonSplitTime = getSplitSegmentTime(comparisonRunSplits, segmentIndex, subsegmentIndex);
+	const isLinear = baseRunSplits.segments.length === 1;
 
 	return {
-		name: getSegmentName(segmentIndex, subsegmentIndex),
+		name: isLinear ? subsegmentIndex.toString() : getSegmentName(segmentIndex, subsegmentIndex),
 		accumulateTime: baseAccumulateTime,
 		time: baseSplitTime,
 		diff: baseAccumulateTime - comparisonAccumulateTime,
@@ -221,9 +222,12 @@ export function generateFinishSplitComparison(
 ): ComparisonSplit {
 	const baseSplitTime = baseRunTime - baseRunSplits.segments.at(-1).subsegments.at(-1).timeReached;
 	const comparisonSplitTime = comparisonRunTime - comparisonRunSplits.segments.at(-1).subsegments.at(-1).timeReached;
+	const isLinear = baseRunSplits.segments.length === 1;
 
 	return {
-		name: baseRunSplits.segments.length.toString(),
+		name: isLinear
+			? baseRunSplits.segments[0].subsegments.length.toString()
+			: baseRunSplits.segments.length.toString(),
 		accumulateTime: baseRunTime,
 		time: baseSplitTime,
 		diff: baseRunTime - comparisonRunTime,

--- a/scripts/hud/comparisons.ts
+++ b/scripts/hud/comparisons.ts
@@ -48,6 +48,8 @@ class HudComparisonsHandler {
 			timerStatus.trackId.type === this.comparison.trackId.type &&
 			timerStatus.trackId.number === this.comparison.trackId.number;
 
+		const isLinear = timerStatus.segmentsCount === 1;
+
 		// TODO: Unordered/optional splits
 		if (timerStatus.state === Timer.TimerState.RUNNING) {
 			if (timerStatus.majorNum <= 1 && timerStatus.minorNum <= 1) {
@@ -62,11 +64,14 @@ class HudComparisonsHandler {
 						timerStatus.minorNum - 1
 					)
 				: {
-						name: Timer.getSegmentName(timerStatus.majorNum - 1, timerStatus.minorNum - 1),
+						name: isLinear
+							? (timerStatus.minorNum - 1).toString()
+							: Timer.getSegmentName(timerStatus.majorNum - 1, timerStatus.minorNum - 1),
 						accumulateTime: timerStatus.runTime
 					};
 
-			this.addComparisonSplit(split, timerStatus.minorNum > 1, hasCompare);
+			const isSubSplit = !isLinear && timerStatus.minorNum > 1;
+			this.addComparisonSplit(split, isSubSplit, hasCompare);
 		} else if (timerStatus.state === Timer.TimerState.FINISHED) {
 			const split = hasCompare
 				? Timer.generateFinishSplitComparison(
@@ -76,7 +81,9 @@ class HudComparisonsHandler {
 						this.comparison.runSplits
 					)
 				: {
-						name: runSplits.segments.length.toString(),
+						name: isLinear
+							? runSplits.segments[0].subsegments.length.toString()
+							: runSplits.segments.length.toString(),
 						accumulateTime: timerStatus.runTime
 					};
 


### PR DESCRIPTION
Checkpoints in linear maps were displaying as 1-1, 1-2, 1-3, etc. in the split comparison UI so I changed it to display just the subsegment number.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
