### PR TITLE
Zoning UI cleanup 2

### DIFF
--- a/layout/pages/zoning/info.xml
+++ b/layout/pages/zoning/info.xml
@@ -1,0 +1,9 @@
+<root>
+	<styles>
+		<include src="file://{resources}/styles/main.scss" />
+	</styles>
+
+	<scripts>
+		<include type="module" src="file://{scripts}/pages/zoning/zoning.ts" />
+	</scripts>
+</root>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -193,7 +193,7 @@
 					</Panel>
 					<Panel class="zoning__property">
 						<Label class="zoning__property-label" text="#Zoning_RegionDetails_TPDest" />
-						<DropDown id="RegionTPDest" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.updateRegionTPDest()">
+						<DropDown id="RegionTPDest" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.onTPDestSelectionChanged()">
 							<!-- Populated in js -->
 							<Label text="#Zoning_TPDest_None" value="0" />
 							<Label text="#Zoning_TPDest_MakeNew" value="1" />

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -143,113 +143,85 @@
 							<!-- Populated in js -->
 						</DropDown>
 					</Panel>
-				</Panel>
-				<Panel class="zoning__menu-separator">
 					<Panel id="Region" class="zoning__property">
-							<Label class="zoning__property-label" text="#Zoning_Region" />
-							<Panel class="zoning__region-property-container">
-								<Button id="MoveToRegionButton" class="button button--green zoning__property-button mr-2" onactivate="ZoneMenuHandler.teleportToRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('MoveToRegionButton', '#Zoning_MoveToRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
-									<Image class="button__icon" src="file://{images}/eye-arrow-right.svg" />
-								</Button>
-								<Button id="AddRegionButton" class="button button--blue zoning__property-button mr-2" onactivate="ZoneMenuHandler.addRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('AddRegionButton', '#Zoning_CreateRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
-									<Image class="button__icon" src="file://{images}/add.svg" />
-								</Button>
-								<Button id="DeleteRegionButton" class="button button--red zoning__property-button mr-2" onactivate="ZoneMenuHandler.deleteRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('DeleteRegionButton', '#Zoning_DeleteRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
-									<Image class="button__icon" src="file://{images}/delete.svg" />
-								</Button>
-								<DropDown id="RegionSelect" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.populateRegionProperties()">
-									<!-- Populated in js -->
-								</DropDown>
-							</Panel>
-					</Panel>
-					<Panel id="PropertyTabs" class="tabs">
-						<RadioButton group="ZoningRegion" class="tabs__tab" value="Points" selected="true" onactivate="ZoneMenuHandler.showRegionMenu('Points')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionPoints_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
-							<Image src="file://{images}/vector-square-close.svg" class="tabs__icon" textureheight="48" />
-						</RadioButton>
-						<Panel class="tabs__gap" />
-						<RadioButton group="ZoningRegion" class="tabs__tab" value="Properties" onactivate="ZoneMenuHandler.showRegionMenu('Properties')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionProperties_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
-							<Image src="file://{images}/list-box-outline.svg" class="tabs__icon" textureheight="48" />
-						</RadioButton>
-						<Panel class="tabs__gap" />
-						<RadioButton group="ZoningRegion" class="tabs__tab" value="Teleport" onactivate="ZoneMenuHandler.showRegionMenu('Teleport')" onmouseover="UiToolkitAPI.ShowTextTooltip('PropertyTabs', '#Zoning_RegionTeleport_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
-							<Image src="file://{images}/ray-start-arrow.svg" class="tabs__icon" textureheight="48" />
-						</RadioButton>
-					</Panel>
-					<Panel id="PointsSection" class="zoning__region-details">
-						<Panel id="RegionPoints" class="zoning__property">
-							<Panel class="zoning__region-property-container">
-								<ToggleButton id="TwoClickMode" class="zoning__two-click-button" convar="mom_zone_two_click" onmouseover="UiToolkitAPI.ShowTextTooltip('TwoClickMode', '#Zoning_TwoClickTogle_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();" />
-								<Button class="button zoning__property-button" onactivate="ZoneMenuHandler.pickCorners();">
-									<Label class="button__text" text="#Zoning_EditPoints" />
-								</Button>
-							</Panel>
-						</Panel>
-						<Panel id="PointsList" class="zoning__region-points-list">
-						<!-- Populated in JS -->
-						</Panel>
-					</Panel>
-					<Panel id="PropertiesSection" class="zoning__region-details">
-						<Panel class="zoning__property">
-							<Label class="zoning__property-label" text="#Zoning_RegionDetails_Bottom" />
-							<Panel class="zoning__region-property-container">
-								<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickBottom()">
-									<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
-								</Button>
-								<TextEntry id="RegionBottom" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionBottom()" />
-							</Panel>
-						</Panel>
-						<Panel class="zoning__property">
-							<Label class="zoning__property-label" text="#Zoning_RegionDetails_Height" />
-							<Panel class="zoning__region-property-container">
-								<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickHeight()">
-									<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
-								</Button>
-								<TextEntry id="RegionHeight" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionHeight()" />
-							</Panel>
-						</Panel>
-						<Panel class="zoning__property">
-							<Label class="zoning__property-label" text="#Zoning_RegionDetails_SafeHeight" />
-							<Panel class="zoning__region-property-container">
-								<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickSafeHeight()">
-									<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
-								</Button>
-								<TextEntry id="RegionSafeHeight" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionSafeHeight()" />
-							</Panel>
-						</Panel>
-					</Panel>
-					<Panel id="TeleportSection" class="zoning__region-details">
-						<Panel class="zoning__property">
-							<Label class="zoning__property-label" text="#Zoning_RegionDetails_TPDest" />
-							<DropDown id="RegionTPDest" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.updateRegionTPDest()">
+						<Label class="zoning__property-label" text="#Zoning_Region" />
+						<Panel class="zoning__region-property-container">
+							<ToggleButton id="TwoClickMode" class="zoning__two-click-button" convar="mom_zone_two_click" onmouseover="UiToolkitAPI.ShowTextTooltip('TwoClickMode', '#Zoning_TwoClickTogle_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();" />
+							<Button class="button zoning__property-button mr-2" onactivate="ZoneMenuHandler.pickCorners();">
+								<Label class="button__text" text="#Zoning_EditPoints" />
+							</Button>
+							<Button id="MoveToRegionButton" class="button button--green zoning__property-button mr-2" onactivate="ZoneMenuHandler.teleportToRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('MoveToRegionButton', '#Zoning_MoveToRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+								<Image class="button__icon" src="file://{images}/eye-arrow-right.svg" />
+							</Button>
+							<Button id="AddRegionButton" class="button button--blue zoning__property-button mr-2" onactivate="ZoneMenuHandler.addRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('AddRegionButton', '#Zoning_CreateRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+								<Image class="button__icon" src="file://{images}/add.svg" />
+							</Button>
+							<Button id="DeleteRegionButton" class="button button--red zoning__property-button mr-2" onactivate="ZoneMenuHandler.deleteRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('DeleteRegionButton', '#Zoning_DeleteRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+								<Image class="button__icon" src="file://{images}/delete.svg" />
+							</Button>
+							<DropDown id="RegionSelect" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.populateRegionProperties()">
 								<!-- Populated in js -->
