### PR TITLE
Leaderboard segments null check

### DIFF
--- a/scripts/pages/leaderboards/leaderboards.ts
+++ b/scripts/pages/leaderboards/leaderboards.ts
@@ -254,7 +254,7 @@ class LeaderboardsHandler {
 
 			// Stage tracks
 			const segments = mapZoneData.tracks.main.zones.segments;
-			if (segments.length > 1) {
+			if (segments && segments.length > 1) {
 				segments.forEach((_, index) => {
 					const trackStr = `${$.Localize('#Leaderboards_Tracks_Stage')} ${index + 1}`;
 					const item = $.CreatePanel('Label', this.panels.tracksDropdown, trackStr, {


### PR DESCRIPTION
This will fix a js error when loading invalid zones.

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
