### PR TITLE
Async replay saving

### DIFF
--- a/scripts/pages/end-of-run/end-of-run.ts
+++ b/scripts/pages/end-of-run/end-of-run.ts
@@ -143,7 +143,7 @@ class EndOfRunHandler {
 	}
 
 	restartMap() {
-		GameInterfaceAPI.ConsoleCommand('mom_restart');
+		GameInterfaceAPI.ConsoleCommand('mom_restart_track');
 		this.hideEndOfRun(true, true);
 	}
 

--- a/scripts/pages/learn.ts
+++ b/scripts/pages/learn.ts
@@ -237,7 +237,7 @@ class Learn {
 		if (this.currentLessonData['TeleTarget']) {
 			const target = this.currentLessonData['TeleTarget'];
 			GameInterfaceAPI.ConsoleCommand(`ent_fire teleport_send_player addoutput "target ${target}"`);
-			$.Schedule(0.05, () => GameInterfaceAPI.ConsoleCommand('mom_restart'));
+			$.Schedule(0.05, () => GameInterfaceAPI.ConsoleCommand('mom_restart_track'));
 			$.Msg(`Learn: Teleporting to TeleTarget ${target}`);
 		} else if (this.currentLessonData['Position']) {
 			const pos = this.currentLessonData['Position'];

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -287,6 +287,9 @@ interface GlobalEventNameMap {
 	/** Fired when the end of run panel should be hidden */
 	EndOfRun_Hide: () => void;
 
+	/** Fired when a run is finished and passes the run metadata for the completed run. At this point the replay has not been saved yet. */
+	EndOfRun_Result_RunFinish: (run: RunMetadata) => void;
+
 	/** Fired when the replay recording finishes and passes whether writing the file was successful */
 	EndOfRun_Result_RunSave: (saved: boolean, run: RunMetadata) => void;
 


### PR DESCRIPTION
Handles async saving of replays for end of run screen. Also fixed a couple of places where `mom_restart` was still being used.

### Checks

-   [X] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [X] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [X] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [X] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [X] All changes requested in review have been `fixup`ed into my original commits.
-   [X] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