-								<Label text="#Zoning_TPDest_None" value="0" />
-								<Label text="#Zoning_TPDest_MakeNew" value="1" />
 							</DropDown>
 						</Panel>
-						<Panel class="zoning__property">
-							<Label id="Position" class="zoning__property-label" text="#Zoning_TPDest_Position" />
-							<Panel class="zoning__region-property-container">
-								<Button id="TelePosPick" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestPos()">
-									<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
-								</Button>
-								<TextEntry id="TeleX" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
-								<TextEntry id="TeleY" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
-								<TextEntry id="TeleZ" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
-							</Panel>
-						</Panel>
-						<Panel class="zoning__property">
-							<Label id="Yaw" class="zoning__property-label" text="#Zoning_TPDest_Yaw" />
-							<Panel class="zoning__region-property-container">
-								<Button id="TeleYawPick" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestYaw()">
-									<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
-								</Button>
-								<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
-							</Panel>
+					</Panel>
+					<Panel class="zoning__property">
+						<Label class="zoning__property-label" text="#Zoning_RegionDetails_Bottom" />
+						<Panel class="zoning__region-property-container">
+							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickBottom()">
+								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
+							</Button>
+							<TextEntry id="RegionBottom" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionBottom()" />
 						</Panel>
 					</Panel>
