### PR TITLE
fix: RegisterHUDPanelForGamemode throws on map load

### DIFF
--- a/scripts/util/register-for-gamemodes.ts
+++ b/scripts/util/register-for-gamemodes.ts
@@ -123,7 +123,7 @@ export function RegisterHUDPanelForGamemode({
 
 	const unregister = () =>
 		handles.forEach(({ event, handle, panel }) =>
-			panel ? $.UnregisterForUnhandledEvent(event, handle) : $.UnregisterEventHandler(event, panel, handle)
+			panel ? $.UnregisterEventHandler(event, panel, handle) : $.UnregisterForUnhandledEvent(event, handle)
 		);
 
 	const handle = $.RegisterForUnhandledEvent('LevelInitPostEntity', () => {


### PR DESCRIPTION
This never worked, but the HUD layout reloading behaviour meant it never got called. Seems to behave properly now with this fix and the reloading removed.