### PR TITLE
Timer status small fixes

### DIFF
--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -307,13 +307,13 @@ interface GlobalEventNameMap {
 
 	OnRegionEditCanceled: () => void;
 
-	/** Fired when the the primary timer of the UI entity transitions to a different state */
+	/** Fired when the primary timer of the UI entity transitions to a different state */
 	OnObservedTimerStateChange: () => void;
 
-	/** Fired when the the primary timer of the UI entity progresses to a new checkpoint */
+	/** Fired when the primary timer of the UI entity progresses to a new checkpoint */
 	OnObservedTimerCheckpointProgressed: () => void;
 
-	/** Fired when the the primary timer of the UI entity effectively starts a segment. */
+	/** Fired when the primary timer of the UI entity effectively starts a segment. */
 	OnObservedTimerSegmentEffectiveStart: () => void;
 
 	/**


### PR DESCRIPTION
When on a map with no zones I made it avoid showing "Timer Disabled" constantly, but with current code if you use practice mode or savelocs, it goes back to showing "Timer Disabled". This PR rewords that logic so it behaves consistently.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

