### PR TITLE
Fix incorrect sound settings

### DIFF
--- a/layout/pages/settings/interface.xml
+++ b/layout/pages/settings/interface.xml
@@ -301,11 +301,6 @@
 					<RadioButton group="timerstopsound" text="#Common_Off" value="0" />
 					<RadioButton group="timerstopsound" text="#Common_On" value="1" />
 				</SettingsEnum>
-
-				<SettingsEnum text="#Settings_Timer_SoundFail" convar="mom_hud_timer_sound_fail_enable" infomessage="#Settings_Timer_SoundFail_Info" tags="sound">
-					<RadioButton group="timerfailsound" text="#Common_Off" value="0" />
-					<RadioButton group="timerfailsound" text="#Common_On" value="1" />
-				</SettingsEnum>
 			</Panel>
 
 			<Panel class="settings-page__spacer" />

--- a/layout/pages/settings/interface.xml
+++ b/layout/pages/settings/interface.xml
@@ -292,12 +292,12 @@
 					<RadioButton group="timerstartsound" text="#Common_On" value="1" />
 				</SettingsEnum>
 
-				<SettingsEnum text="#Settings_Timer_SoundFinish" convar="mom_hud_timer_sound_finish_enable" infomessage="#Settings_Timer_SoundStop_Info" tags="sound">
+				<SettingsEnum text="#Settings_Timer_SoundFinish" convar="mom_hud_timer_sound_finish_enable" infomessage="#Settings_Timer_SoundFinish_Info" tags="sound">
 					<RadioButton group="timerfinishsound" text="#Common_Off" value="0" />
 					<RadioButton group="timerfinishsound" text="#Common_On" value="1" />
 				</SettingsEnum>
 
-				<SettingsEnum text="#Settings_Timer_SoundFinish" convar="mom_hud_timer_sound_stop_enable" infomessage="#Settings_Timer_SoundFinish_Info" tags="sound">
+				<SettingsEnum text="#Settings_Timer_SoundStop" convar="mom_hud_timer_sound_stop_enable" infomessage="#Settings_Timer_SoundStop_Info" tags="sound">
 					<RadioButton group="timerstopsound" text="#Common_Off" value="0" />
 					<RadioButton group="timerstopsound" text="#Common_On" value="1" />
 				</SettingsEnum>


### PR DESCRIPTION
- Fixes incorrect strings for timer stop sound
- Removes unused sound fail settings
- Removed fail sound setting strings from POEditor already

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

