### PR TITLE
enable bhop on tracks

### DIFF
--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -112,6 +112,10 @@
 							<Label class="button__text" text="#Zoning_DefragFlags_Edit" />
 						</Button>
 					</Panel>
+					<Panel id="BhopEnabled" class="zoning__property">
+						<Label class="zoning__property-label" text="#Zoning_BhopEnabled" />
+						<ToggleButton id="CheckBox" class="checkbox checkbox--right zoning__checkbox" onactivate="ZoneMenuHandler.setBhopEnabled()" />
+					</Panel>
 				</Panel>
 			</Panel>
 			<Panel id="SegmentProperties" class="zoning__property-container">

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -66,6 +66,7 @@ class ZoneMenuHandler {
 		maxVelocity: $<TextEntry>('#MaxVelocity')!,
 		defragModifiers: $<Panel>('#DefragFlags')!,
 		stagesEndAtStageStarts: $('#StagesEndAtStageStarts')!.FindChild<ToggleButton>('CheckBox')!,
+		bhopEnabled: $('#BhopEnabled')!.FindChild<ToggleButton>('CheckBox')!,
 		propertiesSegment: $<Panel>('#SegmentProperties')!,
 		limitGroundSpeed: $('#LimitGroundSpeed')!.FindChild<ToggleButton>('CheckBox')!,
 		checkpointsRequired: $('#CheckpointsRequired')!.FindChild<ToggleButton>('CheckBox')!,
@@ -1090,6 +1091,11 @@ class ZoneMenuHandler {
 		trackPanel.FindChildTraverse('ChildContainer')!.RemoveAndDeleteChildren();
 		// keep select button aligned with other tracks
 		trackPanel.FindChildTraverse('Entry')!.SetHasClass('zoning__tracklist-checkpoint', true);
+	}
+
+	setBhopEnabled() {
+		if (!this.hasSelectedMainTrack() || !this.hasSelectedBonusTrack()) return;
+		this.selectedZone.track.bhopEnabled = this.panels.bhopEnabled.checked;
 	}
 
 	setLimitGroundSpeed() {


### PR DESCRIPTION
Closes momentum-mod/game/issues/2288

This pull request adds a checkbox to enable bhop on tracks.

This PR must be merged after state machine changes ([199](https://github.com/momentum-mod/panorama/pull/199))

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below