### PR TITLE
Insert checkpoints at arbitrary position in tracklist

### DIFF
--- a/layout/modals/context-menus/zoning-insert-zone.xml
+++ b/layout/modals/context-menus/zoning-insert-zone.xml
@@ -1,0 +1,16 @@
+<root>
+	<styles>
+		<include src="file://{resources}/styles/main.scss" />
+	</styles>
+
+	<ContextMenuCustomLayout class="contextmenu" tabindex="auto" selectionpos="auto">
+		<Panel id="ContextMenuBody" class="contextmenu simplecontextmenu zoning-context" childfocusonhover="true">
+			<Button id="InsertBefore">
+                <Label text="#Zoning_InsertBefore" class="zoning__tracklist-label" />
+            </Button>
+            <Button id="InsertAfter">
+                <Label text="#Zoning_InsertAfter" class="zoning__tracklist-label" />
+            </Button>
+		</Panel>
+	</ContextMenuCustomLayout>
+</root>


### PR DESCRIPTION
This PR adds the ability to right click a checkpoint in the zoning UI tracklist and insert a new zone before or after it.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
