### PR TITLE
feat: Incorporate refreshed API from lobby system rewrite

### DIFF
--- a/scripts/common/online.ts
+++ b/scripts/common/online.ts
@@ -7,7 +7,7 @@ export interface Lobby {
 
 	members_limit: number;
 
-	isRoaming: boolean;
+	is_map_lobby: boolean;
 }
 
 /* List of all lobbies grouped by currrent/friends/global */
@@ -21,12 +21,6 @@ export type MemberData = Record<steamID, LobbyMember>;
 export interface LobbyMember {
 	map: string;
 
-	/**
-	 * Currently a KV1 string with structure of Appearance.
-	 * If/when needed, tell a C++ programmer - we need to unfuck this code first.
-	 */
-	appearance: string;
-
 	isTyping: 'y' | undefined;
 
 	isSpectating: '1' | undefined;
@@ -35,17 +29,6 @@ export interface LobbyMember {
 	isMuted: boolean | undefined;
 
 	specTargetID: steamID;
-}
-
-interface Appearance {
-	bodygroup: int32;
-	/** RGBA Hex */
-	model_color: string;
-	/** RGBA Hex */
-	trail_color: string;
-	trail_length: int32;
-	trail_enabled: boolean;
-	flashlight_enabled: boolean;
 }
 
 // TODO: All of left/disconnected/kicked/banned are lumped into LEAVE here in C++, could distinguish if needed.

--- a/scripts/modals/popups/lobby-settings.ts
+++ b/scripts/modals/popups/lobby-settings.ts
@@ -11,7 +11,6 @@ class LobbySettingsHandler implements OnPanelLoad {
 		maxPlayers: $<TextEntry>('#MaxPlayers')
 	};
 
-	lobbyMaxPlayers = 250;
 	lobbyButtons: ReadonlyMap<LobbyType, Button> = new Map([
 		[LobbyType.PRIVATE, $('#LobbySettingsPrivateButton')],
 		[LobbyType.FRIENDS, $('#LobbySettingsFriendsOnlyButton')],
@@ -20,17 +19,20 @@ class LobbySettingsHandler implements OnPanelLoad {
 
 	onPanelLoad() {
 		this.lobbyButtons.get(this.panels.cp.GetAttributeString('type', LobbyType.PUBLIC) as LobbyType).checked = true;
-		this.panels.maxPlayers.text = $.GetContextPanel().GetAttributeString('maxplayers', '64');
+		this.panels.maxPlayers.text = $.GetContextPanel().GetAttributeString('maxplayers', '2');
 		this.panels.updateButton.enabled = false;
 	}
 
 	onChanged() {
 		UiToolkitAPI.HideTextTooltip();
 
-		if (this.getMaxPlayersEntered() > this.lobbyMaxPlayers) {
+		if (this.getMaxPlayersEntered() > SteamLobbyAPI.GetMaxAllowedMemberLimit()) {
 			UiToolkitAPI.ShowTextTooltip(
 				'MaxPlayers',
-				$.Localize('#Lobby_MaxPlayers_Warning').replace('%max%', this.lobbyMaxPlayers.toString())
+				$.Localize('#Lobby_MaxPlayers_Warning').replace(
+					'%max%',
+					SteamLobbyAPI.GetMaxAllowedMemberLimit().toString()
+				)
 			);
 			this.panels.updateButton.enabled = false;
 		} else {
@@ -40,9 +42,9 @@ class LobbySettingsHandler implements OnPanelLoad {
 
 	submit() {
 		const type = this.lobbyButtons.entries().find(([, button]) => button.checked)[0];
-		SteamLobbyAPI.ChangeVisibility(+type as 0 | 1 | 2);
+		SteamLobbyAPI.SetType(+type as 0 | 1 | 2);
 
-		SteamLobbyAPI.SetMaxPlayers(this.getMaxPlayersEntered());
+		SteamLobbyAPI.SetMemberLimit(this.getMaxPlayersEntered());
 
 		UiToolkitAPI.CloseAllVisiblePopups();
 	}

--- a/scripts/pages/drawer/lobby.ts
+++ b/scripts/pages/drawer/lobby.ts
@@ -203,7 +203,7 @@ class LobbyHandler {
 
 				const ownerSteamID = lobbyData.owner;
 				const lobbyType = lobbyData.type;
-				const lobbyName = lobbyData.isRoaming
+				const lobbyName = lobbyData.is_map_lobby
 					? `${$.Localize('#Lobby_Roaming')} (${MapCacheAPI.GetMapName()})`
 					: $.Localize('#Lobby_Owner').replace('%owner%', FriendsAPI.GetNameForXUID(ownerSteamID));
 
@@ -264,7 +264,7 @@ class LobbyHandler {
 
 	/** Update the lobbies details view based on current lobby state */
 	updateCurrentLobbyDetails() {
-		const { owner, type, members, members_limit, isRoaming } = Object.values(this.lobbyCurrentData)[0];
+		const { owner, type, members, members_limit, is_map_lobby } = Object.values(this.lobbyCurrentData)[0];
 
 		this.panels.detailsType.SetImage(`file://{images}/online/${LobbyProperties.get(type).icon}.svg`);
 
@@ -273,7 +273,7 @@ class LobbyHandler {
 
 		$.GetContextPanel().SetDialogVariable(
 			'lobbyTitle',
-			isRoaming
+			is_map_lobby
 				? `${$.Localize('#Lobby_Roaming')} (${MapCacheAPI.GetMapName()})`
 				: $.Localize('#Lobby_Owner').replace('%owner%', FriendsAPI.GetNameForXUID(owner))
 		);

--- a/scripts/types-mom/apis.d.ts
+++ b/scripts/types-mom/apis.d.ts
@@ -188,7 +188,7 @@ declare namespace SteamLobbyAPI {
 	function RefreshList(filters: Record<string, never>): boolean;
 
 	/** Create a new lobby with the given visibility */
-	function Create(type: 0 | 1 | 2): void;
+	function Create(type: 0 | 1 | 2, memberLimit: number): void;
 
 	/** Joins a lobby of the given SteamID */
 	function Join(steamID: steamID): void;
@@ -196,14 +196,17 @@ declare namespace SteamLobbyAPI {
 	/** Leaves the current lobby */
 	function Leave(): void;
 
-	/** Change the lobby visibility */
-	function ChangeVisibility(type: 0 | 1 | 2): void;
+	/** Set the lobby type */
+	function SetType(type: 0 | 1 | 2): void;
 
-	/** Set the max players (up to 255) */
-	function SetMaxPlayers(maxPlayers: number): void;
+	/** Set the member limit */
+	function SetMemberLimit(memberLimit: number): void;
 
 	/** Show the Steam Overlay invite dialog if we're in a lobby */
 	function ShowInviteDialog(): void;
+
+	/** Get the maximum member limit a lobby may have */
+	function GetMaxAllowedMemberLimit(): number;
 }
 
 declare namespace GameModeAPI {

--- a/scripts/util/event-definition.ts
+++ b/scripts/util/event-definition.ts
@@ -55,9 +55,6 @@ declare interface GlobalEventNameMap {
 	/** Send a refresh request for the lobby list */
 	RefreshLobbyList: () => void;
 
-	/** Sets the max players of your lobby */
-	Lobby_SetMaxPlayers: (maxPlayers: number) => void;
-
 	MapSelector_OnLoaded: () => void;
 
 	MapSelector_ShowConfirmCancelDownload: (mapID: number) => void;
@@ -84,7 +81,6 @@ $.DefineEvent('Drawer_UpdateLobbyButton', 2);
 $.DefineEvent('Drawer_NavigateToTab', 1);
 $.DefineEvent('Drawer_ExtendAndNavigateToTab', 1);
 $.DefineEvent('RefreshLobbyList', 0);
-$.DefineEvent('Lobby_SetMaxPlayers', 1);
 $.DefineEvent('MapSelector_OnLoaded', 0);
 $.DefineEvent('MapSelector_ShowConfirmCancelDownload', 1);
 $.DefineEvent('MapSelector_HideLeaderboards', 0);


### PR DESCRIPTION
Incorporates some API changes from the rewritten lobby system. We still need to update the localization tokens and their strings from "roaming lobby" to "map lobby".