### PR TITLE
Zoning menu layout rework and logic improvements

### DIFF
--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -68,6 +68,10 @@
 			<BackbufferImagePanel class="full" />
 		</HudBlurTarget>
 
+		<HudBlurTarget id="HudWeakBlur" blurrects="" class="hud-blur hud-blur--weak" hittest="false" hittestchildren="false">
+			<BackbufferImagePanel class="full" />
+		</HudBlurTarget>
+
 		<!-- HUD anchored to top center of screen, laid out vertically top-to-bottom
 		-  NOTE: Not really set up properly - HudTeamCounter should dynamically move
 		-        between HudTopCenter and HudBottomCenter, but instead it just moves
@@ -79,6 +83,10 @@
 			<HudBoneCounts />
 			<MomHudSpectate id="Spectator" />
 			<MomHudJumpStats />
+		</Panel>
+
+		<Panel id="ZoningContainer" hittestchildren="true">
+			<ZoneMenu id="ZoneMenu" hittest="true" hittestchildren="true" />
 		</Panel>
 
 		<!-- This container is here so we can move the leaderboard in and out of it during the end-of-match sequence -->

--- a/layout/hud/tab-menu.xml
+++ b/layout/hud/tab-menu.xml
@@ -51,10 +51,6 @@
 				<Frame src="file://{resources}/layout/pages/end-of-run/end-of-run.xml" hittest="true" hittestchildren="true" />
 			</Panel>
 
-			<Panel id="ZoningContainer" class="hud-tab-menu__zoning" hittestchildren="true">
-				<ZoneMenu id="ZoneMenu" hittest="true" hittestchildren="true" />
-			</Panel>
-
 			<Panel class="hud-tab-menu__stats">
 			</Panel>
 			

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -60,6 +60,9 @@
 				<Button id="AddCancelZoneButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addCancelZone()">
 					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewCancelZone" />
 				</Button>
+				<Button id="AddGlobalRegionButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addGlobalRegion()">
+					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewGlobalRegion" />
+				</Button>
 			</Panel>
 		</Panel>
 		<Label id="PropertiesLabel" class="zoning__header" text="#Zoning_PropertiesLabel" />

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -35,6 +35,9 @@
 				<Button id="AddBonusButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addBonus()">
 					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewBonus" />
 				</Button>
+				<Button id="AddDefragBonusButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addBonus(true)">
+					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewDefragBonus" />
+				</Button>
         	</Panel>
         	<Panel class="zoning__menu-section zoning__itemlist zoning__itemlist--gap-before">
 				<Panel id="CenterList" class="w-full flow-down">

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -111,7 +111,7 @@
 			</Panel>
 			<Panel id="ZoneProperties" class="zoning__property-container">
 				<Panel class="zoning__menu-separator">
-					<Panel id="Filter" class="zoning__property">
+					<Panel id="Filter" class="zoning__property not-global-region">
 						<Label class="zoning__property-label" text="#Zoning_Filter" />
 						<DropDown id="FilterSelect" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.updateZoneFilter()">
 							<Label text="#Zoning_Filter_None" value="0" />
@@ -128,13 +128,13 @@
 							<Button id="MoveToRegionButton" class="button button--green zoning__property-button mr-2" onactivate="ZoneMenuHandler.teleportToRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('MoveToRegionButton', '#Zoning_MoveToRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="button__icon" src="file://{images}/eye-arrow-right.svg" />
 							</Button>
