### PR TITLE
fix: never allow leaderboards to have a scroll bar

### DIFF
--- a/styles/pages/leaderboards/leaderboards.scss
+++ b/styles/pages/leaderboards/leaderboards.scss
@@ -91,7 +91,7 @@
 		border-top: 0px none;
 		transition: opacity 0.1s ease-in-out 0s;
 		opacity: 1;
-		overflow: squish scroll;
+		overflow: squish clip;
 
 		& > VerticalScrollBar .ScrollThumb {
 			opacity: 1;


### PR DESCRIPTION
Related to https://github.com/momentum-mod/game/issues/2324 but that should get closed by 2706 on red