### PR TITLE
display correct prime sight bars in a/d turns based on trueness setting

### DIFF
--- a/scripts/hud/cgaz.ts
+++ b/scripts/hud/cgaz.ts
@@ -1146,8 +1146,8 @@ class CgazHandler {
 				break;
 
 			case InputMode.TURN_LEFT: {
-				fillLeftZones = true;
-				leftOffset = -Math.PI * 0.5 - viewAngle;
+				fillLeftZones = Boolean(this.primeTruenessMode & TruenessMode.CPM_TURN);
+				if (fillLeftZones) leftOffset = -Math.PI * 0.5 - viewAngle;
 				const velocity = MomentumPlayerAPI.GetVelocity();
 				const speed = MomMath.magnitude2D(velocity);
 				const mirrorTarget = this.findFastAngle(speed, MAX_GROUND_SPEED, AIR_ACCEL);
@@ -1155,8 +1155,8 @@ class CgazHandler {
 				break;
 			}
 			case InputMode.TURN_RIGHT: {
-				fillRightZones = true;
-				rightOffset = Math.PI * 0.5 - viewAngle;
+				fillRightZones = Boolean(this.primeTruenessMode & TruenessMode.CPM_TURN);
+				if (fillRightZones) rightOffset = Math.PI * 0.5 - viewAngle;
 				const velocity = MomentumPlayerAPI.GetVelocity();
 				const speed = MomMath.magnitude2D(velocity);
 				const mirrorTarget = this.findFastAngle(speed, MAX_GROUND_SPEED, AIR_ACCEL);
@@ -1173,10 +1173,8 @@ class CgazHandler {
 			}
 		}
 
-		const leftAngles =
-			fillLeftZones && this.primeTruenessMode & TruenessMode.CPM_TURN ? this.primeAngles : this.snapAngles;
-		const rightAngles =
-			fillRightZones && this.primeTruenessMode & TruenessMode.CPM_TURN ? this.primeAngles : this.snapAngles;
+		const leftAngles = fillLeftZones ? this.primeAngles : this.snapAngles;
+		const rightAngles = fillRightZones ? this.primeAngles : this.snapAngles;
 
 		const iLeft = this.updateFirstPrimeZone(leftTarget, leftOffset, this.primeFirstZoneLeft, leftAngles);
 		const iRight = this.updateFirstPrimeZone(rightTarget, rightOffset, this.primeFirstZoneRight, rightAngles);


### PR DESCRIPTION
This pull request corrects the logic for selecting snap angles when CPM turning. The new logic only draws solid bars when a/d turning and the `CPM_TURN` flag (4) is active. When the flag is 0, the inactive strafe bars are shown as hints (same as original behavior).

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
