### PR TITLE
Update End of Run page when new comparison is set

### DIFF
--- a/scripts/pages/end-of-run/end-of-run.ts
+++ b/scripts/pages/end-of-run/end-of-run.ts
@@ -516,7 +516,7 @@ class EndOfRunHandler {
 				selectionSize: 25,
 				events: {
 					// Set the activate event to just press the radiobutton in the splits panel, simplifies the code.
-					onactivate: () => $.DispatchEvent('Activated', $(`#Split${id}`), PanelEventSource.MOUSE),
+					onactivate: () => $.DispatchEvent('Activated', $(`#Split${id}`)!, PanelEventSource.MOUSE),
 					onmouseover: () => {
 						if (!stat) {
 							this.panels.cp.SetDialogVariableFloat('total_time', split.time);


### PR DESCRIPTION
Closes momentum-mod/game/issues/2306

Pretty easy to do with new events. The logic is a bit gross given the dependence on order of events firing but that seems to be very much by design in C++. Have tested pretty thoroughly.

Based on top of https://github.com/momentum-mod/panorama/pull/202

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
