### PR TITLE
Move region edit state machine to c++

### DIFF
--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -231,6 +231,14 @@
 						<Label class="zoning-info__bind-key" text="MOUSE1" />
 					</Panel>
 					<Panel class="zoning-info__bind">
+						<Label class="zoning-info__bind-action" text="Back" />
+						<Label class="zoning-info__bind-key" text="MOUSE2" />
+					</Panel>
+					<Panel class="zoning-info__bind">
+						<Label class="zoning-info__bind-action" text="Cancel region edit" />
+						<Label class="zoning-info__bind-key" text="ESCAPE" />
+					</Panel>
+					<Panel class="zoning-info__bind">
 						<Label class="zoning-info__bind-action" text="Delete last point" />
 						<Label class="zoning-info__bind-key" text="DELETE, BACKSPACE" />
 					</Panel>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -227,24 +227,26 @@
 				<Label id="SelectionMode" class="zoning__property-label" text="{s:selectionModeHint}" />
 				<Panel class="zoning-info__binds-list">
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Select" />
+						<Label class="zoning-info__bind-action" text="{s:mouse1Hint}" />
 						<Label class="zoning-info__bind-key" text="MOUSE1" />
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Back" />
+						<Label class="zoning-info__bind-action" text="{s:mouse2Hint}" />
 						<Label class="zoning-info__bind-key" text="MOUSE2" />
 					</Panel>
 					<Panel class="zoning-info__bind">
 						<Label class="zoning-info__bind-action" text="Cancel region edit" />
 						<Label class="zoning-info__bind-key" text="ESCAPE" />
 					</Panel>
-					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Delete last point" />
-						<Label class="zoning-info__bind-key" text="DELETE, BACKSPACE" />
-					</Panel>
-					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Toggle two-click mode" />
-						<Label class="zoning-info__bind-key" text="MOUSE3" />
+					<Panel id="ZoningBindsCorner" class="zoning-info__category">
+						<Panel class="zoning-info__bind">
+							<Label class="zoning-info__bind-action" text="Delete last point" />
+							<Label class="zoning-info__bind-key" text="DELETE, BACKSPACE" />
+						</Panel>
+						<Panel class="zoning-info__bind">
+							<Label class="zoning-info__bind-action" text="Toggle two-click mode" />
+							<Label class="zoning-info__bind-key" text="MOUSE3" />
+						</Panel>
 					</Panel>
 					<Panel class="zoning-info__bind">
 						<Label class="zoning-info__bind-action" text="Increase reticle distance" />
@@ -264,7 +266,11 @@
 					</Panel>
 					<Panel class="zoning-info__bind">
 						<Label class="zoning-info__bind-action" text="Force grid snap (override geometry snap)" />
-						<Label class="zoning-info__bind-key" text="LCTRL" />
+						<Label class="zoning-info__bind-key" text="SHIFT" />
+					</Panel>
+					<Panel class="zoning-info__bind">
+						<Label class="zoning-info__bind-action" text="Ignore trace (snap to free space)" />
+						<Label class="zoning-info__bind-key" text="LALT" />
 					</Panel>
 				</Panel>
 				<Panel id="GridSlider" class="zoning__property">

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -224,7 +224,7 @@
 		</Panel>
 		<Panel id="InfoPanel" class="zoning__menu-section hide">
 			<Panel class="w-full flow-down">
-				<Label id="SelectionMode" class="zoning__property-label" />
+				<Label id="SelectionMode" class="zoning__property-label" text="{s:selectionModeHint}" />
 				<Panel class="zoning-info__binds-list">
 					<Panel class="zoning-info__bind">
 						<Label class="zoning-info__bind-action" text="Select" />

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -235,41 +235,41 @@
 						<Label class="zoning-info__bind-key" text="MOUSE2" />
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Cancel region edit" />
+						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_CancelEdit" />
 						<Label class="zoning-info__bind-key" text="ESCAPE" />
 					</Panel>
 					<Panel id="ZoningBindsCorner" class="zoning-info__category">
 						<Panel class="zoning-info__bind">
-							<Label class="zoning-info__bind-action" text="Delete last point" />
+							<Label class="zoning-info__bind-action" text="#Zoning_Keybind_DeletePoint" />
 							<Label class="zoning-info__bind-key" text="DELETE, BACKSPACE" />
 						</Panel>
 						<Panel class="zoning-info__bind">
-							<Label class="zoning-info__bind-action" text="Toggle two-click mode" />
+							<Label class="zoning-info__bind-action" text="#Zoning_Keybind_TwoclickToggle" />
 							<Label class="zoning-info__bind-key" text="MOUSE3" />
 						</Panel>
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Increase reticle distance" />
+						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_ReticleDistIncrease" />
 						<Label class="zoning-info__bind-key" text="MWHEELUP" />
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Decrease reticle distance" />
+						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_ReticleDistDecrease" />
 						<Label class="zoning-info__bind-key" text="MWHEELDOWN" />
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Increase grid size" />
+						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_GridSizeIncrease" />
 						<Label class="zoning-info__bind-key" text="]" />
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Decrease grid size" />
+						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_GridSizeDecrease" />
 						<Label class="zoning-info__bind-key" text="[" />
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Force grid snap (override geometry snap)" />
+						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_ForceGridSnap" />
 						<Label class="zoning-info__bind-key" text="SHIFT" />
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="Ignore trace (snap to free space)" />
+						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_ForceReticleDist" />
 						<Label class="zoning-info__bind-key" text="LALT" />
 					</Panel>
 				</Panel>

