### PR TITLE
Fix/zoning binds

### DIFF
--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -235,7 +235,7 @@
 						<Label class="zoning-info__bind-key" text="MOUSE1" />
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_CancelEdit" />
+						<Label class="zoning-info__bind-action" text="{s:mouse2Hint}" />
 						<Label class="zoning-info__bind-key" text="MOUSE2" />
 					</Panel>
 					<Panel id="ZoningBindsOptions" class="zoning-info__category">
@@ -249,13 +249,13 @@
 						</Panel>
 					</Panel>
 					<Panel class="zoning-info__bind">
-						<Label class="zoning-info__bind-action" text="{s:backspaceHint}" />
-						<Label class="zoning-info__bind-key" text="BACKSPACE" />
+						<Label class="zoning-info__bind-action" text="#Zoning_Keybind_CancelEdit" />
+						<Label class="zoning-info__bind-key" text="ESCAPE" />
 					</Panel>
 					<Panel id="ZoningBindsCorner" class="zoning-info__category">
 						<Panel class="zoning-info__bind">
 							<Label class="zoning-info__bind-action" text="#Zoning_Keybind_DeletePoint" />
-							<Label class="zoning-info__bind-key" text="DELETE" />
+							<Label class="zoning-info__bind-key" text="DELETE, BACKSPACE" />
 						</Panel>
 						<Panel class="zoning-info__bind">
 							<Label class="zoning-info__bind-action" text="#Zoning_Keybind_TwoclickToggle" />

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -154,7 +154,7 @@ class ZoneMenuHandler {
 		this.populateDropdown(this.filternameList, this.panels.filterSelect, '', true);
 
 		this.teleDestList = entList.teleport ?? [];
-		this.teleDestList.unshift($.Localize('#Zoning_TPDest_MakeNew'));
+		this.teleDestList.unshift($.Localize('#Zoning_TPDest_UserDefined'));
 		this.teleDestList.unshift($.Localize('#Zoning_TPDest_None'));
 		this.populateDropdown(this.teleDestList, this.panels.regionTPDest, '', true);
 

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -602,9 +602,9 @@ class ZoneMenuHandler {
 
 		this.selectedZone.zone.regions.push(this.createRegion());
 		this.panels.zoningMenu.createRegion(this.isStartZone(this.selectedZone.zone));
+		this.showInfoPanel(true);
 		this.populateDropdown(this.selectedZone.zone.regions, this.panels.regionSelect, 'Region', true);
 		this.panels.regionSelect.SetSelectedIndex(this.selectedZone.zone.regions.length - 1);
-		this.populateRegionProperties();
 	}
 
 	deleteRegion() {
@@ -649,6 +649,7 @@ class ZoneMenuHandler {
 					this.selectedZone.zone.regions = [];
 					this.drawZones();
 					this.panels.zoningMenu.createRegion(this.isStartZone(this.selectedZone.zone));
+					this.showInfoPanel(true);
 				},
 				'none'
 			);
@@ -822,9 +823,9 @@ class ZoneMenuHandler {
 	}
 
 	onRegionEditCanceled() {
+		this.showInfoPanel(false);
 		if (this.selectedZone?.region?.points.length === 0) this.deleteRegion();
 
-		this.showInfoPanel(false);
 		this.drawZones();
 	}
 

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -588,8 +588,8 @@ class ZoneMenuHandler {
 		this.panels.regionHeight.text = region?.height?.toFixed(2) ?? '';
 		this.panels.regionSafeHeight.text = region?.safeHeight?.toFixed(2) ?? '';
 
-		const tpIndex = !region.teleDestTargetname
-			? region.teleDestPos !== undefined && region.teleDestYaw !== undefined
+		const tpIndex = !region?.teleDestTargetname
+			? region?.teleDestPos !== undefined && region?.teleDestYaw !== undefined
 				? 1
 				: 0
 			: (this.teleDestList?.indexOf(region?.teleDestTargetname) ?? 0);


### PR DESCRIPTION
This pull request syncs zoning UI binds with c++ as well as fixes the following bugs:
- JS error when deleting a region after recreating a newly cancelled region
- Zoning menu opens into a bad state if the menu is closed and reopened while editing a region

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

