### PR TITLE
Fix exception clicking on the topnav player card

### DIFF
--- a/scripts/pages/drawer/drawer.ts
+++ b/scripts/pages/drawer/drawer.ts
@@ -5,14 +5,14 @@ export const Tabs = {
 		layout: 'lobby',
 		button: $('#LobbyButton')
 	},
-	ProfileDrawer: {
-		layout: 'profile',
-		button: $('#ProfileButton')
-	},
-	ChallengesDrawer: {
-		layout: 'challenges',
-		button: $('#ChallengesButton')
-	},
+	// ProfileDrawer: {
+	// 	layout: 'profile',
+	// 	button: $('#ProfileButton')
+	// },
+	// ChallengesDrawer: {
+	// 	layout: 'challenges',
+	// 	button: $('#ChallengesButton')
+	// },
 	AboutDrawer: {
 		layout: 'about',
 		button: $('#AboutButton')
@@ -140,12 +140,12 @@ class DrawerHandler {
 		this.panels.lobbyPlayerCountLabel.SetHasClass('rightnav__button-subtitle--hidden', playerCount <= 1);
 	}
 
-	/** Open the profile tab when the main menu player card is pressed */
-	onPlayerCardPressed() {
-		this.extend();
-
-		if (this.activeTab !== 'ProfileDrawer') {
-			$.DispatchEvent('Activated', Tabs.ProfileDrawer.button, PanelEventSource.MOUSE);
-		}
-	}
+	// /** Open the profile tab when the main menu player card is pressed */
+	// onPlayerCardPressed() {
+	// 	this.extend();
+	//
+	// 	if (this.activeTab !== 'ProfileDrawer') {
+	// 		$.DispatchEvent('Activated', Tabs.ProfileDrawer.button, PanelEventSource.MOUSE);
+	// 	}
+	// }
 }


### PR DESCRIPTION
Disabled the profile drawer page for now since there's nothing in it. Didn't realise playercard logic was dependent on it.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
