### PR TITLE
Fix/lobby map names

### DIFF
--- a/scripts/common/online.ts
+++ b/scripts/common/online.ts
@@ -19,7 +19,7 @@ export type LobbyList = Record<uint64_str, Lobby>;
 export type MemberData = Record<steamID, LobbyMember>;
 
 export interface LobbyMember {
-	map: string;
+	map_name: string;
 
 	isTyping: 'y' | undefined;
 

--- a/scripts/pages/drawer/lobby.ts
+++ b/scripts/pages/drawer/lobby.ts
@@ -253,6 +253,18 @@ class LobbyHandler {
 					])
 				);
 
+				const hackId = $.RegisterEventHandler('PanelLoaded', avatarPanel, () => {
+					$.Schedule(2.5, () => {
+						if (newPanel.IsValid()) {
+							newPanel.SetDialogVariable(
+								'lobbyTitle',
+								$.Localize('#Lobby_Owner').replace('%owner%', FriendsAPI.GetNameForXUID(ownerSteamID))
+							);
+							$.UnregisterEventHandler('PanelLoaded', avatarPanel, hackId);
+						}
+					});
+				});
+
 				newPanel.SetDialogVariable('lobbyTitle', lobbyName);
 				newPanel.SetDialogVariable('lobbyPlayerCount', `${lobbyData['members']}/${lobbyData['members_limit']}`);
 				newPanel.SetDialogVariable(

--- a/scripts/pages/drawer/lobby.ts
+++ b/scripts/pages/drawer/lobby.ts
@@ -307,9 +307,9 @@ class LobbyHandler {
 			isMuted ? $.Localize('#Lobby_MutedPlayer') : FriendsAPI.GetNameForXUID(memberSteamID)
 		);
 
-		const memberMap = memberData.map;
+		const memberMap = memberData.map_name;
 		const localSteamID = UserAPI.GetXUID();
-		const localMap = this.lobbyMemberData[localSteamID]?.map;
+		const localMap = this.lobbyMemberData[localSteamID]?.map_name;
 
 		panel.SetDialogVariable('memberMap', isMuted ? '' : (memberMap ?? $.Localize('#Lobby_InMainMenu')));
 
@@ -441,8 +441,8 @@ class LobbyHandler {
 	onLobbyMemberDataUpdated(memberData: MemberData) {
 		for (const [memberSteamID, member] of Object.entries(memberData)) {
 			const localID = UserAPI.GetXUID();
-			const oldMap = this.lobbyMemberData[localID]?.map;
-			const newMap = member.map;
+			const oldMap = this.lobbyMemberData[localID]?.map_name;
+			const newMap = member.map_name;
 
 			if (memberSteamID in this.lobbyMemberData) {
 				const member = this.lobbyMemberData[memberSteamID] as Record<string, any>;


### PR DESCRIPTION
Closes momentum-mod/game/issues/2374

Fix for missing map names, and a very gross hack to temporarily fixed the "[Unnamed]'s Lobby" issue. That issue can be fixed properly when we move lobby TS code to C++.