### PR TITLE
fix: Don't animate sticky arming independently of game state

### DIFF
--- a/scripts/hud/comparisons.ts
+++ b/scripts/hud/comparisons.ts
@@ -139,7 +139,6 @@ class HudComparisonsHandler {
 		});
 
 		$.RegisterForUnhandledEvent('OnObservedTimerReplaced', () => {
-			$.Msg('OnObservedTimerReplaced');
 			this.controlledReplayID = MomentumTimerAPI.GetObservedRunMetadata()?.tempId ?? null;
 			this.regenerateSplits();
 		});

--- a/styles/hud/sticky-count.scss
+++ b/styles/hud/sticky-count.scss
@@ -1,21 +1,5 @@
 @use '../config' as *;
 
-// keyframe sticky arming over a second to avoid ending the animation before the armed state is set
-// (as that causes color flickering)
-@keyframes stickyArmAnim {
-	from {
-	}
-	70% {
-		background-color: $progressbar-background;
-	}
-	// 0.8 second arm time
-	80% {
-		background-color: $progressbar-background-progress;
-	}
-	to {
-	}
-}
-
 .sticky-count {
 	margin: 6px 0 6px 0;
 
@@ -37,8 +21,6 @@
 		}
 
 		&--sticky-arming {
-			animation-name: stickyArmAnim;
-			animation-duration: 1s;
 		}
 
 		&--sticky-armed {


### PR DESCRIPTION
This class gets applied when the stickybomb starts arming and transitions to the "armed" appearance after a set time, but this is incorrect in cases when watching a replay and then pausing or seeking. The animation was very subtle so this just removes it for now, and someone can hook up some transition styling later that is directly tied to arm time.