--- a/scripts/common/web.ts
+++ b/scripts/common/web.ts
@@ -1397,6 +1397,7 @@ export interface MapZones {
 
 export interface GlobalRegions {
 	allowBhop: Region[];
+	cancel: Region[];
 }
 
 export interface MapTracks {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -59,56 +59,55 @@ export enum RegionPolygonProblem {
 @PanelHandler()
 class ZoneMenuHandler {
 	readonly panels = {
-		zoningMenu: $.GetContextPanel<ZoneMenu>(),
-		trackList: $<Panel>('#TrackList'),
-		propertiesPanel: $<Panel>('#PropertiesContainer'),
-		propertiesTrack: $<Panel>('#TrackProperties'),
-		maxVelocity: $<TextEntry>('#MaxVelocity'),
-		defragModifiers: $<Panel>('#DefragFlags'),
-		stagesEndAtStageStarts: $('#StagesEndAtStageStarts').FindChild<ToggleButton>('CheckBox'),
-		propertiesSegment: $<Panel>('#SegmentProperties'),
-		limitGroundSpeed: $('#LimitGroundSpeed').FindChild<ToggleButton>('CheckBox'),
-		checkpointsRequired: $('#CheckpointsRequired').FindChild<ToggleButton>('CheckBox'),
-		checkpointsOrdered: $('#CheckpointsOrdered').FindChild<ToggleButton>('CheckBox'),
-		segmentName: $<TextEntry>('#SegmentName'),
-		propertiesZone: $<Panel>('#ZoneProperties'),
-		infoPanel: $<Panel>('#InfoPanel'),
-		selectionMode: $<Label>('#SelectionMode'),
-		filterSelect: $<DropDown>('#FilterSelect'),
-		volumeSelect: $<DropDown>('#VolumeSelect'),
-		regionSelect: $<DropDown>('#RegionSelect'),
-		regionBottom: $<TextEntry>('#RegionBottom'),
-		regionHeight: $<TextEntry>('#RegionHeight'),
-		regionSafeHeight: $<TextEntry>('#RegionSafeHeight'),
-		regionTPDest: $<DropDown>('#RegionTPDest'),
+		zoningMenu: $.GetContextPanel<ZoneMenu>()!,
+		trackList: $<Panel>('#TrackList')!,
+		propertiesPanel: $<Panel>('#PropertiesContainer')!,
+		propertiesTrack: $<Panel>('#TrackProperties')!,
+		maxVelocity: $<TextEntry>('#MaxVelocity')!,
+		defragModifiers: $<Panel>('#DefragFlags')!,
+		stagesEndAtStageStarts: $('#StagesEndAtStageStarts')!.FindChild<ToggleButton>('CheckBox')!,
+		propertiesSegment: $<Panel>('#SegmentProperties')!,
+		limitGroundSpeed: $('#LimitGroundSpeed')!.FindChild<ToggleButton>('CheckBox')!,
+		checkpointsRequired: $('#CheckpointsRequired')!.FindChild<ToggleButton>('CheckBox')!,
+		checkpointsOrdered: $('#CheckpointsOrdered')!.FindChild<ToggleButton>('CheckBox')!,
+		segmentName: $<TextEntry>('#SegmentName')!,
+		propertiesZone: $<Panel>('#ZoneProperties')!,
+		infoPanel: $<Panel>('#InfoPanel')!,
+		selectionMode: $<Label>('#SelectionMode')!,
+		filterSelect: $<DropDown>('#FilterSelect')!,
+		volumeSelect: $<DropDown>('#VolumeSelect')!,
+		regionSelect: $<DropDown>('#RegionSelect')!,
+		regionBottom: $<TextEntry>('#RegionBottom')!,
+		regionHeight: $<TextEntry>('#RegionHeight')!,
+		regionSafeHeight: $<TextEntry>('#RegionSafeHeight')!,
+		regionTPDest: $<DropDown>('#RegionTPDest')!,
 		regionTPPos: {
-			x: $<TextEntry>('#TeleX'),
-			y: $<TextEntry>('#TeleY'),
-			z: $<TextEntry>('#TeleZ')
+			x: $<TextEntry>('#TeleX')!,
+			y: $<TextEntry>('#TeleY')!,
+			z: $<TextEntry>('#TeleZ')!
 		},
-		regionTPPosButton: $<Button>('#SetTeleDestPosButton'),
-		regionTPYaw: $<TextEntry>('#TeleYaw'),
-		regionTPYawButton: $<Button>('#SetTeleDestYawButton')
+		regionTPPosButton: $<Button>('#SetTeleDestPosButton')!,
+		regionTPYaw: $<TextEntry>('#TeleYaw')!,
+		regionTPYawButton: $<Button>('#SetTeleDestYawButton')!
 	};
 
-	zoningLimits: ZoneEditorLimits;
+	zoningLimits: ZoneEditorLimits | null = null;
 	selectedZone = {
 		track: null as MainTrack | BonusTrack | null,
 		segment: null as Segment | null,
 		zone: null as Zone | null,
 		region: null as Region | null
 	};
-	activeDeleteButton: Button | null;
-	mapZoneData: MapZones | null;
-	filternameList: string[] | null;
-	teleDestList: string[] | null;
+	activeDeleteButton: Button | null = null;
+	mapZoneData: MapZones | null = null;
+	filternameList: string[] | null = null;
+	teleDestList: string[] | null = null;
 
 	constructor() {
 		$.RegisterForUnhandledEvent('ZoneMenu_Show', () => this.showZoneMenu());
 		$.RegisterForUnhandledEvent('ZoneMenu_Hide', () => this.hideZoneMenu());
 		$.RegisterForUnhandledEvent('OnRegionEditCompleted', (region) => this.onRegionEditCompleted(region));
 		$.RegisterForUnhandledEvent('OnRegionEditCanceled', () => this.onRegionEditCanceled());
-
 		$.RegisterForUnhandledEvent('LevelInitPostEntity', this.onLoad.bind(this));
 	}
 
@@ -167,10 +166,9 @@ class ZoneMenuHandler {
 			this.mapZoneData.tracks.main.zones?.segments?.length > 0 &&
 			this.mapZoneData.tracks.main.zones.segments[0]?.checkpoints?.length === 0
 		) {
-			const checkpointButton = this.panels.trackList
-				.GetChild(0)
-				?.FindChildTraverse<Button>('AddCheckpointButton');
-			const checkpointLabel = checkpointButton?.GetChild<Label>(0);
+			const mainTrackPanel = this.panels.trackList.GetChild(0)!;
+			const checkpointButton = mainTrackPanel.FindChildTraverse<Button>('AddCheckpointButton')!;
+			const checkpointLabel = checkpointButton.GetChild<Label>(0)!;
 			const startLabel = $.CreatePanel('Label', checkpointButton, '', {
 				class: 'zoning__tracklist-label zoning__tracklist-label--add'
 			});
@@ -178,25 +176,26 @@ class ZoneMenuHandler {
 			checkpointLabel.SetHasClass('hide', true);
 			startLabel.text = $.Localize('#Zoning_CreateStart');
 
-			const checkpointList = this.panels.trackList.GetChild(0).FindChildTraverse<Panel>('CheckpointContainer');
+			const checkpointList = mainTrackPanel.FindChildTraverse<Panel>('CheckpointContainer')!;
 			checkpointButton.SetPanelEvent('onactivate', () => {
 				checkpointLabel.SetHasClass('hide', false);
 				startLabel.SetHasClass('hide', true);
 				this.addCheckpoint(
-					this.mapZoneData.tracks.main,
-					this.mapZoneData.tracks.main.zones.segments[0],
+					this.mapZoneData!.tracks.main,
+					this.mapZoneData!.tracks.main.zones.segments[0],
 					checkpointList
 				);
 
-				checkpointList.GetChild(0).FindChildTraverse<Label>('Name').text = $.Localize('#Zoning_Start_Track');
+				checkpointList.GetChild(0)!.FindChildTraverse<Label>('Name')!.text = $.Localize('#Zoning_Start_Track');
 
-				checkpointButton.SetPanelEvent('onactivate', () =>
+				checkpointButton.SetPanelEvent('onactivate', () => {
+					if (!this.mapZoneData) return;
 					this.addCheckpoint(
 						this.mapZoneData.tracks.main,
 						this.mapZoneData.tracks.main.zones.segments[0],
 						checkpointList
-					)
-				);
+					);
+				});
 			});
 		}
 
@@ -205,11 +204,11 @@ class ZoneMenuHandler {
 			this.createTrackEntry(this.panels.trackList, bonus, `${bonusTag} ${i + 1}`);
 		}
 
-		const lastTrack = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses?.length ?? 0);
-		const addBonusButton = lastTrack.FindChildTraverse<Panel>('AddBonusButton');
+		const lastTrack = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses?.length ?? 0)!;
+		const addBonusButton = lastTrack.FindChildTraverse<Panel>('AddBonusButton')!;
 		addBonusButton.SetHasClass('hide', false);
 
-		const mainTrackButton = this.panels.trackList.GetChild(0).FindChildTraverse<ToggleButton>('SelectButton');
+		const mainTrackButton = this.panels.trackList.GetChild(0)!.FindChildTraverse<ToggleButton>('SelectButton')!;
 		mainTrackButton.SetSelected(true);
 
 		this.updateSelection(this.mapZoneData.tracks.main, null, null, null);
@@ -228,6 +227,8 @@ class ZoneMenuHandler {
 			this.panels.trackList.RemoveAndDeleteChildren();
 		}
 		this.activeDeleteButton = null;
+
+		if (!this.mapZoneData) return;
 
 		MomentumTimerAPI.SetActiveZoneDefs(this.mapZoneData);
 	}
@@ -248,11 +249,11 @@ class ZoneMenuHandler {
 		if (trackChildContainer === null) return;
 		if (track.zones === undefined) {
 			trackChildContainer.RemoveAndDeleteChildren();
-			trackChildContainer.GetParent().FindChildTraverse('CollapseButton').visible = false;
+			trackChildContainer.GetParent()!.FindChildTraverse('CollapseButton')!.visible = false;
 			return;
 		}
 
-		const trackSegmentContainer = trackChildContainer.FindChildTraverse<Panel>('SegmentContainer');
+		const trackSegmentContainer = trackChildContainer.FindChildTraverse<Panel>('SegmentContainer')!;
 		const segmentTag = $.Localize('#Zoning_Segment');
 		const checkpointTag = $.Localize('#Zoning_Checkpoint');
 		const cancelTag = $.Localize('#Zoning_CancelZone');
@@ -272,11 +273,11 @@ class ZoneMenuHandler {
 
 			if (segmentChildContainer === null) continue;
 			if (segment.checkpoints?.length === 0 && segment.cancel?.length === 0) {
-				trackChildContainer.FindChildTraverse<Panel>('CollapseButton').visible = false;
+				trackChildContainer.FindChildTraverse<Panel>('CollapseButton')!.visible = false;
 				continue;
 			}
 
-			const segmentCheckpointContainer = segmentChildContainer.FindChildTraverse<Panel>('CheckpointContainer');
+			const segmentCheckpointContainer = segmentChildContainer.FindChildTraverse<Panel>('CheckpointContainer')!;
 			for (const [j, zone] of segment.checkpoints?.entries() ?? []) {
 				const minorId = j
 					? `${checkpointTag} ${j}`
@@ -290,7 +291,7 @@ class ZoneMenuHandler {
 				});
 			}
 
-			const segmentCancelContainer = segmentChildContainer.FindChildTraverse<Panel>('CancelContainer');
+			const segmentCancelContainer = segmentChildContainer.FindChildTraverse<Panel>('CancelContainer')!;
 			for (const [j, zone] of segment.cancel?.entries() ?? []) {
 				const cancelId = `${cancelTag} ${j + 1}`;
 				this.addTracklistEntry(segmentCancelContainer, cancelId, TracklistSnippet.CHECKPOINT, {
@@ -302,7 +303,7 @@ class ZoneMenuHandler {
 		}
 
 		if (track.zones.end) {
-			const trackEndZoneContainer = trackChildContainer.FindChildTraverse<Panel>('EndZoneContainer');
+			const trackEndZoneContainer = trackChildContainer.FindChildTraverse<Panel>('EndZoneContainer')!;
 			this.addTracklistEntry(trackEndZoneContainer, endTag, TracklistSnippet.CHECKPOINT, {
 				track: track,
 				segment: null,
@@ -315,28 +316,35 @@ class ZoneMenuHandler {
 		parent: GenericPanel,
 		name: string,
 		snippet: string,
-		selectionObj: { track: MainTrack | BonusTrack; segment: Segment | null; zone: Zone | null },
+		selectionObj: { track: MainTrack | BonusTrack | null; segment: Segment | null; zone: Zone | null },
 		setActive: boolean = false
 	): GenericPanel | null {
 		const newTracklistPanel = $.CreatePanel('Panel', parent, name);
 		newTracklistPanel.LoadLayoutSnippet(snippet);
 
-		const label = newTracklistPanel.FindChildTraverse<Label>('Name');
+		const label = newTracklistPanel.FindChildTraverse<Label>('Name')!;
 		label.text = name;
 
-		const collapseButton = newTracklistPanel.FindChildTraverse('CollapseButton');
-		const childContainer = newTracklistPanel.FindChildTraverse('ChildContainer');
-		const expandIcon = newTracklistPanel.FindChildTraverse<Image>('TracklistExpandIcon');
-		const collapseIcon = newTracklistPanel.FindChildTraverse<Image>('TracklistCollapseIcon');
+		const collapseButton = newTracklistPanel.FindChildTraverse('CollapseButton')!;
+		const childContainer = newTracklistPanel.FindChildTraverse('ChildContainer')!;
+		const expandIcon = newTracklistPanel.FindChildTraverse<Image>('TracklistExpandIcon')!;
+		const collapseIcon = newTracklistPanel.FindChildTraverse<Image>('TracklistCollapseIcon')!;
+
+		// checkpoint entries do not have a collapse button or child container
 		if (collapseButton && childContainer) {
 			collapseButton.SetPanelEvent('onactivate', () =>
 				this.toggleCollapse(childContainer, expandIcon, collapseIcon)
 			);
 		}
 
-		const selectButton = newTracklistPanel.FindChildTraverse<ToggleButton>('SelectButton');
-		const deleteButton = newTracklistPanel.FindChildTraverse<Button>('DeleteButton');
-		if ('stagesEndAtStageStarts' in selectionObj.track && !selectionObj.segment && !selectionObj.zone) {
+		const selectButton = newTracklistPanel.FindChildTraverse<ToggleButton>('SelectButton')!;
+		const deleteButton = newTracklistPanel.FindChildTraverse<Button>('DeleteButton')!;
+		if (
+			selectionObj.track &&
+			'stagesEndAtStageStarts' in selectionObj.track &&
+			!selectionObj.segment &&
+			!selectionObj.zone
+		) {
 			selectButton.SetPanelEvent('onactivate', () => {
 				this.updateSelection(selectionObj.track, selectionObj.segment, selectionObj.zone, null);
 			});
@@ -349,9 +357,12 @@ class ZoneMenuHandler {
 		}
 
 		if (selectionObj.zone) {
-			selectButton.SetPanelEvent('ondblclick', () =>
-				this.panels.zoningMenu.moveToRegion(selectionObj.zone.regions[0])
-			);
+			selectButton.SetPanelEvent('ondblclick', () => {
+				if (!selectionObj.zone || !selectionObj.zone.regions[0])
+					throw new Error('Attempted to teleport to missing zone/region!');
+
+				this.panels.zoningMenu.moveToRegion(selectionObj.zone.regions[0]);
+			});
 		} else {
 			selectButton.SetPanelEvent('ondblclick', () =>
 				this.toggleCollapse(childContainer, expandIcon, collapseIcon)
@@ -359,34 +370,36 @@ class ZoneMenuHandler {
 		}
 
 		if (snippet === TracklistSnippet.TRACK) {
-			const addSegmentButton = childContainer.FindChildTraverse<Panel>('AddSegmentButton');
-			const addEndZoneButton = childContainer.FindChildTraverse<Panel>('AddEndZoneButton');
-			if (!('stagesEndAtStageStarts' in selectionObj.track)) {
+			const addSegmentButton = childContainer.FindChildTraverse<Panel>('AddSegmentButton')!;
+			const addEndZoneButton = childContainer.FindChildTraverse<Panel>('AddEndZoneButton')!;
+			if (selectionObj.track && !('stagesEndAtStageStarts' in selectionObj.track)) {
 				addSegmentButton.DeleteAsync(0);
 			} else {
 				addSegmentButton.SetPanelEvent('onactivate', () => this.addSegment());
 			}
-			addEndZoneButton.SetPanelEvent('onactivate', () => this.addEndZone(selectionObj.track));
-			if (selectionObj.track.zones.end) {
+			addEndZoneButton.SetPanelEvent('onactivate', () => this.addEndZone(selectionObj.track!));
+			if (selectionObj.track?.zones?.end) {
 				addEndZoneButton.SetHasClass('hide', true);
 			}
 		}
 
 		if (snippet === TracklistSnippet.SEGMENT) {
-			const addCheckpointButton = childContainer.FindChildTraverse<Panel>('AddCheckpointButton');
-			const addCancelZoneButton = childContainer.FindChildTraverse<Panel>('AddCancelZoneButton');
+			const addCheckpointButton = childContainer.FindChildTraverse<Panel>('AddCheckpointButton')!;
+			const addCancelZoneButton = childContainer.FindChildTraverse<Panel>('AddCancelZoneButton')!;
 			addCheckpointButton.SetPanelEvent('onactivate', () =>
+				// addCheckpoint() handles bad track and segment arguments
 				this.addCheckpoint(
-					selectionObj.track,
-					selectionObj.segment,
-					childContainer.FindChildTraverse<Panel>('CheckpointContainer')
+					selectionObj.track!,
+					selectionObj.segment!,
+					childContainer.FindChildTraverse<Panel>('CheckpointContainer')!
 				)
 			);
 			addCancelZoneButton.SetPanelEvent('onactivate', () =>
+				// addCancelZone() handles bad track and segment arguments
 				this.addCancelZone(
-					selectionObj.track,
-					selectionObj.segment,
-					childContainer.FindChildTraverse<Panel>('CancelContainer')
+					selectionObj.track!,
+					selectionObj.segment!,
+					childContainer.FindChildTraverse<Panel>('CancelContainer')!
 				)
 			);
 		}
@@ -474,10 +487,12 @@ class ZoneMenuHandler {
 		this.selectedZone.zone = selectedZone;
 		this.selectedZone.region = null; // this is set in populateRegionProperties()
 
-		const validity = this.isSelectionValid();
-		this.panels.propertiesTrack.visible = !validity.zone && !validity.segment && validity.track;
-		this.panels.propertiesSegment.visible = !validity.zone && validity.segment;
-		this.panels.propertiesZone.visible = validity.zone;
+		const validTrack = this.hasSelectedTrack();
+		const validSegment = this.hasSelectedSegment();
+		const validZone = this.hasSelectedZone();
+		this.panels.propertiesTrack.visible = !validZone && !validSegment && validTrack;
+		this.panels.propertiesSegment.visible = !validZone && validSegment;
+		this.panels.propertiesZone.visible = validZone;
 
 		this.activeDeleteButton?.SetHasClass('hide', true);
 		deleteButton?.SetHasClass('hide', false);
@@ -491,8 +506,8 @@ class ZoneMenuHandler {
 	}
 
 	populateZoneProperties() {
-		if (!this.mapZoneData || !this.isSelectionValid().zone) return;
-		const zone = this.selectedZone.zone!;
+		if (!this.mapZoneData || !this.hasSelectedZone()) return;
+		const zone = this.selectedZone.zone;
 		const filterIndex = zone.filtername ? (this.filternameList?.indexOf(zone.filtername) ?? 0) : 0;
 		this.panels.filterSelect.SetSelectedIndex(filterIndex);
 		this.populateDropdown(zone.regions, this.panels.regionSelect, 'Region', true);
@@ -501,8 +516,8 @@ class ZoneMenuHandler {
 	}
 
 	populateSegmentProperties() {
-		if (!this.mapZoneData || !this.isSelectionValid().segment) return;
-		const segment = this.selectedZone.segment!;
+		if (!this.mapZoneData || !this.hasSelectedSegment()) return;
+		const segment = this.selectedZone.segment;
 		this.panels.limitGroundSpeed.SetSelected(segment.limitStartGroundSpeed);
 		this.panels.checkpointsRequired.SetSelected(segment.checkpointsRequired);
 		this.panels.checkpointsOrdered.SetSelected(segment.checkpointsOrdered);
@@ -510,12 +525,12 @@ class ZoneMenuHandler {
 	}
 
 	populateTrackProperties() {
-		if (!this.mapZoneData || !this.isSelectionValid().track) return;
-		const track = this.selectedZone.track!;
-		const parentPanel = this.panels.stagesEndAtStageStarts.GetParent();
-		parentPanel.visible = 'stagesEndAtStageStarts' in track;
+		if (!this.mapZoneData || !this.hasSelectedTrack()) return;
+		const track = this.selectedZone.track;
+		const parentPanel = this.panels.stagesEndAtStageStarts.GetParent()!;
+		parentPanel.visible = this.hasSelectedMainTrack();
 		this.panels.stagesEndAtStageStarts.SetSelected(Boolean((track as MainTrack).stagesEndAtStageStarts ?? false));
-		this.panels.defragModifiers.visible = this.selectedZone.track !== this.mapZoneData.tracks.main;
+		this.panels.defragModifiers.visible = this.hasSelectedBonusTrack();
 		this.panels.maxVelocity.text =
 			this.mapZoneData.maxVelocity === undefined ? '' : this.mapZoneData.maxVelocity.toFixed(0);
 	}
@@ -543,7 +558,7 @@ class ZoneMenuHandler {
 			? region.teleDestPos !== undefined && region.teleDestYaw !== undefined
 				? 1
 				: 0
-			: this.teleDestList?.indexOf(region?.teleDestTargetname);
+			: (this.teleDestList?.indexOf(region?.teleDestTargetname) ?? 0);
 		this.panels.regionTPDest.SetSelectedIndex(tpIndex);
 		this.onTPDestSelectionChanged();
 	}
@@ -558,6 +573,8 @@ class ZoneMenuHandler {
 	}
 
 	deleteRegion() {
+		if (!this.mapZoneData || !this.selectedZone.region) return;
+
 		if (this.selectedZone.zone?.regions?.length === 1) {
 			UiToolkitAPI.ShowGenericPopupTwoOptionsBgStyle(
 				$.Localize('#Zoning_Delete'),
@@ -565,22 +582,31 @@ class ZoneMenuHandler {
 				'warning-popup',
 				$.Localize('#Zoning_Delete'),
 				() => {
-					const trackIndex =
-						this.selectedZone.track === this.mapZoneData.tracks.main
-							? 0
-							: this.mapZoneData.tracks.bonuses.indexOf(this.selectedZone.track) + 1;
-					const segmentIndex = this.selectedZone.track.zones.segments.indexOf(this.selectedZone.segment);
+					if (!this.mapZoneData || !this.selectedZone?.track || !this.selectedZone.track.zones) return;
+					const trackIndex = this.hasSelectedBonusTrack()
+						? this.mapZoneData.tracks.bonuses!.indexOf(this.selectedZone.track) + 1
+						: 0;
 
 					this.deleteSelection();
-					const childContainer = this.panels.trackList
-						.GetChild(trackIndex)
-						?.FindChildTraverse('ChildContainer');
-					const segmentPanel = childContainer?.FindChildTraverse('SegmentContainer')?.GetChild(segmentIndex);
-					const selectButton = segmentPanel?.FindChildTraverse<ToggleButton>('SelectButton');
-					const deleteButton = segmentPanel?.FindChildTraverse<Button>('DeleteButton');
+					const trackPanel = this.panels.trackList.GetChild(trackIndex)!;
+					const trackChildContainer = trackPanel.FindChildTraverse('ChildContainer')!;
+					if (this.hasSelectedSegment()) {
+						const segmentIndex = this.selectedZone.track.zones.segments.indexOf(this.selectedZone.segment);
+						const segmentPanel = trackChildContainer
+							.FindChildTraverse('SegmentContainer')!
+							.GetChild(segmentIndex);
+						const selectButton = segmentPanel?.FindChildTraverse<ToggleButton>('SelectButton');
+						const deleteButton = segmentPanel?.FindChildTraverse<Button>('DeleteButton');
 
-					selectButton?.SetSelected(true);
-					this.updateSelection(this.selectedZone.track, this.selectedZone.segment, null, deleteButton);
+						if (selectButton) selectButton.SetSelected(true);
+						if (deleteButton)
+							this.updateSelection(
+								this.selectedZone.track,
+								this.selectedZone.segment,
+								null,
+								deleteButton
+							);
+					}
 				},
 				$.Localize('#Zoning_Recreate'),
 				() => {
@@ -675,29 +701,37 @@ class ZoneMenuHandler {
 
 		const teleDestIndex = this.panels.regionTPDest.GetSelected()?.GetAttributeInt('value', 0);
 		if (teleDestIndex === 0) {
-			// no teleport destination for this region
+			// user is requesting no teleport destination for this region
 			this.selectedZone.region.teleDestTargetname = '';
 			delete this.selectedZone.region.teleDestPos;
 			delete this.selectedZone.region.teleDestYaw;
 
 			this.setRegionTPDestTextEntriesActive(false);
 		} else if (teleDestIndex === 1 && this.selectedZone.region.points?.length > 0) {
+			// user is requesting to place a TP destination at some location (not entity)
 			if (
 				this.selectedZone.region.teleDestPos === undefined ||
 				this.selectedZone.region.teleDestYaw === undefined
 			) {
-				this.selectedZone.region = this.panels.zoningMenu.createDefaultTeleDest(this.selectedZone.region);
-				this.selectedZone.region.teleDestYaw = 0;
 				this.selectedZone.region.teleDestTargetname = '';
+				const index = this.panels.regionSelect.GetSelected()?.GetAttributeInt('value', -1);
+				if (index !== -1)
+					this.selectedZone.zone.regions[index] = this.panels.zoningMenu.createDefaultTeleDest(
+						this.selectedZone.region
+					);
+
+				this.selectedZone.region = this.selectedZone.zone.regions[index];
+				this.pickTeleDestYaw();
 			}
 
-			this.panels.regionTPPos.x.text = this.selectedZone.region.teleDestPos[0].toFixed(2);
-			this.panels.regionTPPos.y.text = this.selectedZone.region.teleDestPos[1].toFixed(2);
-			this.panels.regionTPPos.z.text = this.selectedZone.region.teleDestPos[2].toFixed(2);
-			this.panels.regionTPYaw.text = this.selectedZone.region.teleDestYaw.toFixed(2);
+			this.panels.regionTPPos.x.text = this.selectedZone.region.teleDestPos?.at(0)?.toFixed(2) ?? '';
+			this.panels.regionTPPos.y.text = this.selectedZone.region.teleDestPos?.at(1)?.toFixed(2) ?? '';
+			this.panels.regionTPPos.z.text = this.selectedZone.region.teleDestPos?.at(2)?.toFixed(2) ?? '';
+			this.panels.regionTPYaw.text = this.selectedZone.region.teleDestYaw?.toFixed(2) ?? '';
 
 			this.setRegionTPDestTextEntriesActive(true);
 		} else {
+			// user is requesting to use an entity as the TP destination
 			this.selectedZone.region.teleDestTargetname = this.teleDestList[teleDestIndex];
 			delete this.selectedZone.region.teleDestPos;
 			delete this.selectedZone.region.teleDestYaw;
@@ -717,11 +751,11 @@ class ZoneMenuHandler {
 		const yaw = Number.parseFloat(this.panels.regionTPYaw.text);
 
 		this.selectedZone.region.teleDestPos = [
-			Number.isNaN(x) ? 0 : x,
-			Number.isNaN(y) ? 0 : y,
-			Number.isNaN(z) ? 0 : z
+			Number.isNaN(x) ? undefined : x,
+			Number.isNaN(y) ? undefined : y,
+			Number.isNaN(z) ? undefined : z
 		];
-		this.selectedZone.region.teleDestYaw = Number.isNaN(yaw) ? 0 : yaw;
+		this.selectedZone.region.teleDestYaw = Number.isNaN(yaw) ? undefined : yaw;
 
 		this.drawZones();
 	}
@@ -743,6 +777,8 @@ class ZoneMenuHandler {
 	}
 
 	onRegionEditCompleted(newRegion: Region) {
+		if (!this.selectedZone.zone) return;
+
 		const index = this.panels.regionSelect.GetSelected()?.GetAttributeInt('value', -1);
 		if (index !== -1) this.selectedZone.zone.regions[index] = newRegion;
 
@@ -751,7 +787,7 @@ class ZoneMenuHandler {
 	}
 
 	onRegionEditCanceled() {
-		if (!this.selectedZone?.region?.points.length) this.deleteRegion();
+		if (this.selectedZone?.region?.points.length === 0) this.deleteRegion();
 
 		this.showInfoPanel(false);
 		this.drawZones();
@@ -767,8 +803,8 @@ class ZoneMenuHandler {
 	addBonus() {
 		if (!this.mapZoneData) return;
 
-		const lastTrack = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses?.length ?? 0);
-		const addBonusButton = lastTrack.FindChildTraverse<Panel>('AddBonusButton');
+		const lastTrack = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses?.length ?? 0)!;
+		const addBonusButton = lastTrack.FindChildTraverse<Panel>('AddBonusButton')!;
 		addBonusButton.SetHasClass('hide', true);
 
 		const bonus = this.createBonusTrack();
@@ -784,18 +820,18 @@ class ZoneMenuHandler {
 			`${$.Localize('#Zoning_Bonus')} ${this.mapZoneData.tracks.bonuses.length}`
 		);
 
-		const newBonusPanel = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses.length);
-		const segmentContainer = newBonusPanel.FindChildTraverse('SegmentContainer');
-		const checkpointContainer = segmentContainer.FindChildTraverse<Panel>('CheckpointContainer');
-		this.addCheckpoint(bonus, bonus.zones.segments[0], checkpointContainer);
+		const newBonusPanel = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses.length)!;
+		const segmentContainer = newBonusPanel.FindChildTraverse('SegmentContainer')!;
+		const checkpointContainer = segmentContainer.FindChildTraverse<Panel>('CheckpointContainer')!;
+		this.addCheckpoint(bonus, bonus.zones!.segments[0], checkpointContainer);
 
-		const selectButton = checkpointContainer.FindChildTraverse<ToggleButton>('SelectButton');
-		const deleteButton = checkpointContainer.FindChildTraverse<Button>('DeleteButton');
-		const newBonusButton = newBonusPanel.FindChildTraverse<Panel>('AddBonusButton');
+		const selectButton = checkpointContainer.FindChildTraverse<ToggleButton>('SelectButton')!;
+		const deleteButton = checkpointContainer.FindChildTraverse<Button>('DeleteButton')!;
+		const newBonusButton = newBonusPanel.FindChildTraverse<Panel>('AddBonusButton')!;
 		newBonusButton.SetHasClass('hide', false);
 		selectButton.SetSelected(true);
 
-		this.updateSelection(bonus, bonus.zones.segments[0], bonus.zones.segments[0].checkpoints[0], deleteButton);
+		this.updateSelection(bonus, bonus.zones!.segments[0], bonus.zones!.segments[0].checkpoints[0], deleteButton);
 	}
 
 	addSegment() {
@@ -810,14 +846,15 @@ class ZoneMenuHandler {
 			mainTrack.zones.segments.push(newSegment);
 		}
 
-		const segmentList = this.panels.trackList.GetChild(0)?.FindChildTraverse('SegmentContainer');
+		const mainTrackPanel = this.panels.trackList.GetChild(0)!;
+		const segmentList = mainTrackPanel.FindChildTraverse('SegmentContainer')!;
 		const id = `${$.Localize('#Zoning_Segment')} ${mainTrack.zones.segments.length}`;
 		const childContainer = this.addTracklistEntry(segmentList, id, TracklistSnippet.SEGMENT, {
 			track: mainTrack,
 			segment: newSegment,
 			zone: null
-		});
-		const checkpointContainer = childContainer.FindChildTraverse<Panel>('CheckpointContainer');
+		})!;
+		const checkpointContainer = childContainer.FindChildTraverse<Panel>('CheckpointContainer')!;
 		this.addTracklistEntry(
 			checkpointContainer,
 			mainTrack.zones.segments.length > 0 ? $.Localize('#Zoning_Start_Stage') : $.Localize('#Zoning_Start_Track'),
@@ -832,7 +869,10 @@ class ZoneMenuHandler {
 	}
 
 	addCheckpoint(track: MainTrack | BonusTrack, segment: Segment, checkpointsList: Panel) {
-		if (!this.mapZoneData || !segment || !checkpointsList) return;
+		if (!this.mapZoneData || !checkpointsList) return;
+		if (!track) throw new Error('Attempted to add checkpoint zone to missing track!');
+		if (!segment) throw new Error('Attempted to add checkpoint zone to missing segment!');
+		if (this.hasSelectedDefragBonus()) throw new Error('Defrag Bonus must share zones with Main track!');
 
 		const newZone = this.createZone();
 		segment.checkpoints.push(newZone);
@@ -840,7 +880,7 @@ class ZoneMenuHandler {
 		const id =
 			segment.checkpoints.length > 1
 				? `${$.Localize('#Zoning_Checkpoint')} ${segment.checkpoints.length - 1}`
-				: track.zones.segments.indexOf(segment) > 0
+				: track.zones!.segments.indexOf(segment) > 0
 					? $.Localize('#Zoning_Start_Stage')
 					: $.Localize('#Zoning_Start_Track');
 		this.addTracklistEntry(
@@ -859,40 +899,45 @@ class ZoneMenuHandler {
 
 	addEndZone(track: MainTrack | BonusTrack) {
 		// TODO: fix this seleciton logic
-		if (!this.mapZoneData || !this.isSelectionValid().track) return;
-		if (this.isSelectionValid().defragBonus) {
-			$.Warning('Defrag Bonus must share zones with Main track!');
-			return;
+		if (!this.mapZoneData || !this.hasSelectedTrack()) return;
+		if (this.hasSelectedDefragBonus()) {
+			throw new Error('Defrag Bonus must share zones with Main track!');
 		}
+
 		const endZone = this.createZone();
-		track.zones.end = endZone;
+		track.zones!.end = endZone;
 
-		let trackPanel: Panel;
-		if (track === this.mapZoneData.tracks.main) {
-			trackPanel = this.panels.trackList.GetChild(0);
-		} else {
-			const bonusId = this.mapZoneData.tracks.bonuses.indexOf(track);
-			trackPanel = this.panels.trackList.GetChild(1 + bonusId);
+		let trackPanel: Panel | null = null;
+		if (this.hasSelectedMainTrack()) {
+			trackPanel = this.panels.trackList.GetChild(0)!;
+		} else if (this.hasSelectedBonusTrack()) {
+			const bonusId = this.mapZoneData.tracks.bonuses!.indexOf(track);
+			if (bonusId === undefined || bonusId === -1) throw new Error('Selected track missing trasklist entry!');
+
+			trackPanel = this.panels.trackList.GetChild(1 + bonusId)!;
 		}
-		const endZoneContainer = trackPanel.FindChildTraverse('EndZoneContainer');
 
-		this.addTracklistEntry(
-			endZoneContainer,
-			$.Localize('#Zoning_EndZone'),
-			TracklistSnippet.CHECKPOINT,
-			{
-				track: track,
-				segment: null,
-				zone: endZone
-			},
-			true
-		);
-
-		trackPanel.FindChildTraverse('AddEndZoneButton').SetHasClass('hide', true);
+		if (trackPanel) {
+			const endZoneContainer = trackPanel.FindChildTraverse('EndZoneContainer')!;
+			this.addTracklistEntry(
+				endZoneContainer,
+				$.Localize('#Zoning_EndZone'),
+				TracklistSnippet.CHECKPOINT,
+				{
+					track: track,
+					segment: null,
+					zone: endZone
+				},
+				true
+			);
+			trackPanel.FindChildTraverse('AddEndZoneButton')!.SetHasClass('hide', true);
+		}
 	}
 
 	addCancelZone(track: MainTrack | BonusTrack, segment: Segment, cancelList: Panel) {
-		if (!this.mapZoneData || !segment || !cancelList) return;
+		if (!this.mapZoneData || !cancelList) return;
+		if (!track) throw new Error('Attempted to add cancel zone to missing track!');
+		if (!segment) throw new Error('Attempted to add cancel zone to missing segment!');
 
 		const newZone = this.createZone();
 		if (!segment.cancel) {
@@ -936,13 +981,14 @@ class ZoneMenuHandler {
 		if (this.selectedZone.track && this.selectedZone.segment && this.selectedZone.zone) {
 			const checkpointIndex = this.selectedZone.segment.checkpoints.indexOf(this.selectedZone.zone);
 			if (checkpointIndex === -1) {
-				const cancelIndex = this.selectedZone.segment.cancel.indexOf(this.selectedZone.zone);
-				this.selectedZone.segment.cancel.splice(cancelIndex, 1);
+				const cancelIndex = this.selectedZone.segment.cancel?.indexOf(this.selectedZone.zone);
+				if (cancelIndex !== undefined && cancelIndex !== -1)
+					this.selectedZone.segment.cancel!.splice(cancelIndex, 1);
 			} else {
 				this.selectedZone.segment.checkpoints.splice(checkpointIndex, 1);
 			}
 		} else if (this.selectedZone.track && this.selectedZone.segment) {
-			if (this.selectedZone.track.zones.segments?.length === 1) {
+			if (this.selectedZone.track.zones?.segments?.length === 1) {
 				$.Msg('Track must have at least one segment!');
 			}
 			const index = this.mapZoneData.tracks.main.zones.segments.indexOf(this.selectedZone.segment);
@@ -950,7 +996,7 @@ class ZoneMenuHandler {
 		} else if (this.selectedZone.track && this.selectedZone.zone) {
 			delete this.selectedZone.track.zones.end;
 		} else if (this.selectedZone.track) {
-			if ('stagesEndAtStageStarts' in this.selectedZone.track) {
+			if (this.hasSelectedMainTrack()) {
 				$.Msg("Can't delete Main track!!!");
 				this.mapZoneData.tracks.main = {
 					zones: {
@@ -959,12 +1005,13 @@ class ZoneMenuHandler {
 					},
 					stagesEndAtStageStarts: true
 				};
-			} else {
-				const trackIndex = this.mapZoneData.tracks.bonuses.indexOf(this.selectedZone.track);
-				this.mapZoneData.tracks.bonuses.splice(trackIndex, 1);
+			} else if (this.hasSelectedBonusTrack()) {
+				const trackIndex = this.mapZoneData.tracks.bonuses!.indexOf(this.selectedZone.track);
+				if (trackIndex !== undefined && trackIndex !== -1)
+					this.mapZoneData.tracks.bonuses!.splice(trackIndex, 1);
 
-				const lastTrack = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses?.length ?? 0);
-				const addBonusButton = lastTrack.FindChildTraverse<Panel>('AddBonusButton');
+				const lastTrack = this.panels.trackList.GetChild(this.mapZoneData.tracks.bonuses?.length ?? 0)!;
+				const addBonusButton = lastTrack.FindChildTraverse<Panel>('AddBonusButton')!;
 				addBonusButton.SetHasClass('hide', true);
 			}
 		}
@@ -984,12 +1031,12 @@ class ZoneMenuHandler {
 	}
 
 	setStageEndAtStageStarts() {
-		if (!this.isSelectionValid().track || !('stagesEndAtStageStarts' in this.selectedZone.track)) return;
+		if (!this.hasSelectedMainTrack()) return;
 		this.selectedZone.track.stagesEndAtStageStarts = this.panels.stagesEndAtStageStarts.checked;
 	}
 
 	showDefragFlagMenu() {
-		if (!this.isSelectionValid().track || !('defragModifiers' in this.selectedZone.track)) return;
+		if (!this.hasSelectedBonusTrack() || !('defragModifiers' in this.selectedZone.track)) return;
 
 		const flagEditMenu = UiToolkitAPI.ShowCustomLayoutContextMenuParametersDismissEvent<Panel>(
 			this.panels.defragModifiers.id,
@@ -1001,79 +1048,79 @@ class ZoneMenuHandler {
 			}
 		);
 
-		const hasteFlag = flagEditMenu.FindChildTraverse<Panel>('FlagHaste');
-		hasteFlag.checked = (this.selectedZone.track.defragModifiers & DefragFlags.HASTE) > 0;
+		const hasteFlag = flagEditMenu.FindChildTraverse<Panel>('FlagHaste')!;
+		hasteFlag.checked = (this.selectedZone.track.defragModifiers! & DefragFlags.HASTE) > 0;
 		hasteFlag.SetPanelEvent('onactivate', () => this.setDefragFlags(DefragFlags.HASTE));
 
-		const slickFlag = flagEditMenu.FindChildTraverse<Panel>('FlagSlick');
-		slickFlag.checked = (this.selectedZone.track.defragModifiers & DefragFlags.SLICK) > 0;
+		const slickFlag = flagEditMenu.FindChildTraverse<Panel>('FlagSlick')!;
+		slickFlag.checked = (this.selectedZone.track.defragModifiers! & DefragFlags.SLICK) > 0;
 		slickFlag.SetPanelEvent('onactivate', () => this.setDefragFlags(DefragFlags.SLICK));
 
-		const damageBoostFlag = flagEditMenu.FindChildTraverse<Panel>('FlagDamageBoost');
-		damageBoostFlag.checked = (this.selectedZone.track.defragModifiers & DefragFlags.DAMAGEBOOST) > 0;
+		const damageBoostFlag = flagEditMenu.FindChildTraverse<Panel>('FlagDamageBoost')!;
+		damageBoostFlag.checked = (this.selectedZone.track.defragModifiers! & DefragFlags.DAMAGEBOOST) > 0;
 		damageBoostFlag.SetPanelEvent('onactivate', () => this.setDefragFlags(DefragFlags.DAMAGEBOOST));
 
-		const rocketsFlag = flagEditMenu.FindChildTraverse<Panel>('FlagRockets');
-		rocketsFlag.checked = (this.selectedZone.track.defragModifiers & DefragFlags.ROCKETS) > 0;
+		const rocketsFlag = flagEditMenu.FindChildTraverse<Panel>('FlagRockets')!;
+		rocketsFlag.checked = (this.selectedZone.track.defragModifiers! & DefragFlags.ROCKETS) > 0;
 		rocketsFlag.SetPanelEvent('onactivate', () => this.setDefragFlags(DefragFlags.ROCKETS));
 
-		const plasmaFlag = flagEditMenu.FindChildTraverse<Panel>('FlagPlasma');
-		plasmaFlag.checked = (this.selectedZone.track.defragModifiers & DefragFlags.PLASMA) > 0;
+		const plasmaFlag = flagEditMenu.FindChildTraverse<Panel>('FlagPlasma')!;
+		plasmaFlag.checked = (this.selectedZone.track.defragModifiers! & DefragFlags.PLASMA) > 0;
 		plasmaFlag.SetPanelEvent('onactivate', () => this.setDefragFlags(DefragFlags.PLASMA));
 
-		const bfgFlag = flagEditMenu.FindChildTraverse<Panel>('FlagBFG');
-		bfgFlag.checked = (this.selectedZone.track.defragModifiers & DefragFlags.BFG) > 0;
+		const bfgFlag = flagEditMenu.FindChildTraverse<Panel>('FlagBFG')!;
+		bfgFlag.checked = (this.selectedZone.track.defragModifiers! & DefragFlags.BFG) > 0;
 		bfgFlag.SetPanelEvent('onactivate', () => this.setDefragFlags(DefragFlags.BFG));
 	}
 
 	setDefragFlags(flag: DefragFlags) {
 		// don't use defragBonus validity check because we could be setting the flags for the first time
-		if (!this.isSelectionValid().track || !('defragModifiers' in this.selectedZone.track!)) return;
-		this.selectedZone.track.defragModifiers ^= flag;
+		if (!this.hasSelectedBonusTrack() || !('defragModifiers' in this.selectedZone.track)) return;
+		this.selectedZone.track.defragModifiers! ^= flag;
 	}
 
 	onDefragFlagMenuClosed() {
-		if (!this.isSelectionValid().defragBonus) return;
+		if (!this.hasSelectedDefragBonus() || !this.mapZoneData) return;
 		delete this.selectedZone.track.zones;
-		const bonusIndex = this.mapZoneData!.tracks.bonuses.indexOf(this.selectedZone.track);
-		const trackPanel = this.panels.trackList.GetChild(1 + bonusIndex);
-		trackPanel.FindChildTraverse('CollapseButton').visible = false;
-		trackPanel.FindChildTraverse('ChildContainer').RemoveAndDeleteChildren();
+		const bonusIndex = this.mapZoneData.tracks.bonuses!.indexOf(this.selectedZone.track);
+		if (bonusIndex === undefined || bonusIndex === -1) throw new Error('Missing bonus track!');
+
+		const trackPanel = this.panels.trackList.GetChild(1 + bonusIndex)!;
+		trackPanel.FindChildTraverse('CollapseButton')!.visible = false;
+		trackPanel.FindChildTraverse('ChildContainer')!.RemoveAndDeleteChildren();
 		// keep select button aligned with other tracks
-		trackPanel.FindChildTraverse('Entry').SetHasClass('zoning__tracklist-checkpoint', true);
+		trackPanel.FindChildTraverse('Entry')!.SetHasClass('zoning__tracklist-checkpoint', true);
 	}
 
 	setLimitGroundSpeed() {
-		if (!this.isSelectionValid().segment) return;
+		if (!this.hasSelectedSegment()) return;
 		this.selectedZone.segment!.limitStartGroundSpeed = this.panels.limitGroundSpeed.checked;
 	}
 
 	setCheckpointsOrdered() {
-		if (!this.isSelectionValid().segment) return;
+		if (!this.hasSelectedSegment()) return;
 		this.selectedZone.segment!.checkpointsOrdered = this.panels.checkpointsOrdered.checked;
 	}
 
 	setCheckpointsRequired() {
-		if (!this.isSelectionValid().segment) return;
+		if (!this.hasSelectedSegment()) return;
 		this.selectedZone.segment!.checkpointsRequired = this.panels.checkpointsRequired.checked;
 	}
 
 	setSegmentName() {
-		if (!this.isSelectionValid().segment) return;
+		if (!this.hasSelectedSegment()) return;
 		this.selectedZone.segment!.name = this.panels.segmentName.text;
 		// feat: later
 		// update segment name in trasklist tree
 	}
 
 	drawZones() {
-		if (!this.mapZoneData) return;
-		if (!this.selectedZone) return;
+		if (!this.mapZoneData || !this.selectedZone) return;
 
 		const renderRegions: ZoneEditorRegion[] = [];
-
-		const validity = this.isSelectionValid();
-
-		for (const [segmentNumber, segment] of this.selectedZone.track.zones.segments?.entries() ?? []) {
+		const track = this.hasSelectedDefragBonus() ? this.mapZoneData.tracks.main : this.selectedZone.track;
+		// draw track containing selected zone (if one exists)
+		for (const [segmentNumber, segment] of track?.zones?.segments?.entries() ?? []) {
 			for (const [checkpointNumber, checkpoint] of segment.checkpoints?.entries() ?? []) {
 				for (const region of checkpoint.regions) {
 					renderRegions.push({
@@ -1084,7 +1131,7 @@ class ZoneMenuHandler {
 									? RegionRenderMode.START
 									: RegionRenderMode.MAJOR_CHECKPOINT
 								: RegionRenderMode.MINOR_CHECKPOINT,
-						editing: validity.zone && region === this.selectedZone.region
+						editing: this.hasSelectedZone() && region === this.selectedZone.region
 					});
 				}
 			}
@@ -1093,16 +1140,32 @@ class ZoneMenuHandler {
 					renderRegions.push({
 						region: region,
 						renderMode: RegionRenderMode.CANCEL,
-						editing: validity.zone && region === this.selectedZone.region
+						editing: this.hasSelectedZone() && region === this.selectedZone.region
 					});
 				}
 			}
 		}
-		for (const region of this.selectedZone.track.zones.end?.regions ?? []) {
+		for (const region of track?.zones?.end?.regions ?? []) {
 			renderRegions.push({
 				region: region,
 				renderMode: RegionRenderMode.END,
-				editing: validity.zone && region === this.selectedZone.region
+				editing: this.hasSelectedZone() && region === this.selectedZone.region
+			});
+		}
+
+		// draw global regions
+		for (const region of this.mapZoneData.globalRegions?.allowBhop ?? []) {
+			renderRegions.push({
+				region: region,
+				renderMode: RegionRenderMode.NONE,
+				editing: region === this.selectedZone.region
+			});
+		}
+		for (const region of this.mapZoneData.globalRegions?.cancel ?? []) {
+			renderRegions.push({
+				region: region,
+				renderMode: RegionRenderMode.CANCEL,
+				editing: region === this.selectedZone.region
 			});
 		}
 
@@ -1127,25 +1190,43 @@ class ZoneMenuHandler {
 
 	isStartZone(zone: Zone | null): boolean {
 		if (!zone || !this.mapZoneData) return false;
-        const { main, bonuses } = this.mapZoneData.tracks;
+		const { main, bonuses } = this.mapZoneData.tracks;
 
-        return (
-            (main.zones.segments.some?.((segment) => segment.checkpoints.at(0) === zone) ?? false) ||
-            (bonuses?.some?.((bonus) => bonus.zones?.segments?.at(0)?.checkpoints?.at(0) === zone) ?? false)
-        );
+		return (
+			(main.zones.segments.some?.((segment) => segment.checkpoints.at(0) === zone) ?? false) ||
+			(bonuses?.some?.((bonus) => bonus.zones?.segments?.at(0)?.checkpoints?.at(0) === zone) ?? false)
+		);
 	}
 
-	isSelectionValid() {
-		const trackValidity = Boolean(this.selectedZone) && Boolean(this.selectedZone.track);
-		return {
-			track: trackValidity,
-			defragBonus:
-				trackValidity &&
-				(this.selectedZone.track!.zones === undefined ||
-					('defragModifiers' in this.selectedZone.track! &&
-						Boolean(this.selectedZone.track.defragModifiers))),
-			segment: trackValidity && Boolean(this.selectedZone.segment),
-			zone: trackValidity && Boolean(this.selectedZone.zone)
-		};
+	hasSelectedTrack(): this is { selectedZone: { track: MainTrack | BonusTrack } } {
+		return this.selectedZone.track != null;
+	}
+
+	hasSelectedMainTrack(): this is { selectedZone: { track: MainTrack } } {
+		return this.selectedZone.track !== null && 'stagesEndAtStageStarts' in this.selectedZone.track;
+	}
+
+	hasSelectedBonusTrack(): this is { selectedZone: { track: BonusTrack } } {
+		return (
+			this.selectedZone.track !== null &&
+			this.selectedZone.track !== this.mapZoneData?.tracks.main &&
+			(this.mapZoneData?.tracks.bonuses?.includes(this.selectedZone.track) ?? false)
+		);
+	}
+
+	hasSelectedSegment(): this is { selectedZone: { segment: Segment }; track: MainTrack | BonusTrack } {
+		return this.selectedZone.segment != null && this.selectedZone.track != null;
+	}
+
+	hasSelectedZone(): this is { selectedZone: { zone: Zone }; track: MainTrack | BonusTrack } {
+		return this.selectedZone.zone != null && this.selectedZone.track != null;
+	}
+
+	hasSelectedDefragBonus(): this is { selectedZone: { track: { zones: undefined; defragModifiers: number } } } {
+		return (
+			this.hasSelectedBonusTrack() &&
+			(this.selectedZone.track.zones == null ||
+				('defragModifiers' in this.selectedZone.track && this.selectedZone.track.defragModifiers != null))
+		);
 	}
 }

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -559,21 +559,38 @@ class ZoneMenuHandler {
 
 	deleteRegion() {
 		if (this.selectedZone.zone?.regions?.length === 1) {
-			$.Warning("Deleted the last Region in this zone!!!");
-			const trackIndex =
-				this.selectedZone.track === this.mapZoneData.tracks.main
-					? 0
-					: this.mapZoneData.tracks.bonuses.indexOf(this.selectedZone.track) + 1;
-			const segmentIndex = this.selectedZone.track.zones.segments.indexOf(this.selectedZone.segment);
+			UiToolkitAPI.ShowGenericPopupTwoOptionsBgStyle(
+				$.Localize('#Zoning_Delete'),
+				$.Localize('#Zoning_LastRegion_Message'),
+				'warning-popup',
+				$.Localize('#Zoning_Delete'),
+				() => {
+					const trackIndex =
+						this.selectedZone.track === this.mapZoneData.tracks.main
+							? 0
+							: this.mapZoneData.tracks.bonuses.indexOf(this.selectedZone.track) + 1;
+					const segmentIndex = this.selectedZone.track.zones.segments.indexOf(this.selectedZone.segment);
 
-			this.deleteSelection();
-			const childContainer = this.panels.trackList.GetChild(trackIndex)?.FindChildTraverse('ChildContainer');
-			const segmentPanel = childContainer?.FindChildTraverse('SegmentContainer')?.GetChild(segmentIndex);
-			const selectButton = segmentPanel.FindChildTraverse<ToggleButton>('SelectButton');
-			const deleteButton = segmentPanel.FindChildTraverse<Button>('DeleteButton');
+					this.deleteSelection();
+					const childContainer = this.panels.trackList
+						.GetChild(trackIndex)
+						?.FindChildTraverse('ChildContainer');
+					const segmentPanel = childContainer?.FindChildTraverse('SegmentContainer')?.GetChild(segmentIndex);
+					const selectButton = segmentPanel?.FindChildTraverse<ToggleButton>('SelectButton');
+					const deleteButton = segmentPanel?.FindChildTraverse<Button>('DeleteButton');
 
-			selectButton?.SetSelected(true);
-			this.updateSelection(this.selectedZone.track, this.selectedZone.segment, null, deleteButton);
+					selectButton?.SetSelected(true);
+					this.updateSelection(this.selectedZone.track, this.selectedZone.segment, null, deleteButton);
+				},
+				$.Localize('#Zoning_Recreate'),
+				() => {
+					if (!this.selectedZone || !this.selectedZone.zone) throw new Error('Missing selected zone!');
+					this.selectedZone.zone.regions = [];
+					this.drawZones();
+					this.panels.zoningMenu.createRegion(this.isStartZone(this.selectedZone.zone));
+				},
+				'none'
+			);
 			return;
 		}
 		const index = this.panels.regionSelect.GetSelected()?.GetAttributeInt('value', -1);

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -395,7 +395,7 @@ class ZoneMenuHandler {
 			selectButton.SetSelected(true);
 			this.updateSelection(selectionObj.track, selectionObj.segment, selectionObj.zone, deleteButton);
 			if (selectionObj.zone) {
-				this.panels.zoningMenu.createRegion(!selectionObj.segment.checkpoints.indexOf(selectionObj.zone));
+				this.panels.zoningMenu.createRegion(this.isStartZone(selectionObj.zone));
 				this.showInfoPanel(true);
 			}
 		}
@@ -1106,6 +1106,16 @@ class ZoneMenuHandler {
 		MomentumTimerAPI.LoadZoneDefs(false);
 		this.initMenu();
 		this.drawZones();
+	}
+
+	isStartZone(zone: Zone | null): boolean {
+		if (!zone || !this.mapZoneData) return false;
+        const { main, bonuses } = this.mapZoneData.tracks;
+
+        return (
+            (main.zones.segments.some?.((segment) => segment.checkpoints.at(0) === zone) ?? false) ||
+            (bonuses?.some?.((bonus) => bonus.zones?.segments?.at(0)?.checkpoints?.at(0) === zone) ?? false)
+        );
 	}
 
 	isSelectionValid() {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -535,9 +535,9 @@ class ZoneMenuHandler {
 		const region = this.selectedZone.zone.regions[index];
 		this.selectedZone.region = region;
 
-		this.panels.regionBottom.text = (region?.bottom ?? 0).toFixed(2);
-		this.panels.regionHeight.text = (region?.height ?? 0).toFixed(2);
-		this.panels.regionSafeHeight.text = (region?.safeHeight ?? 0).toFixed(2);
+		this.panels.regionBottom.text = region?.bottom?.toFixed(2) ?? '';
+		this.panels.regionHeight.text = region?.height?.toFixed(2) ?? '';
+		this.panels.regionSafeHeight.text = region?.safeHeight?.toFixed(2) ?? '';
 
 		const tpIndex = !region.teleDestTargetname
 			? region.teleDestPos !== undefined && region.teleDestYaw !== undefined

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -303,11 +303,9 @@ interface GlobalEventNameMap {
 
 	ZoneMenu_Hide: () => void;
 
-	OnPointPicked: (region: import('common/web').Region) => void;
+	OnRegionEditCompleted: (region: import('common/web').Region) => void;
 
-	OnPointDeleted: (region: import('common/web').Region) => void;
-
-	OnPickCanceled: () => void;
+	OnRegionEditCanceled: () => void;
 
 	/** Fired when the the primary timer of the UI entity transitions to a different state */
 	OnObservedTimerStateChange: () => void;

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -151,7 +151,9 @@ interface ZoneEditorLimits {
 }
 
 interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {
-	startPointPick(mode: import('pages/zoning/zoning').PickType, region: import('common/web').Region): void;
+	createRegion(startZone: boolean): void;
+
+	editRegion(mode: import('pages/zoning/zoning').PickType, region: import('common/web').Region): void;
 
 	getEntityList(): import('pages/zoning/zoning').EntityList;
 

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -345,6 +345,11 @@ $medium: 28px;
 		flow-children: down;
 	}
 
+	&__category {
+		width: 100%;
+		flow-children: down;
+	}
+
 	&__bind {
 		width: 100%;
 		flow-children: right;


### PR DESCRIPTION
Closes momentum-mod/game/issues/2285

This pull request moves code that handles region edit state changes to c++. User facing changes:
- Unset region properties (bottom, height, safe height) are shown as blank instead of 0.00
- Deleting the last region in a zone allows the user to recreate the region for that zone. Zones are deleted from the tracklist (same as existing behavior)
- The binds list is updated to show `MOUSE2` and `ESCAPE` which function as a "back" button while editing/creating a region, and canceling the edit/creation of a region. The difference between back and cancel is subtle, cancel will always take the user straight to the menu.

Depends on red MR.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

