### PR TITLE
Fix toasts not showing in the HUD

### DIFF
--- a/layout/util/toast-manager.xml
+++ b/layout/util/toast-manager.xml
@@ -7,7 +7,7 @@
 		<include type="module" src="file://{scripts}/util/toast-manager.ts" />
 	</scripts>
 
-	<Panel class="w-full h-full" hittest="false" hittestchildren="false">
+	<Panel class="w-full h-full" hittest="false" hittestchildren="false" onload="registerToastManager()">
 		<ConVarEnabler class="toast-manager" hittest="false" hittestchildren="false" convar="mom_ui_toasts_enable" togglevisibility="true">
 			<Panel id="Center" class="toast-manager__center" />
 			<Panel id="Left" class="toast-manager__left" />


### PR DESCRIPTION
My system for exposing `ToastManager` to JS via ESM global caused a single instance to be created (in MainMenu, just happened to be first). Had to faff around a bit wrapping every instance (MainMenu, Hud, GlobalPopups) in the main global to get everything to work, plus some extra crap due to the behaviour of HUD reloading on map load.

Closes https://github.com/momentum-mod/game/issues/2272

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below