-				</Panel>
-				<Panel id="GridSlider" class="zoning__property">
-					<SettingsSlider text="#Zoning_GridSnapSize" class="zoning__slider" min="1" max="64" percentage="false" convar="mom_zone_grid" />
+					<Panel class="zoning__property">
+						<Label class="zoning__property-label" text="#Zoning_RegionDetails_Height" />
+						<Panel class="zoning__region-property-container">
+							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickHeight()">
+								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
+							</Button>
+							<TextEntry id="RegionHeight" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionHeight()" />
+						</Panel>
+					</Panel>
+					<Panel class="zoning__property">
+						<Label class="zoning__property-label" text="#Zoning_RegionDetails_SafeHeight" />
+						<Panel class="zoning__region-property-container">
+							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickSafeHeight()">
+								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
+							</Button>
+							<TextEntry id="RegionSafeHeight" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionSafeHeight()" />
+						</Panel>
+					</Panel>
+					<Panel class="zoning__property">
+						<Label class="zoning__property-label" text="#Zoning_RegionDetails_TPDest" />
+						<DropDown id="RegionTPDest" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.updateRegionTPDest()">
+							<!-- Populated in js -->
+							<Label text="#Zoning_TPDest_None" value="0" />
+							<Label text="#Zoning_TPDest_MakeNew" value="1" />
+						</DropDown>
+					</Panel>
+					<Panel class="zoning__property">
+						<Label id="Position" class="zoning__property-label" text="#Zoning_TPDest_Position" />
+						<Panel class="zoning__region-property-container">
+							<Button id="TelePosPick" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestPos()">
+								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
+							</Button>
+							<TextEntry id="TeleX" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+							<TextEntry id="TeleY" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+							<TextEntry id="TeleZ" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+						</Panel>
+					</Panel>
+					<Panel class="zoning__property">
+						<Label id="Yaw" class="zoning__property-label" text="#Zoning_TPDest_Yaw" />
+						<Panel class="zoning__region-property-container">
+							<Button id="TeleYawPick" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestYaw()">
+								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
+							</Button>
+							<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+						</Panel>
+					</Panel>
+					<Panel id="GridSlider" class="zoning__property">
+						<SettingsSlider text="#Zoning_GridSnapSize" class="zoning__slider" min="1" max="64" percentage="false" convar="mom_zone_grid" />
+					</Panel>
 				</Panel>
 			</Panel>
 		</Panel>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -78,8 +78,8 @@
 		<snippet name="region-point">
 			<Panel class="zoning__region-property-container">
 				<!--label-->
-				<TextEntry id="PointX" class="textentry zoning__textentry" maxchars="6" textmode="numeric" />
-				<TextEntry id="PointY" class="textentry zoning__textentry" maxchars="6" textmode="numeric" />
+				<TextEntry id="PointX" class="textentry zoning__textentry" maxchars="10" textmode="numeric" />
+				<TextEntry id="PointY" class="textentry zoning__textentry" maxchars="10" textmode="numeric" />
 				<Button id="DeleteButton" class="zoning__region-point-delete">
 					<Image class="zoning__region-point-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
 				</Button>
@@ -170,7 +170,7 @@
 							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickBottom()">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
-							<TextEntry id="RegionBottom" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionBottom()" />
+							<TextEntry id="RegionBottom" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionBottom()" />
 						</Panel>
 					</Panel>
 					<Panel class="zoning__property">
@@ -179,7 +179,7 @@
 							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickHeight()">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
-							<TextEntry id="RegionHeight" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionHeight()" />
+							<TextEntry id="RegionHeight" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionHeight()" />
 						</Panel>
 					</Panel>
 					<Panel class="zoning__property">
@@ -188,7 +188,7 @@
 							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickSafeHeight()">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
-							<TextEntry id="RegionSafeHeight" class="textentry zoning__textentry" maxchars="8" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionSafeHeight()" />
+							<TextEntry id="RegionSafeHeight" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionSafeHeight()" />
 						</Panel>
 					</Panel>
 					<Panel class="zoning__property">
@@ -205,9 +205,9 @@
 							<Button id="TelePosPick" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestPos()">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
-							<TextEntry id="TeleX" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
-							<TextEntry id="TeleY" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
-							<TextEntry id="TeleZ" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+							<TextEntry id="TeleX" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+							<TextEntry id="TeleY" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+							<TextEntry id="TeleZ" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
 						</Panel>
 					</Panel>
 					<Panel class="zoning__property">
