### PR TITLE
fix TP destinations in Zoning UI

### DIFF
--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -951,10 +951,10 @@ class ZoneMenuHandler {
 			if (this.selectedRegion.teleDestPos === undefined || this.selectedRegion.teleDestYaw === undefined) {
 				this.selectedRegion.teleDestTargetname = '';
 				const index = this.panels.regionSelect.GetSelected()?.GetAttributeInt('value', -1);
-				if (index !== -1)
-					this.selectedZone.zone.regions[index] = this.panels.zoningMenu.createDefaultTeleDest(
-						this.selectedRegion
-					);
+				if (index !== -1) {
+					const regionWithTPDest = this.panels.zoningMenu.createDefaultTeleDest(this.selectedRegion);
+					this.deepCopyRegion(this.selectedZone.zone.regions[index], regionWithTPDest);
+				}
 
 				this.selectedRegion = this.selectedZone.zone.regions[index];
 				this.pickTeleDestPos();
@@ -1014,16 +1014,30 @@ class ZoneMenuHandler {
 
 	onRegionEditCompleted(newRegion: Region) {
 		if (this.selectedZone.globalRegion?.index != null) {
-			this.selectedZone.globalRegion.regions[this.selectedZone.globalRegion.index] = newRegion;
+			this.deepCopyRegion(
+				this.selectedZone.globalRegion.regions[this.selectedZone.globalRegion.index],
+				newRegion
+			);
 		} else if (this.selectedZone.zone) {
 			const index = this.panels.regionSelect.GetSelected()?.GetAttributeInt('value', -1);
-			if (index !== -1) this.selectedZone.zone.regions[index] = newRegion;
+			if (index !== -1) this.deepCopyRegion(this.selectedZone.zone.regions[index], newRegion);
 		} else {
 			return;
 		}
 
 		this.setInfoPanelShown(false);
 		this.drawZones();
+	}
+
+	deepCopyRegion(to: Region, from: Region) {
+		if (!to || !from) return;
+		to.points = [...from.points];
+		to.bottom = from.bottom;
+		to.height = from.height;
+		if (from.safeHeight !== undefined) to.safeHeight = from.safeHeight;
+		if (from.teleDestTargetname !== undefined) to.teleDestTargetname = from.teleDestTargetname;
+		if (from.teleDestPos !== undefined) to.teleDestPos = [...from.teleDestPos];
+		if (from.teleDestYaw !== undefined) to.teleDestYaw = from.teleDestYaw;
 	}
 
 	onRegionEditCanceled() {


### PR DESCRIPTION
This pull request fixes the following bugs:
- Setting user-defined TP destination seemed to not update/save
- Setting no target or a named entity as the targetname did not delete the destination position and yaw fields

Also, the pano code now has separate functions for reloading the properties data (text entries) and updating the zone defs because the user changed the dropdown selection.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below