### PR TITLE
Jump timing improvements

### DIFF
--- a/scripts/hud/jump-timing.ts
+++ b/scripts/hud/jump-timing.ts
@@ -5,8 +5,7 @@ import { RgbaTuple, rgbaTupleLerp, tupleToRgbaString } from 'util/colors';
 
 const Colors = {
 	RED: [255, 0, 0, 255] as RgbaTuple,
-	ORANGE: [255, 165, 0, 255] as RgbaTuple,
-	YELLOW: [255, 255, 0, 255] as RgbaTuple
+	ORANGE: [255, 165, 0, 255] as RgbaTuple
 };
 
 @PanelHandler()
@@ -21,31 +20,62 @@ class JumpTimingHandler {
 		lateBarProgress: $<Panel>('#JumpLateBar_Left')
 	};
 
+	perfWindow: number;
+	range: number;
+	bufferedJumpingEnabled: boolean;
+
 	constructor() {
 		RegisterHUDPanelForGamemode({
 			gamemodes: GamemodeCategories.get(GamemodeCategory.BHOP), // TODO: Add stamina bhop game mode
+			onLoad: () => this.onMapInit(),
+			events: [
+				{
+					event: 'JumpTimingSettingChanged',
+					callback: () => this.updateSettings()
+				}
+			],
 			handledEvents: [
 				{
 					event: 'JumpTimingDataUpdate',
 					panel: this.panels.container,
-					callback: (jumpTiming, maxTimingPenalty) => this.onJumpTimingUpdate(jumpTiming, maxTimingPenalty)
+					callback: (jumpTiming) => this.onJumpTimingUpdate(jumpTiming)
 				}
 			]
 		});
+
+		this.panels.earlyBarProgress.style.backgroundColor = tupleToRgbaString(Colors.ORANGE);
 	}
 
-	onJumpTimingUpdate(jumpTiming: number, maxTimingPenalty: number) {
-		// Blend between yellow and orange for early timing, and orange and red for late timing since you lose more speed on the ground from friction and stamina
-		const earlyTimingRatio = jumpTiming < 0 ? -jumpTiming / maxTimingPenalty : 0;
-		this.panels.earlyBar.value = earlyTimingRatio;
-		this.panels.earlyLabel.text = jumpTiming < 0 ? -jumpTiming : 0;
-		const colorLerp = (Math.abs(jumpTiming) - 1) / (maxTimingPenalty - 1);
-		const earlyTimingColor = rgbaTupleLerp(Colors.YELLOW, Colors.ORANGE, colorLerp);
-		this.panels.earlyBarProgress.style.backgroundColor = tupleToRgbaString(earlyTimingColor);
+	onMapInit() {
+		this.updateSettings();
+	}
 
-		const lateTimingRatio = jumpTiming > 0 ? jumpTiming / maxTimingPenalty : 0;
+	updateSettings() {
+		this.range = GameInterfaceAPI.GetSettingInt('mom_hud_jump_timing_range');
+		this.perfWindow = GameInterfaceAPI.GetSettingInt('mom_mv_perfect_jump_window');
+		this.bufferedJumpingEnabled = GameInterfaceAPI.GetSettingInt('mom_mv_autohop_mode') === 2;
+
+		this.panels.earlyLabel.visible = this.bufferedJumpingEnabled;
+		this.panels.earlyBar.visible = this.bufferedJumpingEnabled;
+		this.panels.lateBar.style.width = this.bufferedJumpingEnabled ? '50%' : '100%';
+	}
+
+	onJumpTimingUpdate(jumpTiming: number) {
+		jumpTiming = Math.max(Math.min(jumpTiming, this.range), -this.range);
+
+		if (this.bufferedJumpingEnabled) {
+			const earlyTimingRatio =
+				jumpTiming < 0
+					? Math.max(-jumpTiming - this.perfWindow, 0) / Math.max(this.range - this.perfWindow, 1)
+					: 0;
+			this.panels.earlyBar.value = earlyTimingRatio;
+			this.panels.earlyLabel.text = jumpTiming < 0 ? -jumpTiming : 0;
+		}
+
+		const lateTimingRatio = jumpTiming > 0 ? jumpTiming / this.range : 0;
 		this.panels.lateBar.value = lateTimingRatio;
 		this.panels.lateLabel.text = jumpTiming > 0 ? jumpTiming : 0;
+		const colorLerp = (Math.abs(jumpTiming) - 1) / (this.range - 1);
 		const lateTimingColor = rgbaTupleLerp(Colors.ORANGE, Colors.RED, colorLerp);
 		this.panels.lateBarProgress.style.backgroundColor = tupleToRgbaString(lateTimingColor);
 	}

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -137,8 +137,11 @@ interface GlobalEventNameMap {
 
 	DFJumpMaxDelayChanged: (newDelay: float) => void;
 
+	/** Called when the player changes a jump timing setting (mom_hud_jump_timing_range, mom_mv_perfect_jump_window, or mom_mv_autohop_mode). */
+	JumpTimingSettingChanged: () => void;
+
 	/** Jump timing has been updated */
-	JumpTimingDataUpdate: (jumpTiming: number, maxTimingPenalty: number) => void;
+	JumpTimingDataUpdate: (jumpTiming: number) => void;
 
 	OnJumpStatsCFGChange: () => void;
 


### PR DESCRIPTION
- Added support for new perf timing window
- Use events to update timing range and perf window
- Use a constant color for early timing since the speed penalty is now fixed

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