-							<Button id="AddRegionButton" class="button button--blue zoning__property-button mr-2" onactivate="ZoneMenuHandler.addRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('AddRegionButton', '#Zoning_CreateRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+							<Button id="AddRegionButton" class="button button--blue zoning__property-button mr-2 not-global-region" onactivate="ZoneMenuHandler.addRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('AddRegionButton', '#Zoning_CreateRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="button__icon" src="file://{images}/add.svg" />
 							</Button>
-							<Button id="DeleteRegionButton" class="button button--red zoning__property-button mr-2" onactivate="ZoneMenuHandler.deleteRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('DeleteRegionButton', '#Zoning_DeleteRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
+							<Button id="DeleteRegionButton" class="button button--red zoning__property-button mr-2 not-global-region" onactivate="ZoneMenuHandler.deleteRegion()" onmouseover="UiToolkitAPI.ShowTextTooltip('DeleteRegionButton', '#Zoning_DeleteRegion_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 								<Image class="button__icon" src="file://{images}/delete.svg" />
 							</Button>
-							<DropDown id="RegionSelect" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.populateRegionProperties()">
+							<DropDown id="RegionSelect" class="dropdown zoning__dropdown not-global-region" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.populateRegionProperties()">
 								<!-- Populated in js -->
 							</DropDown>
 						</Panel>
@@ -157,7 +157,7 @@
 							<TextEntry id="RegionHeight" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionHeight()" />
 						</Panel>
 					</Panel>
-					<Panel class="zoning__property">
+					<Panel class="zoning__property not-global-region">
 						<Label class="zoning__property-label" text="#Zoning_RegionDetails_SafeHeight" />
 						<Panel class="zoning__region-property-container">
 							<Button id='SetSafeHeightButton' class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickSafeHeight()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetSafeHeightButton', '#Zoning_SetSafeHeight_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
@@ -166,7 +166,7 @@
 							<TextEntry id="RegionSafeHeight" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionSafeHeight()" />
 						</Panel>
 					</Panel>
-					<Panel class="zoning__property">
+					<Panel class="zoning__property not-global-region">
 						<Label class="zoning__property-label" text="#Zoning_RegionDetails_TPDest" />
 						<DropDown id="RegionTPDest" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.onTPDestSelectionChanged()">
 							<!-- Populated in js -->
@@ -174,7 +174,7 @@
 							<Label text="#Zoning_TPDest_MakeNew" value="1" />
 						</DropDown>
 					</Panel>
-					<Panel class="zoning__property">
+					<Panel class="zoning__property not-global-region">
 						<Label id="Position" class="zoning__property-label" text="#Zoning_TPDest_Position" />
 						<Panel class="zoning__region-property-container">
 							<Button id="SetTeleDestPosButton" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestPos()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetTeleDestPosButton', '#Zoning_SetTeleDestPos_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
@@ -185,7 +185,7 @@
 							<TextEntry id="TeleZ" class="textentry zoning__textentry" maxchars="10" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
 						</Panel>
 					</Panel>
-					<Panel class="zoning__property">
+					<Panel class="zoning__property not-global-region">
 						<Label id="Yaw" class="zoning__property-label" text="#Zoning_TPDest_Yaw" />
 						<Panel class="zoning__region-property-container">
 							<Button id="SetTeleDestYawButton" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestYaw()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetTeleDestYawButton', '#Zoning_SetTeleDestYaw_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -88,6 +88,7 @@
 	</snippets>
 
 	<ZoneMenu class="zoning" acceptsinput="true" acceptsfocus="true">
+		<Label class="zoning__title" text="#Zoning_WindowTitle" />
 		<Label id="TrackListLabel" class="zoning__header" text="#Zoning_TrackListLabel" />
 		<Panel id="TrackListContainer" class="zoning__menu-section">
         	<Panel id="TrackList" class="zoning__track-list">

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -8,92 +8,56 @@
 	</scripts>
 
 	<snippets>
-		<snippet name="tracklist-track">
-			<Panel class="zoning__tracklist-track">
-				<Panel id="Entry" class="zoning__tracklist-course-entry">
-					<Button id="CollapseButton" class="zoning__collapse-button">
-						<Image id="TracklistCollapseIcon" class="button__icon zoning__collapse-icon zoning__icon-green hide" src="file://{images}/add.svg" />
-						<Image id="TracklistExpandIcon" class="button__icon zoning__collapse-icon zoning__icon-red" src="file://{images}/subtract.svg" />
-					</Button>
-					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
-						<Label id="Name" class="zoning__tracklist-label" />
-					</RadioButton>
-					<Button id="DeleteButton" class="zoning__tracklist-delete hide">
-						<Image class="zoning__tracklist-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
-					</Button>
-				</Panel>
-				<Panel id="ChildContainer" class="zoning__list-container">
-					<Panel id="SegmentContainer" class="w-full flow-down" />
-					<Button id="AddSegmentButton" class="zoning__add-button">
-						<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewSegment" />
-					</Button>
-					<Panel id="EndZoneContainer" class="w-full flow-down" />
-					<Button id="AddEndZoneButton" class="zoning__add-button">
-						<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewEndZone" />
-					</Button>
-				</Panel>
-				<Button id="AddBonusButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addBonus()">
-					<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewBonus" />
+
+		<snippet name="itemlist-item">
+			<Panel class="w-full flow-right">
+				<Button id="SelectButton" class="zoning__item-selectbutton">
+					<Label id="Name" class="zoning__item-label" />
+				</Button>
+				<Button id="DeleteButton" class="zoning__item-deletebutton hide">
+					<Image class="zoning__item-deletebutton__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
 				</Button>
 			</Panel>
 		</snippet>
-		<snippet name="tracklist-segment">
-			<Panel class="w-full flow-down">
-				<Panel id="Entry" class="zoning__tracklist-course-entry">
-					<Button id="CollapseButton" class="zoning__collapse-button">
-						<Image id="TracklistCollapseIcon" class="button__icon zoning__collapse-icon zoning__icon-green hide" src="file://{images}/add.svg" />
-						<Image id="TracklistExpandIcon" class="button__icon zoning__collapse-icon zoning__icon-red" src="file://{images}/subtract.svg" />
-					</Button>
-					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
-						<Label id="Name" class="zoning__tracklist-label" />
-					</RadioButton>
-					<Button id="DeleteButton" class="zoning__tracklist-delete hide">
-						<Image class="zoning__tracklist-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
-					</Button>
-				</Panel>
-				<Panel id="ChildContainer" class="zoning__list-container">
-					<Panel id="CheckpointContainer" class="zoning__tracklist-checkpoint" />
-					<Button id="AddCheckpointButton" class="zoning__add-button">
-						<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewCheckpoint" />
-					</Button>
-					<Panel id="CancelContainer" class="zoning__tracklist-checkpoint" />
-					<Button id="AddCancelZoneButton" class="zoning__add-button">
-						<Label class="zoning__tracklist-label zoning__tracklist-label--add" text="#Zoning_NewCancelZone" />
-					</Button>
-				</Panel>
-			</Panel>
-		</snippet>
-		<snippet name="tracklist-checkpoint">
-			<Panel class="w-full flow-down">
-				<Panel id="Entry" class="zoning__tracklist-course-entry">
-					<RadioButton id="SelectButton" class="zoning__tracklist-button" group="tracklist">
-						<Label id="Name" class="zoning__tracklist-label" />
-					</RadioButton>
-					<Button id="DeleteButton" class="zoning__tracklist-delete hide">
-						<Image class="zoning__tracklist-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
-					</Button>
-				</Panel>
-			</Panel>
-		</snippet>
-		<snippet name="region-point">
-			<Panel class="zoning__region-property-container">
-				<!--label-->
-				<TextEntry id="PointX" class="textentry zoning__textentry" maxchars="10" textmode="numeric" />
-				<TextEntry id="PointY" class="textentry zoning__textentry" maxchars="10" textmode="numeric" />
-				<Button id="DeleteButton" class="zoning__region-point-delete">
-					<Image class="zoning__region-point-delete__icon" src="file://{images}/close-box-outline.svg" textureheight="24" />
-				</Button>
-			</Panel>
-		</snippet>
+
 	</snippets>
 
 	<ZoneMenu class="zoning" acceptsinput="true" acceptsfocus="true">
 		<Label class="zoning__title" text="#Zoning_Menu" />
-		<Label id="TrackListLabel" class="zoning__header" text="#Zoning_TrackListLabel" />
-		<Panel id="TrackListContainer" class="zoning__menu-section">
-        	<Panel id="TrackList" class="zoning__track-list">
-            	<!-- Populated in js -->
+		<Panel id="ItemListsContainer" class="zoning__itemlists">
+        	<Panel class="zoning__menu-section zoning__itemlist">
+				<Button id="CreateMainButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.createMain()">
+					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_CreateMain" />
+				</Button>
+        		<Panel id="LeftList" class="w-full flow-down">
+            		<!-- Populated in js -->
+				</Panel>
+				<Button id="AddBonusButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addBonus()">
+					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewBonus" />
+				</Button>
         	</Panel>
+        	<Panel class="zoning__menu-section zoning__itemlist zoning__itemlist--gap-before">
+				<Panel id="CenterList" class="w-full flow-down">
+					<!-- Populated in js -->
+				</Panel>
+				<Button id="AddSegmentButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addSegment()">
+					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewSegment" />
+				</Button>
+				<Button id="AddEndZoneButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addEndZone()">
+					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewEndZone" />
+				</Button>
+			</Panel>
+			<Panel class="zoning__menu-section zoning__itemlist zoning__itemlist--gap-before">
+				<Panel id="RightList" class="w-full flow-down">
+					<!-- Populated in js -->
+				</Panel>
+				<Button id="AddCheckpointButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addCheckpoint()">
+					<Label id="AddCheckpointButtonLabel" class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewCheckpoint" />
+				</Button>
+				<Button id="AddCancelZoneButton" class="zoning__add-button hide" onactivate="ZoneMenuHandler.addCancelZone()">
+					<Label class="zoning__itemlist-label zoning__itemlist-label--add" text="#Zoning_NewCancelZone" />
+				</Button>
+			</Panel>
 		</Panel>
 		<Label id="PropertiesLabel" class="zoning__header" text="#Zoning_PropertiesLabel" />
 		<Panel id="PropertiesContainer" class="zoning__menu-section">

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -88,7 +88,7 @@
 	</snippets>
 
 	<ZoneMenu class="zoning" acceptsinput="true" acceptsfocus="true">
-		<Label class="zoning__title" text="#Zoning_WindowTitle" />
+		<Label class="zoning__title" text="#Zoning_Menu" />
 		<Label id="TrackListLabel" class="zoning__header" text="#Zoning_TrackListLabel" />
 		<Panel id="TrackListContainer" class="zoning__menu-section">
         	<Panel id="TrackList" class="zoning__track-list">

--- a/scripts/common/web.ts
+++ b/scripts/common/web.ts
@@ -1692,7 +1692,7 @@ export interface GlobalRegions {
 }
 
 export interface MapTracks {
-	main: MainTrack;
+	main?: MainTrack;
 	bonuses?: BonusTrack[];
 }
 
@@ -1723,7 +1723,7 @@ export interface Segment {
 }
 
 export interface Zone {
-	regions: Region[];
+	regions?: Region[];
 	filtername?: string;
 }
 

--- a/scripts/common/web.ts
+++ b/scripts/common/web.ts
@@ -1687,8 +1687,8 @@ export interface MapZones {
 }
 
 export interface GlobalRegions {
-	allowBhop: Region[];
-	cancel: Region[];
+	allowBhop?: Region[];
+	cancel?: Region[];
 }
 
 export interface MapTracks {

--- a/scripts/hud/tab-menu.ts
+++ b/scripts/hud/tab-menu.ts
@@ -13,7 +13,6 @@ class HudTabMenuHandler {
 		cp: $.GetContextPanel<MomHudTabMenu>(),
 		sidebysideContainer: $<Panel>('#SideBySideContainer'),
 		endOfRunContainer: $<Panel>('#EndOfRunContainer'),
-		zoningContainer: $<Panel>('#ZoningContainer'),
 		zoningOpen: $<Button>('#ZoningOpen'),
 		zoningClose: $<Button>('#ZoningClose'),
 		gamemodeIcon: $<Image>('#HudTabMenuGamemodeImage'),
@@ -29,36 +28,17 @@ class HudTabMenuHandler {
 		$.RegisterForUnhandledEvent('HudTabMenu_ForceClose', () => this.close());
 		$.RegisterForUnhandledEvent('EndOfRun_Show', (reason) => this.showEndOfRun(reason));
 		$.RegisterForUnhandledEvent('EndOfRun_Hide', () => this.hideEndOfRun());
-		$.RegisterForUnhandledEvent('ZoneMenu_Show', () => this.showZoneMenu());
-		$.RegisterForUnhandledEvent('ZoneMenu_Hide', () => this.hideZoneMenu());
-		$.RegisterForUnhandledEvent('LevelInitPostEntity', () => this.hideZoneMenu());
 		$.RegisterForUnhandledEvent('ActiveZoneDefsChanged', () => this.updateMapStats());
 	}
 
 	showEndOfRun(reason: EndOfRunShowReason) {
 		this.panels.sidebysideContainer.AddClass('hud-tab-menu__leaderboards--hidden');
 		this.panels.endOfRunContainer.RemoveClass('hud-tab-menu__endofrun--hidden');
-		this.panels.zoningContainer.AddClass('hud-tab-menu__zoning--hidden');
 	}
 
 	hideEndOfRun() {
 		this.panels.sidebysideContainer.RemoveClass('hud-tab-menu__leaderboards--hidden');
 		this.panels.endOfRunContainer.AddClass('hud-tab-menu__endofrun--hidden');
-		this.panels.zoningContainer.AddClass('hud-tab-menu__zoning--hidden');
-	}
-
-	showZoneMenu() {
-		this.panels.cp.AddClass('hud-tab-menu--offset');
-		this.panels.sidebysideContainer.AddClass('hud-tab-menu__leaderboards--hidden');
-		this.panels.endOfRunContainer.AddClass('hud-tab-menu__endofrun--hidden');
-		this.panels.zoningContainer.RemoveClass('hud-tab-menu__zoning--hidden');
-	}
-
-	hideZoneMenu() {
-		this.panels.cp.RemoveClass('hud-tab-menu--offset');
-		this.panels.sidebysideContainer.RemoveClass('hud-tab-menu__leaderboards--hidden');
-		this.panels.endOfRunContainer.AddClass('hud-tab-menu__endofrun--hidden');
-		this.panels.zoningContainer.AddClass('hud-tab-menu__zoning--hidden');
 	}
 
 	setMapData(isOfficial: boolean) {

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -290,9 +290,35 @@ class ZoneMenuHandler {
 		const bonusTag = $.Localize('#Zoning_Bonus');
 		for (const [i, bonus] of this.mapZoneData.tracks.bonuses?.entries() ?? []) {
 			const selectionObj: ZoneSelection = { track: bonus, segment: null, zone: null };
-			this.addItemListItem(this.panels.leftList, `${bonusTag} ${i + 1}`, bonus, ItemType.TRACK, selectionObj);
-		}
+			const item = this.addItemListItem(
+				this.panels.leftList,
+				`${bonusTag} ${i + 1}`,
+				bonus,
+				ItemType.TRACK,
+				selectionObj
+			);
 
+			item.SetPanelEvent('oncontextmenu', () => {
+				const insertBonus = (before) => {
+					// Select this one first for the context of where to add the new one
+					this.updateSelection(selectionObj);
+					this.addBonus(before ? i : i + 1);
+				};
+
+				const contextItems = [
+					{
+						label: '#Zoning_InsertBonusBefore',
+						jsCallback: () => insertBonus(true)
+					},
+					{
+						label: '#Zoning_InsertBonusAfter',
+						jsCallback: () => insertBonus(false)
+					}
+				];
+
+				UiToolkitAPI.ShowSimpleContextMenu('', '', contextItems);
+			});
+		}
 		this.rebuildCenterList();
 		this.rebuildRightList();
 
@@ -902,12 +928,16 @@ class ZoneMenuHandler {
 		this.setInfoPanelShown(true);
 	}
 
-	addBonus() {
+	addBonus(index = null) {
 		if (!this.mapZoneData) return;
 
 		const bonus = this.createBonusTrack();
 		if (!this.mapZoneData.tracks.bonuses) {
-			this.mapZoneData.tracks.bonuses = [bonus];
+			this.mapZoneData.tracks.bonuses = [];
+		}
+
+		if (index != null && index < this.mapZoneData.tracks.bonuses.length) {
+			this.mapZoneData.tracks.bonuses.splice(Math.max(index, 0), 0, bonus);
 		} else {
 			this.mapZoneData.tracks.bonuses.push(bonus);
 		}

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -207,8 +207,24 @@ class ZoneMenuHandler {
 
 		item.FindChildTraverse<Label>('Name')!.text = label;
 
-		item.FindChildTraverse<ToggleButton>('SelectButton')?.SetPanelEvent('onactivate', () => {
+		const selectButton = item.FindChildTraverse<ToggleButton>('SelectButton');
+
+		selectButton.SetPanelEvent('onactivate', () => {
 			this.updateSelection(selectionWhenActivated);
+		});
+
+		selectButton.SetPanelEvent('ondblclick', () => {
+			let zone: Zone = null;
+			if (selectionWhenActivated.zone) {
+				zone = selectionWhenActivated.zone;
+			} else if (selectionWhenActivated.segment) {
+				zone = selectionWhenActivated.segment.checkpoints[0];
+			} else if (selectionWhenActivated.track) {
+				zone = selectionWhenActivated.track.zones.segments[0].checkpoints[0];
+			}
+			if (zone) {
+				this.panels.zoningMenu.moveToRegion(zone.regions[0]);
+			}
 		});
 
 		let isInActiveHierarchy = false;
@@ -225,7 +241,6 @@ class ZoneMenuHandler {
 		}
 
 		if (isInActiveHierarchy) {
-			const selectButton = item.FindChildTraverse<ToggleButton>('SelectButton');
 			selectButton.AddClass('in-active-hierarchy');
 
 			if (zonesObject === this.getActiveSelection()) {

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -156,7 +156,7 @@ interface ZoneEditorLimits {
 	MAX_SEGMENT_CHECKPOINTS: number;
 	MAX_STAGE_TRACKS: number;
 	MAX_BONUS_TRACKS: number;
-	MAX_ZONES_ALL_TRACKS: number;
+	MAX_REGIONS: number;
 }
 
 interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {

--- a/styles/hud/hud.scss
+++ b/styles/hud/hud.scss
@@ -11,6 +11,10 @@ Hud,
 	height: 100%;
 	-s2-mix-blend-mode: opaque;
 	blur: fastgaussian(4, 4, 5);
+
+	&--weak {
+		blur: fastgaussian(4, 4, 2);
+	}
 }
 
 #HudTopLeft {

--- a/styles/hud/tab-menu.scss
+++ b/styles/hud/tab-menu.scss
@@ -18,16 +18,6 @@
 		}
 	}
 
-	&--offset {
-		margin: 32px;
-		horizontal-align: left;
-		vertical-align: top;
-
-		& > .hud-tab-menu__wrapper > .hud-tab-menu__header {
-			visibility: collapse;
-		}
-	}
-
 	&__wrapper {
 		flow-children: down;
 		box-shadow: 0 0 20px 0 rgba(0, 0, 0, 1);

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -6,11 +6,21 @@ $smaller: 12px;
 $small: 16px;
 $medium: 28px;
 
+#ZoningContainer {
+	margin: 24px;
+	width: 560px;
+	background-color: rgba(0, 0, 0, 0.5);
+}
+
 .zoning {
 	width: 100%;
 	padding: 8px;
 	flow-children: down;
 	overflow: squish;
+
+	&.nomousecapture {
+		opacity: 0.5;
+	}
 
 	&__title {
 		@include mixin.font-styles($use-header: true);

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -44,7 +44,7 @@ $medium: 28px;
 		width: 100%;
 		background-color: $dark-200;
 		margin: 2px 0px;
-		padding: 6px 0px;
+		padding: 4px;
 		border-radius: 6px;
 		border: 1px solid rgba(50, 50, 50, 0.7);
 		flow-children: down;
@@ -53,7 +53,6 @@ $medium: 28px;
 
 	&__menu-separator {
 		width: 100%;
-		padding: 0px 6px;
 		border-radius: 4px;
 		flow-children: down;
 
@@ -64,36 +63,45 @@ $medium: 28px;
 		}
 	}
 
-	&__track-list {
+	&__itemlists {
 		width: 100%;
-		height: 330px;
-		padding: 0px 6px;
-		margin-right: 6px;
-		flow-children: down;
-		overflow: squish scroll;
+		flow-children: right;
 
-		& > VerticalScrollBar .ScrollThumb {
-			border-radius: 2px;
+		// & > VerticalScrollBar .ScrollThumb {
+		// 	border-radius: 2px;
+		// }
+	}
+
+	&__itemlist {
+		height: 300px;
+		width: 32.666%;
+
+		&--gap-before {
+			margin-left: 1%;
 		}
 	}
 
-	&__tracklist-button {
+	&__item-selectbutton {
 		margin: 1px 1px;
 		padding: 2px 4px;
 		border: 1px none;
 		border-radius: 6px;
 
-		&:selected {
-			background-color: $light-200;
-			border: 1px solid $gray-800;
+		&.in-active-hierarchy {
+			background-color: $gray-500;
+			border: 1px solid $gray-600;
+
+			&.selected {
+				background-color: $gray-800;
+			}
 		}
 
-		&:hover {
-			border: 1px solid $gray-800;
+		&:not(.selected):hover {
+			border: 1px solid $gray-900;
 		}
 	}
 
-	&__tracklist-delete {
+	&__item-deletebutton {
 		vertical-align: center;
 		height: 16px;
 		tooltip-position: bottom;
@@ -117,42 +125,27 @@ $medium: 28px;
 		width: fit-children;
 		horizontal-align: left;
 		flow-children: right;
-		margin: 2px 20px;
+		margin: 2px;
 		padding: 2px 4px;
-
-		> Image {
-		}
 	}
 
-	&__tracklist-track {
+	&__itemlist-item {
 		width: 100%;
 		flow-children: down;
 	}
 
-	&__tracklist-label {
+	&__itemlist-label {
 		font-size: $small;
 
 		&--add {
 			font-size: $smaller;
 			font-style: italic;
 			color: $gray-800;
+
+			&:hover {
+				color: white;
+			}
 		}
-	}
-
-	&__tracklist-segment {
-		width: 100%;
-		flow-children: down;
-	}
-
-	&__tracklist-checkpoint {
-		width: 100%;
-		margin: 0px 18px;
-		flow-children: down;
-	}
-
-	&__tracklist-course-entry {
-		width: 100%;
-		flow-children: right;
 	}
 
 	&__list-container {

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -1,4 +1,5 @@
 @use '../../config' as *;
+@use '../../abstract/mixin';
 @use 'sass:color';
 
 $smaller: 12px;
@@ -7,18 +8,24 @@ $medium: 28px;
 
 .zoning {
 	width: 100%;
-	padding: 4px 4px;
+	padding: 8px;
 	flow-children: down;
 	overflow: squish;
 
+	&__title {
+		@include mixin.font-styles($use-header: true);
+		font-size: 40px;
+	}
+
 	&__header {
-		color: white;
-		font-family: $font-header;
+		@include mixin.font-styles($use-header: true);
 		font-size: $medium;
+		margin-top: 6px;
+		margin-left: 6px;
 	}
 
 	&__button-box {
-		margin: 2px 0px;
+		margin-top: 8px;
 		horizontal-align: right;
 		flow-children: right;
 	}
@@ -29,6 +36,7 @@ $medium: 28px;
 		margin: 2px 0px;
 		padding: 6px 0px;
 		border-radius: 6px;
+		border: 1px solid rgba(50, 50, 50, 0.7);
 		flow-children: down;
 		overflow: squish scroll;
 	}
@@ -48,7 +56,7 @@ $medium: 28px;
 
 	&__track-list {
 		width: 100%;
-		height: 274px;
+		height: 330px;
 		padding: 0px 6px;
 		margin-right: 6px;
 		flow-children: down;


### PR DESCRIPTION
- Change the zoning menu to be a standalone window instead of being an alternate mode of the tab menu. When `mom_zone_edit` is enabled, the zoning menu is always open rather than being tied to the tab menu bind. Instead of using the tab menu bind in combination with right click to lock the zoning menu open and interact with it, now while its open you just right click to capture the mouse to interact with it, and right or left click outside the menu to uncapture the mouse and go back to controlling the in-game camera. When the window is open but the mouse is not captured, the menu becomes translucent to not block the view as much and also make it especially clear whether the mouse is currently captured. This does make the "zone editing binds" info harder to read, but I plan to move this info to a separate small window soon to make it more obvious (and then it wont be translucent).


https://github.com/user-attachments/assets/4d781408-33d2-49cd-a30d-61459bb1ceda


- Rework the top section into three side-by-side lists roughly corresponding to tracks, segments, and zones. This is a more efficient use of space and is much easier to navigate.

![image](https://github.com/user-attachments/assets/76a1ebb8-42ae-4aaa-8995-86f15e52bede)


- Streamline the internal logic for the top section to improve maintainability and minimize bugs by rebuilding the entire DOM from scratch with each change to the zones data.
- Eliminate the ability for the zones data to end up in most invalid intermediate states. For example, it is no longer possible to have a track which does not have at least one segment with at least one checkpoint (i.e. the start zone) defined. I think the only possible invalid states now are "no main track" and "no track end zone". Allowing these states is convenient for the zoning process, so the game logic will be altered to allow booting up zones in these states when local zone definitions are used.
- When adding a bonus, there are now separate buttons for "add bonus" and "add defrag modifier bonus". Once a bonus is created, it is permanently locked to that type. As such, you are no longer allowed to turn off all modifiers for a modifier bonus.
- This also incorporates global region creation and editing