### PR TITLE
fix: hide unimplemented counters on Key Press HUD

### DIFF
--- a/layout/hud/keypress.xml
+++ b/layout/hud/keypress.xml
@@ -33,7 +33,7 @@
 		<Label id="KeyLeft" class="keypress__key keypress__unimplemented" text="" />
 		<Label id="KeyRight" class="keypress__key keypress__unimplemented" text="" />
 
-		<Label id="CountStrafes" class="keypress__key" text="{i:strafes}" />
-		<Label id="CountJumps" class="keypress__key" text="{i:jumps}" />
+		<Label id="CountStrafes" class="keypress__key keypress__unimplemented" text="{i:strafes}" />
+		<Label id="CountJumps" class="keypress__key keypress__unimplemented" text="{i:jumps}" />
 	</MomHudKeyPress>
 </root>


### PR DESCRIPTION
Closes https://github.com/momentum-mod/game/issues/2396

Since the jump and strafe counters will only be implemented on 0.12.0, it would be worth it reducing the visual noise on the corner and hide them until they are implemented.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

