### PR TITLE
Remove REPLAY_FINISHED_RUN from EndOfRunShowReason

### DIFF
--- a/scripts/common/timer.ts
+++ b/scripts/common/timer.ts
@@ -526,8 +526,7 @@ export function generateComparisonSplits(baseRun: RunMetadata, comparisonRun: Ru
 /** Enum for why end of run is being shown */
 export enum EndOfRunShowReason {
 	PLAYER_FINISHED_RUN = 0,
-	REPLAY_FINISHED_RUN = 1,
-	MANUALLY_SHOWN = 2
+	MANUALLY_SHOWN = 1
 }
 
 /** Enum for different run submission states */


### PR DESCRIPTION
This is no longer used since the end of run menu will only display when the local player finishes a run.

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below