### PR TITLE
Playercard onactivate exception

### DIFF
--- a/scripts/pages/drawer/drawer.ts
+++ b/scripts/pages/drawer/drawer.ts
@@ -140,12 +140,13 @@ class DrawerHandler {
 		this.panels.lobbyPlayerCountLabel.SetHasClass('rightnav__button-subtitle--hidden', playerCount <= 1);
 	}
 
-	// /** Open the profile tab when the main menu player card is pressed */
-	// onPlayerCardPressed() {
+	/** Open the profile tab when the main menu player card is pressed */
+	onPlayerCardPressed() {
+	// Leaving this disabled for now until we finish/move profile stuff.
 	// 	this.extend();
 	//
 	// 	if (this.activeTab !== 'ProfileDrawer') {
 	// 		$.DispatchEvent('Activated', Tabs.ProfileDrawer.button, PanelEventSource.MOUSE);
 	// 	}
-	// }
+	}
 }


### PR DESCRIPTION
Think I missed a change when committing the original fix for this, I had removed the event handler in `<PlayerCard class="h-full" onactivate="DrawerHandler.onPlayerCardPressed();" />`. But on second thought I think it's better we keep that, and just make `onPlayerCardPressed` a noop for now.
