### PR TITLE
Fix: prime sight part 2

### DIFF
--- a/scripts/hud/cgaz.ts
+++ b/scripts/hud/cgaz.ts
@@ -1174,9 +1174,9 @@ class CgazHandler {
 		}
 
 		const leftAngles =
-			fillLeftZones && this.primeTruenessMode === TruenessMode.CPM_TURN ? this.primeAngles : this.snapAngles;
+			fillLeftZones && this.primeTruenessMode & TruenessMode.CPM_TURN ? this.primeAngles : this.snapAngles;
 		const rightAngles =
-			fillRightZones && this.primeTruenessMode === TruenessMode.CPM_TURN ? this.primeAngles : this.snapAngles;
+			fillRightZones && this.primeTruenessMode & TruenessMode.CPM_TURN ? this.primeAngles : this.snapAngles;
 
 		const iLeft = this.updateFirstPrimeZone(leftTarget, leftOffset, this.primeFirstZoneLeft, leftAngles);
 		const iRight = this.updateFirstPrimeZone(rightTarget, rightOffset, this.primeFirstZoneRight, rightAngles);
@@ -1235,7 +1235,7 @@ class CgazHandler {
 				end: jLeft,
 				direction: -1
 			};
-			this.fillActivePrimeZones(zoneRange, leftOffset, gainZonesMap, gainMax, velocity, wishDir);
+			this.fillActivePrimeZones(zoneRange, leftOffset, leftAngles, gainZonesMap, gainMax, velocity, wishDir);
 		}
 
 		if (fillRightZones) {
@@ -1246,7 +1246,7 @@ class CgazHandler {
 				end: jRight,
 				direction: 1
 			};
-			this.fillActivePrimeZones(zoneRange, rightOffset, gainZonesMap, gainMax, velocity, wishDir);
+			this.fillActivePrimeZones(zoneRange, rightOffset, rightAngles, gainZonesMap, gainMax, velocity, wishDir);
 		}
 
 		const scale = 1 / (gainMax > 0 ? gainMax : this.primeAccel);
@@ -1289,12 +1289,13 @@ class CgazHandler {
 	fillActivePrimeZones(
 		zoneRange: { direction: number; start: number; end: number },
 		offset: number,
+		angles: number[],
 		gainZonesMap: Map<unknown, number>,
 		gainMax: number,
 		velocity: vec3,
 		wishDir: vec2
 	) {
-		const angleCount = this.primeAngles.length;
+		const angleCount = angles.length;
 		let count = (zoneRange.direction * (zoneRange.end - zoneRange.start) + angleCount) % angleCount;
 		let index = zoneRange.start;
 		let zone;
@@ -1302,8 +1303,8 @@ class CgazHandler {
 			index = (index + zoneRange.direction + angleCount) % angleCount;
 			zone = this.primeZones[index];
 
-			const left = MomMath.wrapToHalfPi(this.primeAngles[index] - offset);
-			const right = MomMath.wrapToHalfPi(this.primeAngles[(index + 1) % angleCount] - offset);
+			const left = MomMath.wrapToHalfPi(angles[index] - offset);
+			const right = MomMath.wrapToHalfPi(angles[(index + 1) % angleCount] - offset);
 			this.updateZone(zone, left, right, 0, PRIME_SIGHT_CLASS, this.primeSplitZone);
 			const speedGain = this.findPrimeGain(zone, velocity, wishDir);
 			gainZonesMap.set(zone, speedGain);


### PR DESCRIPTION
This PR fixes an issue with the implementation of `mom_df_hud_prime_trueness` that prevented the hud from correctly calculating active and mirror zones separately while CPM turning.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
