### PR TITLE
Fix handled event regressions

### DIFF
--- a/scripts/hud/df-jump.ts
+++ b/scripts/hud/df-jump.ts
@@ -29,13 +29,16 @@ class DFJumpHandler {
 			onLoad: () => this.onMapInit(),
 			events: [
 				{
-					event: 'DFJumpDataUpdate',
-					callback: (releaseDelay, pressDelay, totalDelay) =>
-						this.onDFJumpUpdate(releaseDelay, pressDelay, totalDelay)
-				},
-				{
 					event: 'DFJumpMaxDelayChanged',
 					callback: (newDelay) => this.setMaxDelay(newDelay)
+				}
+			],
+			handledEvents: [
+				{
+					event: 'DFJumpDataUpdate',
+					panel: this.panels.container,
+					callback: (releaseDelay, pressDelay, totalDelay) =>
+						this.onDFJumpUpdate(releaseDelay, pressDelay, totalDelay)
 				}
 			]
 		});

--- a/scripts/hud/ground-boost.ts
+++ b/scripts/hud/ground-boost.ts
@@ -50,9 +50,9 @@ class GroundboostHandler {
 		RegisterHUDPanelForGamemode({
 			gamemodes: GamemodeCategories.get(GamemodeCategory.DEFRAG),
 			onLoad: () => this.onMapInit(),
-			events: [
-				{ event: 'HudProcessInput', callback: () => this.onHudUpdate() },
-				{ event: 'OnDefragHUDGroundboostChange', callback: () => this.onConfigChange() }
+			events: [{ event: 'OnDefragHUDGroundboostChange', callback: () => this.onConfigChange() }],
+			handledEvents: [
+				{ event: 'HudProcessInput', panel: $.GetContextPanel(), callback: () => this.onHudUpdate() }
 			]
 		});
 	}

--- a/scripts/hud/powerup-timer.ts
+++ b/scripts/hud/powerup-timer.ts
@@ -22,7 +22,7 @@ class PowerupTimerHandler {
 	constructor() {
 		RegisterHUDPanelForGamemode({
 			gamemodes: GamemodeCategories.get(GamemodeCategory.DEFRAG),
-			events: [{ event: 'HudProcessInput', callback: () => this.onUpdate() }]
+			handledEvents: [{ event: 'HudProcessInput', panel: $.GetContextPanel(), callback: () => this.onUpdate() }]
 		});
 	}
 

--- a/scripts/hud/replay-controls.ts
+++ b/scripts/hud/replay-controls.ts
@@ -16,7 +16,7 @@ class ReplayControlsHandler {
 	};
 
 	constructor() {
-		$.RegisterForUnhandledEvent('HudProcessInput', () => this.onHudUpdate());
+		$.RegisterEventHandler('HudProcessInput', $.GetContextPanel(), () => this.onHudUpdate());
 		$.RegisterEventHandler('SliderValueChanged', $.GetContextPanel(), (_, value) => {
 			GameInterfaceAPI.ConsoleCommand(`mom_tv_replay_goto ${value * 100}%`);
 		});

--- a/scripts/hud/synchronizer.ts
+++ b/scripts/hud/synchronizer.ts
@@ -80,7 +80,6 @@ class Synchronizer {
 			gamemodes: [Gamemode.BHOP, Gamemode.SURF, Gamemode.CLIMB_KZT, Gamemode.CLIMB_MOM],
 			onLoad: () => this.onLoad(),
 			events: [
-				{ event: 'HudProcessInput', callback: () => this.onUpdate() },
 				{ event: 'OnJumpStarted', callback: () => this.onJump() },
 				{ event: 'OnSynchroModeChanged', callback: (cvarValue) => this.setDisplayMode(cvarValue) },
 				{ event: 'OnSynchroColorModeChanged', callback: (cvarValue) => this.setColorMode(cvarValue === 1) },
@@ -93,7 +92,8 @@ class Synchronizer {
 					event: 'OnSynchroStatColorModeChanged',
 					callback: (cvarValue) => this.setStatColorMode(cvarValue === 1)
 				}
-			]
+			],
+			handledEvents: [{ event: 'HudProcessInput', panel: $.GetContextPanel(), callback: () => this.onUpdate() }]
 		});
 	}
 


### PR DESCRIPTION
<!-- Describe what your pull request is doing here -->
Addresses regressions made in commits [b46c6b5](https://github.com/momentum-mod/panorama/commit/b46c6b5ed69926172d347eabb8ee79c2b020a7a8) and [af37ff6](https://github.com/momentum-mod/panorama/commit/af37ff63d1e48be29c36d06aecb9faefd82648ed) where events that should have been registered using `RegisterEventHandler` were switched to `RegisterForUnhandledEvent`. This pull request restores the original behavior.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
