### PR TITLE
Use new event for loading tracks on a local map leaderboards

### DIFF
--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -325,8 +325,11 @@ interface GlobalEventNameMap {
 	/** Fired when the leaderboards has its map data set but before times are loaded */
 	Leaderboards_MapDataSet: (isOfficial: boolean) => void;
 
-	/** Fired when the map leaderboard data has loaded */
-	Leaderboards_MapLeaderboardsLoaded: (map: import('common/web').MMap) => void;
+	/** Fired when the official map leaderboard data has loaded */
+	Leaderboards_OfficialMapLeaderboardsLoaded: (map: import('common/web').MMap) => void;
+
+	/** Fired when the local map leaderboard data has loaded */
+	Leaderboards_LocalMapLeaderboardsLoaded: () => void;
 
 	LeaderboardEntry_TimeDataUpdated: () => void;
 


### PR DESCRIPTION
This also fixes an issue with the tracks dropdown not clearing when switching to a meta game mode with no maps.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below