### PR TITLE
feat: Replace GetReplayRunMetadata with GetObservedRunMetadata

### DIFF
--- a/scripts/types-mom/apis.d.ts
+++ b/scripts/types-mom/apis.d.ts
@@ -169,8 +169,6 @@ declare namespace MomentumReplayAPI {
 	function GetReplayState(): ReplayState;
 
 	function GetReplayProgress(): ReplayProgress;
-
-	function GetReplayRunMetadata(): RunMetadata | null;
 }
 
 declare namespace ChatAPI {
@@ -253,6 +251,9 @@ declare namespace MomentumTimerAPI {
 
 	/** Gets the observed timer run splits */
 	function GetObservedTimerRunSplits(): import('common/timer').RunSplits;
+
+	/** Gets the observed run metadata. Returns null if not observing a run replay. */
+	function GetObservedRunMetadata(): RunMetadata | null;
 
 	/** Gets the ZoneDefs for the active zones, if any */
 	function GetActiveZoneDefs(): Zones;


### PR DESCRIPTION
Basically the same thing, but better upholds the design goal of pano timer UI/HUD code only ever needing to think about and check "observed" data without being acutely aware of what the observed thing is.

Note that the new API is under `MomentumTimerAPI` rather than `MomentumReplayAPI`