@@ -216,7 +216,7 @@
 							<Button id="TeleYawPick" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestYaw()">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
-							<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+							<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="4" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
 						</Panel>
 					</Panel>
 				</Panel>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -167,7 +167,7 @@
 					<Panel class="zoning__property">
 						<Label class="zoning__property-label" text="#Zoning_RegionDetails_Bottom" />
 						<Panel class="zoning__region-property-container">
-							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickBottom()">
+							<Button id='SetBottomButton' class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickBottom()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetBottomButton', '#Zoning_SetBottom_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
 							<TextEntry id="RegionBottom" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionBottom()" />
@@ -176,7 +176,7 @@
 					<Panel class="zoning__property">
 						<Label class="zoning__property-label" text="#Zoning_RegionDetails_Height" />
 						<Panel class="zoning__region-property-container">
-							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickHeight()">
+							<Button id='SetHeightButton' class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickHeight()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetHeightButton', '#Zoning_SetHeight_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
 							<TextEntry id="RegionHeight" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionHeight()" />
@@ -185,7 +185,7 @@
 					<Panel class="zoning__property">
 						<Label class="zoning__property-label" text="#Zoning_RegionDetails_SafeHeight" />
 						<Panel class="zoning__region-property-container">
-							<Button class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickSafeHeight()">
+							<Button id='SetSafeHeightButton' class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickSafeHeight()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetSafeHeightButton', '#Zoning_SetSafeHeight_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
 							<TextEntry id="RegionSafeHeight" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionSafeHeight()" />
@@ -202,7 +202,7 @@
 					<Panel class="zoning__property">
 						<Label id="Position" class="zoning__property-label" text="#Zoning_TPDest_Position" />
 						<Panel class="zoning__region-property-container">
-							<Button id="TelePosPick" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestPos()">
+							<Button id="SetTeleDestPosButton" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestPos()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetTeleDestPosButton', '#Zoning_SetTeleDestPos_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
 							<TextEntry id="TeleX" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
@@ -213,7 +213,7 @@
 					<Panel class="zoning__property">
 						<Label id="Yaw" class="zoning__property-label" text="#Zoning_TPDest_Yaw" />
 						<Panel class="zoning__region-property-container">
-							<Button id="TeleYawPick" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestYaw()">
+							<Button id="SetTeleDestYawButton" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestYaw()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetTeleDestYawButton', '#Zoning_SetTeleDestYaw_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>
 							<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="4" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -219,10 +219,15 @@
 							<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="6" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
 						</Panel>
 					</Panel>
-					<Panel id="GridSlider" class="zoning__property">
-						<SettingsSlider text="#Zoning_GridSnapSize" class="zoning__slider" min="1" max="64" percentage="false" convar="mom_zone_grid" />
-					</Panel>
 				</Panel>
+			</Panel>
+		</Panel>
+		<Panel id="InfoPanel" class="zoning__menu-section hide">
+			<Label id="SelectionMode" class="zoning__property-label" />
+			<Panel class="zoning__property-container">
+			</Panel>
+			<Panel id="GridSlider" class="zoning__property">
+				<SettingsSlider text="#Zoning_GridSnapSize" class="zoning__slider" min="1" max="64" percentage="false" convar="mom_zone_grid" />
 			</Panel>
 		</Panel>
 		<Panel class="zoning__button-box">

--- a/scripts/hud/tab-menu.ts
+++ b/scripts/hud/tab-menu.ts
@@ -31,6 +31,7 @@ class HudTabMenuHandler {
 		$.RegisterForUnhandledEvent('EndOfRun_Hide', () => this.hideEndOfRun());
 		$.RegisterForUnhandledEvent('ZoneMenu_Show', () => this.showZoneMenu());
 		$.RegisterForUnhandledEvent('ZoneMenu_Hide', () => this.hideZoneMenu());
+		$.RegisterForUnhandledEvent('LevelInitPostEntity', () => this.hideZoneMenu());
 		$.RegisterForUnhandledEvent('ActiveZoneDefsChanged', () => this.updateMapStats());
 	}
 

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -114,6 +114,7 @@ class ZoneMenuHandler {
 		$.RegisterForUnhandledEvent('ZoneMenu_Show', () => this.showZoneMenu());
 		$.RegisterForUnhandledEvent('ZoneMenu_Hide', () => this.hideZoneMenu());
 		$.RegisterForUnhandledEvent('OnPointPicked', (region) => this.onPointPicked(region));
+		$.RegisterForUnhandledEvent('OnPointDeleted', (index) => this.onPointDeleted(index));
 		$.RegisterForUnhandledEvent('OnPickCanceled', () => this.onPickCanceled());
 
 		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.initMenu.bind(this));
