### PR TITLE
Add missing timer binds

### DIFF
--- a/layout/pages/settings/input.xml
+++ b/layout/pages/settings/input.xml
@@ -126,7 +126,9 @@
 				<SettingsKeyBinder text="#Keybind_RestartTrack" bind="mom_restart_track" tags="restart,reset" />
 				<SettingsKeyBinder text="#Keybind_RestartStage" bind="mom_restart_stage" tags="restart,reset,stage" />
 				<SettingsKeyBinder text="#Keybind_Respawn" bind="mom_respawn" tags="restart,reset,respawn" />
+				<SettingsKeyBinder text="#Keybind_TeleportToSpawn" bind="mom_teleport_to_spawn" tags="restart,reset,spawn" />
 				<SettingsKeyBinder text="#Keybind_Main" bind="mom_main" tags="restart,reset,switch,track" />
+				<SettingsKeyBinder text="#Keybind_TimerStop" bind="mom_timer_stop" tags="timer,stop" />
 
 				<Label class="settings-group__subtitle" text="#Settings_Keybinds_Savestates" />
 


### PR DESCRIPTION
Add binds for `mom_teleport_to_spawn` and `mom_timer_stop`.

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below