### PR TITLE
Fix map name and "user is typing" not updating lobby drawer

### DIFF
--- a/scripts/pages/drawer/lobby.ts
+++ b/scripts/pages/drawer/lobby.ts
@@ -457,10 +457,7 @@ class LobbyHandler {
 			const newMap = member.map_name;
 
 			if (memberSteamID in this.lobbyMemberData) {
-				const member = this.lobbyMemberData[memberSteamID] as Record<string, any>;
-				for (const [k, v] of Object.entries(member)) {
-					member[k] = v;
-				}
+				Object.assign(this.lobbyMemberData[memberSteamID], member);
 			} else {
 				this.lobbyMemberData[memberSteamID] = member;
 			}


### PR DESCRIPTION
This was a bug I introduced when porting to TypeScript. `member` was being redefined so code just assigned values from one object to itself. Using original `member` variable fixes it, also Object.assign is simpler way to do this.
