### PR TITLE
Add button to extend region height to ceiling

### DIFF
--- a/images/arrow-collapse-up.svg
+++ b/images/arrow-collapse-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="#fff" d="M4.08,11.92L12,4L19.92,11.92L18.5,13.33L13,7.83V22H11V7.83L5.5,13.33L4.08,11.92M12,4H22V2H2V4H12Z" /></svg>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -176,6 +176,9 @@
 					<Panel class="zoning__property">
 						<Label class="zoning__property-label" text="#Zoning_RegionDetails_Height" />
 						<Panel class="zoning__region-property-container">
+							<Button id="ExtendToCeilingButton" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.extendToCeiling()"  onmouseover="UiToolkitAPI.ShowTextTooltip('ExtendToCeilingButton', '#Zoning_ExtendToCeiling_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+								<Image class="zoning__region-point-pick__icon" src="file://{images}/arrow-collapse-up.svg" />
+							</Button>
 							<Button id='SetHeightButton' class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickHeight()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetHeightButton', '#Zoning_SetHeight_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 							</Button>

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -654,6 +654,11 @@ class ZoneMenuHandler {
 		this.drawZones();
 	}
 
+	extendToCeiling() {
+		if (!this.selectedZone || !this.selectedZone.region) return;
+		this.panels.zoningMenu.extendRegionToCeiling(this.selectedZone.region);
+	}
+
 	pickHeight() {
 		if (!this.selectedZone || !this.selectedZone.region) return;
 		this.panels.zoningMenu.editRegion(PickType.HEIGHT, this.selectedZone.region);

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -169,4 +169,6 @@ interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {
 	getZoningLimits(): ZoneEditorLimits;
 
 	createDefaultTeleDest(region: import('common/web').Region): import('common/web').Region;
+
+	extendRegionToCeiling(region: import('common/web').Region): void;
 }


### PR DESCRIPTION
This pull request adds a button to the region properties menu that allows a region to be extended to the "tallest" ceiling point above a region. The tallest point is found by checking:
 - each corner
 - the average of all corners
 - teleport destination position if it is set and not equal to the corner average
 - teleport entity origin if one exists

Fancier logic for finding the "true" tallest point may be possible with a bit of math, but this approach should be plenty accurate for nearly all cases.

Depends on red changes.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below