### PR TITLE
Add OnControlledReplaySet, GetReplayRunMetadata, and RunMetadata tempId field

### DIFF
--- a/scripts/common/timer.ts
+++ b/scripts/common/timer.ts
@@ -45,6 +45,7 @@ export interface RunMetadata {
 	playerName: string;
 	trackId: TrackID;
 	runTime: double;
+	tempId: number;
 	runSplits: RunSplits | null;
 }
 

--- a/scripts/hud/status.ts
+++ b/scripts/hud/status.ts
@@ -14,8 +14,8 @@ class HudStatusHandler {
 		$.RegisterForUnhandledEvent('OnSaveStateUpdate', (count, current, usingMenu) =>
 			this.onSaveStateChange(count, current, usingMenu)
 		);
-		$.RegisterForUnhandledEvent('OnObservedTimerStateChange', (_trackID) => this.update());
-		$.RegisterForUnhandledEvent('OnObservedTimerCheckpointProgressed', (_trackID) => this.update());
+		$.RegisterForUnhandledEvent('OnObservedTimerStateChange', () => this.update());
+		$.RegisterForUnhandledEvent('OnObservedTimerCheckpointProgressed', () => this.update());
 		$.RegisterForUnhandledEvent('OnObservedTimerReplaced', () => this.update());
 
 		$.GetContextPanel<MomHudStatus>().hiddenHUDBits = HideHud.TABMENU;

--- a/scripts/types-mom/apis.d.ts
+++ b/scripts/types-mom/apis.d.ts
@@ -169,6 +169,8 @@ declare namespace MomentumReplayAPI {
 	function GetReplayState(): ReplayState;
 
 	function GetReplayProgress(): ReplayProgress;
+
+	function GetReplayRunMetadata(): RunMetadata | null;
 }
 
 declare namespace ChatAPI {

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -307,16 +307,19 @@ interface GlobalEventNameMap {
 	OnPickCanceled: () => void;
 
 	/** Fired when the the primary timer of the UI entity transitions to a different state */
-	OnObservedTimerStateChange: (trackID: import('common/timer').TrackID) => void;
+	OnObservedTimerStateChange: () => void;
 
 	/** Fired when the the primary timer of the UI entity progresses to a new checkpoint */
-	OnObservedTimerCheckpointProgressed: (trackId: import('common/timer').TrackID) => void;
+	OnObservedTimerCheckpointProgressed: () => void;
 
 	/** Fired when the the primary timer of the UI entity effectively starts a segment. */
-	OnObservedTimerSegmentEffectiveStart: (trackId: import('common/timer').TrackID) => void;
+	OnObservedTimerSegmentEffectiveStart: () => void;
 
 	/** Fired when the UI entity changes or when primary timer of the UI entity changes */
 	OnObservedTimerReplaced: () => void;
+
+	/** Fired when a new controllable replay is set, or the prior one was shut down */
+	OnControlledReplaySet: () => void;
 
 	/** Fired when the selected time list type is changed, passing the old times list type and new type that was selected */
 	Leaderboards_TimeListTypeChange: (


### PR DESCRIPTION
- `OnControlledReplaySet` - fires when the controlled replay is set, replaced, or unset
- `GetReplayRunMetadata` - gets the RunMetadata for the controlled replay, if any (will be null if the controlled replay is not for a particular run)
- `RunMetadata.tempId` - can be used to tell runs apart