@@ -760,8 +761,15 @@ class ZoneMenuHandler {
 		this.drawZones();
 	}
 
+	onPointDeleted(index: number | undefined) {
+		if (!this.selectedZone || !this.selectedZone.region) return;
 
+		if (this.selectedZone.region.points.length === 0) return;
 
+		if (index === undefined) {
+			this.selectedZone.region.points.pop();
+		} else {
+			this.selectedZone.region.points.splice(index, 1);
 		}
 
 		this.drawZones();

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -528,8 +528,6 @@ class ZoneMenuHandler {
 
 		const filterIndex = this.panels.filterSelect.GetSelected()?.GetAttributeInt('value', 0);
 		this.selectedZone.zone.filtername = filterIndex ? this.filternameList[filterIndex] : '';
-
-		this.drawZones();
 	}
 
 	populateRegionProperties() {
@@ -559,8 +557,6 @@ class ZoneMenuHandler {
 		this.populateDropdown(this.selectedZone.zone.regions, this.panels.regionSelect, 'Region', true);
 		this.panels.regionSelect.SetSelectedIndex(this.selectedZone.zone.regions.length - 1);
 		this.populateRegionProperties();
-
-		this.drawZones();
 	}
 
 	deleteRegion() {
@@ -843,7 +839,7 @@ class ZoneMenuHandler {
 
 		this.pointPick = PickType.NONE;
 		this.showInfoPanel(false);
-		//this.drawZones();
+		this.drawZones();
 	}
 
 	showInfoPanel(hideProperties: boolean) {
@@ -1091,15 +1087,11 @@ class ZoneMenuHandler {
 		if (!this.mapZoneData) return;
 		const velocity = Number.parseFloat(this.panels.maxVelocity.text);
 		this.mapZoneData.maxVelocity = !Number.isNaN(velocity) && velocity > 0 ? velocity : 0;
-
-		this.drawZones();
 	}
 
 	setStageEndAtStageStarts() {
 		if (!this.isSelectionValid().track || !('stagesEndAtStageStarts' in this.selectedZone.track)) return;
 		this.selectedZone.track.stagesEndAtStageStarts = this.panels.stagesEndAtStageStarts.checked;
-
-		this.drawZones();
 	}
 
 	showDefragFlagMenu() {
@@ -1155,29 +1147,21 @@ class ZoneMenuHandler {
 		trackPanel.FindChildTraverse('ChildContainer').RemoveAndDeleteChildren();
 		// keep select button aligned with other tracks
 		trackPanel.FindChildTraverse('Entry').SetHasClass('zoning__tracklist-checkpoint', true);
-
-		this.drawZones();
 	}
 
 	setLimitGroundSpeed() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.limitStartGroundSpeed = this.panels.limitGroundSpeed.checked;
-
-		this.drawZones();
 	}
 
 	setCheckpointsOrdered() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.checkpointsOrdered = this.panels.checkpointsOrdered.checked;
-
-		this.drawZones();
 	}
 
 	setCheckpointsRequired() {
 		if (!this.isSelectionValid().segment) return;
 		this.selectedZone.segment!.checkpointsRequired = this.panels.checkpointsRequired.checked;
-
-		this.drawZones();
 	}
 
 	setSegmentName() {
@@ -1185,8 +1169,6 @@ class ZoneMenuHandler {
 		this.selectedZone.segment!.name = this.panels.segmentName.text;
 		// feat: later
 		// update segment name in trasklist tree
-
-		this.drawZones();
 	}
 
 	drawZones() {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -28,13 +28,6 @@ enum DefragFlags {
 	BFG = 1 << 5
 }
 
-enum RegionMenu {
-	POINTS = 'Points',
-	PROPERTIES = 'Properties',
-	TELEPORT = 'Teleport',
-	RESET = 'Reset'
-}
-
 export enum PickType {
 	NONE = 0,
 	CORNER = 1,

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -546,13 +546,13 @@ class ZoneMenuHandler {
 		this.panels.regionHeight.text = (region?.height ?? 0).toFixed(2);
 		this.panels.regionSafeHeight.text = (region?.safeHeight ?? 0).toFixed(2);
 
-		const tpIndex = !region.teleDestTargetname
+		const tpIndex = (region.teleDestTargetname === undefined || region.teleDestTargetname === '')
 			? region.teleDestPos !== undefined && region.teleDestYaw !== undefined
 				? 1
 				: 0
 			: this.teleDestList?.indexOf(region.teleDestTargetname);
 		this.panels.regionTPDest.SetSelectedIndex(tpIndex);
-		this.updateRegionTPDest();
+		this.onTPDestSelectionChanged();
 	}
 
 	addRegion() {
@@ -658,7 +658,7 @@ class ZoneMenuHandler {
 		this.showInfoPanel(true);
 	}
 
-	updateRegionTPDest() {
+	onTPDestSelectionChanged() {
 		if (!this.selectedZone || !this.selectedZone.region || !this.teleDestList) return;
 
 		const teleDestIndex = this.panels.regionTPDest.GetSelected()?.GetAttributeInt('value', 0);

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -773,16 +773,10 @@ class ZoneMenuHandler {
 		this.drawZones();
 	}
 
-	onPointDeleted(index: number | undefined) {
+	onPointDeleted(newPoints: Region) {
 		if (!this.selectedZone || !this.selectedZone.region) return;
 
-		if (this.selectedZone.region.points.length === 0) return;
-
-		if (index === undefined) {
-			this.selectedZone.region.points.pop();
-		} else {
-			this.selectedZone.region.points.splice(index, 1);
-		}
+		this.selectedZone.region = newPoints;
 
 		this.drawZones();
 	}

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -935,7 +935,7 @@ class ZoneMenuHandler {
 		const checkpointContainer = childContainer.FindChildTraverse<Panel>('CheckpointContainer');
 		this.addTracklistEntry(
 			checkpointContainer,
-			$.Localize('#Zoning_Start_Stage'),
+			mainTrack.zones.segments.length > 0 ? $.Localize('#Zoning_Start_Stage') : $.Localize('#Zoning_Start_Track'),
 			TracklistSnippet.CHECKPOINT,
 			{
 				track: mainTrack,
@@ -952,7 +952,12 @@ class ZoneMenuHandler {
 		const newZone = this.createZone();
 		segment.checkpoints.push(newZone);
 
-		const id = `${$.Localize('#Zoning_Checkpoint')} ${segment.checkpoints.length - 1}`;
+		const id =
+			segment.checkpoints.length > 1
+				? `${$.Localize('#Zoning_Checkpoint')} ${segment.checkpoints.length - 1}`
+				: track.zones.segments.indexOf(segment) > 0
+					? $.Localize('#Zoning_Start_Stage')
+					: $.Localize('#Zoning_Start_Track');
 		this.addTracklistEntry(
 			checkpointsList,
 			id,

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -119,10 +119,24 @@ class ZoneMenuHandler {
 		$.RegisterForUnhandledEvent('OnPointDeleted', (index) => this.onPointDeleted(index));
 		$.RegisterForUnhandledEvent('OnPickCanceled', () => this.onPickCanceled());
 
-		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.initMenu.bind(this));
+		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.onLoad.bind(this));
 	}
 
 	onLoad() {
+		if (this.panels.trackList?.GetChildCount()) {
+			this.panels.trackList.RemoveAndDeleteChildren();
+		}
+
+		this.getZoneData();
+
+		this.pointPick = PickType.NONE;
+
+		//prompt to copy official zones to local
+
+		this.initMenu();
+	}
+
+	getZoneData() {
 		this.mapZoneData = MomentumTimerAPI.GetActiveZoneDefs() ?? {
 			tracks: {
 				main: {
@@ -141,7 +155,7 @@ class ZoneMenuHandler {
 
 	initMenu() {
 		if (!this.mapZoneData) {
-			this.onLoad();
+			this.getZoneData();
 		}
 
 		if (!this.mapZoneData) return;

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -86,9 +86,9 @@ class ZoneMenuHandler {
 			y: $<TextEntry>('#TeleY'),
 			z: $<TextEntry>('#TeleZ')
 		},
-		regionTPPosPick: $<Button>('#TelePosPick'),
+		regionTPPosButton: $<Button>('#SetTeleDestPosButton'),
 		regionTPYaw: $<TextEntry>('#TeleYaw'),
-		regionTPYawPick: $<Button>('#TeleYawPick')
+		regionTPYawButton: $<Button>('#SetTeleDestYawButton')
 	};
 
 	zoningLimits: ZoneEditorLimits;
@@ -716,9 +716,9 @@ class ZoneMenuHandler {
 		this.panels.regionTPPos.x.enabled = enable;
 		this.panels.regionTPPos.y.enabled = enable;
 		this.panels.regionTPPos.z.enabled = enable;
-		this.panels.regionTPPosPick.enabled = enable;
+		this.panels.regionTPPosButton.enabled = enable;
 		this.panels.regionTPYaw.enabled = enable;
-		this.panels.regionTPYawPick.enabled = enable;
+		this.panels.regionTPYawButton.enabled = enable;
 
 		if (!enable) {
 			this.panels.regionTPPos.x.text = '';

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -70,6 +70,7 @@ class ZoneMenuHandler {
 	readonly panels = {
 		zoningMenu: $.GetContextPanel<ZoneMenu>(),
 		trackList: $<Panel>('#TrackList'),
+		propertiesPanel: $<Panel>('#PropertiesContainer'),
 		propertiesTrack: $<Panel>('#TrackProperties'),
 		maxVelocity: $<TextEntry>('#MaxVelocity'),
 		defragModifiers: $<Panel>('#DefragFlags'),
@@ -80,7 +81,8 @@ class ZoneMenuHandler {
 		checkpointsOrdered: $('#CheckpointsOrdered').FindChild<ToggleButton>('CheckBox'),
 		segmentName: $<TextEntry>('#SegmentName'),
 		propertiesZone: $<Panel>('#ZoneProperties'),
-		propertyTabs: $<Panel>('#PropertyTabs'),
+		infoPanel: $<Panel>('#InfoPanel'),
+		selectionMode: $<Label>('#SelectionMode'),
 		filterSelect: $<DropDown>('#FilterSelect'),
 		volumeSelect: $<DropDown>('#VolumeSelect'),
 		regionSelect: $<DropDown>('#RegionSelect'),
@@ -581,12 +583,14 @@ class ZoneMenuHandler {
 		if (GameInterfaceAPI.GetSettingBool('mom_zone_two_click')) this.selectedZone.region.points.length = 0;
 
 		this.panels.zoningMenu.startPointPick(this.pointPick, this.selectedZone.region);
+		this.showInfoPanel(true);
 	}
 
 	pickBottom() {
 		this.pointPick = PickType.BOTTOM;
 
 		this.panels.zoningMenu.startPointPick(this.pointPick, this.selectedZone.region);
+		this.showInfoPanel(true);
 	}
 
 	setRegionBottom() {
@@ -602,6 +606,7 @@ class ZoneMenuHandler {
 		this.pointPick = PickType.HEIGHT;
 
 		this.panels.zoningMenu.startPointPick(this.pointPick, this.selectedZone.region);
+		this.showInfoPanel(true);
 	}
 
 	setRegionHeight() {
@@ -617,6 +622,7 @@ class ZoneMenuHandler {
 		this.pointPick = PickType.SAFE_HEIGHT;
 
 		this.panels.zoningMenu.startPointPick(this.pointPick, this.selectedZone.region);
+		this.showInfoPanel(true);
 	}
 
 	setRegionSafeHeight() {
@@ -632,12 +638,14 @@ class ZoneMenuHandler {
 		this.pointPick = PickType.TELE_DEST_POS;
 
 		this.panels.zoningMenu.startPointPick(this.pointPick, this.selectedZone.region);
+		this.showInfoPanel(true);
 	}
 
 	pickTeleDestYaw() {
 		this.pointPick = PickType.TELE_DEST_YAW;
 
 		this.panels.zoningMenu.startPointPick(this.pointPick, this.selectedZone.region);
+		this.showInfoPanel(true);
 	}
 
 	updateRegionTPDest() {
@@ -722,6 +730,7 @@ class ZoneMenuHandler {
 
 		switch (this.pointPick) {
 			case PickType.NONE:
+				this.showInfoPanel(false);
 				return;
 
 			case PickType.CORNER:
@@ -776,17 +785,55 @@ class ZoneMenuHandler {
 	}
 
 	onPickCanceled() {
-		this.pointPick = PickType.NONE;
-
 		if (
 			this.isSelectionValid().zone &&
 			this.selectedZone.region &&
 			this.selectedZone.region.points.length > 2 &&
 			this.selectedZone.region.height === 0
-		)
+		) {
 			this.pickHeight();
-
+		} else if (this.pointPick === PickType.TELE_DEST_POS) {
+			this.pickTeleDestYaw();
+		} else {
+			this.pointPick = PickType.NONE;
+			this.showInfoPanel(false);
+		}
 		this.drawZones();
+	}
+
+	showInfoPanel(hideProperties: boolean) {
+		this.panels.propertiesPanel.SetHasClass('hide', hideProperties);
+		this.panels.infoPanel.SetHasClass('hide', !hideProperties);
+
+		switch (this.pointPick) {
+			case PickType.NONE:
+				this.panels.selectionMode.text = '';
+				break;
+
+			case PickType.CORNER:
+				this.panels.selectionMode.text = '#Zoning_SelectionMode_Corner';
+				break;
+
+			case PickType.BOTTOM:
+				this.panels.selectionMode.text = '#Zoning_SelectionMode_Bottom';
+				break;
+
+			case PickType.HEIGHT:
+				this.panels.selectionMode.text = '#Zoning_SelectionMode_Height';
+				break;
+
+			case PickType.SAFE_HEIGHT:
+				this.panels.selectionMode.text = '#Zoning_SelectionMode_SafeHeight';
+				break;
+
+			case PickType.TELE_DEST_POS:
+				this.panels.selectionMode.text = '#Zoning_SelectionMode_TpPos';
+				break;
+
+			case PickType.TELE_DEST_YAW:
+				this.panels.selectionMode.text = '#Zoning_SelectionMode_TpYaw';
+				break;
+		}
 	}
 
 	addBonus() {

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -297,7 +297,7 @@ interface GlobalEventNameMap {
 
 	ZoneMenu_Hide: () => void;
 
-	OnPointPicked: (point: vec3) => void;
+	OnPointPicked: (region: import('common/web').Region) => void;
 
 	OnPickCanceled: () => void;
 

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -299,6 +299,8 @@ interface GlobalEventNameMap {
 
 	OnPointPicked: (region: import('common/web').Region) => void;
 
+	OnPointDeleted: (point: number | undefined) => void;
+
 	OnPickCanceled: () => void;
 
 	/** Fired when the the primary timer of the UI entity transitions to a different state */

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -299,7 +299,7 @@ interface GlobalEventNameMap {
 
 	OnPointPicked: (region: import('common/web').Region) => void;
 
-	OnPointDeleted: (point: number | undefined) => void;
+	OnPointDeleted: (region: import('common/web').Region) => void;
 
 	OnPickCanceled: () => void;
 

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -148,11 +148,9 @@ interface ZoneEditorLimits {
 }
 
 interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {
-	startPointPick(mode: import('pages/zoning/zoning').PickType): void;
+	startPointPick(mode: import('pages/zoning/zoning').PickType, region: import('common/web').Region): void;
 
 	getEntityList(): import('pages/zoning/zoning').EntityList;
-
-	setCornersFromRegion(region: import('common/web').Region): void;
 
 	moveToRegion(region: import('common/web').Region): void;
 

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -162,4 +162,6 @@ interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {
 	): import('pages/zoning/zoning').RegionPolygonProblem;
 
 	getZoningLimits(): ZoneEditorLimits;
+
+	createDefaultTeleDest(region: import('common/web').Region): import('common/web').Region;
 }

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -326,8 +326,9 @@ $medium: 28px;
 
 	&__textentry {
 		horizontal-align: right;
-		margin-left: 16px;
-		width: 80px;
+		margin-left: 8px;
+		width: 120px;
+		text-align: right;
 
 		&:disabled,
 		&:disabled:hover {


### PR DESCRIPTION
Closes:
momentum-mod/game/issues/2122
momentum-mod/game/issues/2225

This PR changes the UX around point placement while zoning and updates the UI accordingly. The region menu has been updated to remove tabs for points, properties, and teleport.
- Edit points in world space
- Click a corner to reposition it
- Click an edge midpoint to insert a corner
- Press backspace or delete to remove the last corner
- Change corner mode with middle click
- Creating zones now requires fewer clicks

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
