### PR TITLE
Add subsegment splits to end of run menu

### DIFF
--- a/scripts/pages/end-of-run/end-of-run.ts
+++ b/scripts/pages/end-of-run/end-of-run.ts
@@ -350,8 +350,8 @@ class EndOfRunHandler {
 			shadeAboveToOriginColor: '#ffffff33'
 		};
 
-		let max = 0;
-		let min = 0;
+		let max = Number.MIN_VALUE;
+		let min = Number.MAX_VALUE;
 
 		// Point for each zone
 		const comparisonSplits = comparison.segmentSplits;

--- a/scripts/pages/end-of-run/end-of-run.ts
+++ b/scripts/pages/end-of-run/end-of-run.ts
@@ -398,8 +398,8 @@ class EndOfRunHandler {
 
 		// Now decide whether to increase the number of intervals. This is just based on what looks good to me.
 		let yInterval: number;
-		if (range / scaleFactor >= 2) yInterval = scaleFactor * 2;
-		else if (range / scaleFactor >= 1) yInterval = scaleFactor;
+		if (range / scaleFactor >= 5) yInterval = scaleFactor * 2;
+		else if (range / scaleFactor >= 2.5) yInterval = scaleFactor;
 		else yInterval = scaleFactor / 2;
 
 		// Set the axis


### PR DESCRIPTION
I will follow up with some improvements to the stage checkpoint splits so that they are evenly spaced and the x-axis has the appropriate labels ("4-1", "4-2", etc.)

Linear map:
![image](https://github.com/user-attachments/assets/42c9a1cd-4540-47de-b263-5a4fce892d20)

Staged map:
![image](https://github.com/user-attachments/assets/57f3c2c5-54f5-4f94-aee3-c54eb264d628)

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
