### PR TITLE
fix: replace usage of UpdateCurrentAnimationKeyframes with TriggerClass

### DIFF
--- a/scripts/hud/static-menu.ts
+++ b/scripts/hud/static-menu.ts
@@ -1,5 +1,3 @@
 $.RegisterEventHandler('StaticHudMenu_EntrySelected', $.GetContextPanel(), (panel: Panel) => {
-	panel.AddClass('static-hud-menu__entry--highlight');
-	const kfs = panel.CreateCopyOfCSSKeyframes('StaticHudMenuEntrySelected');
-	panel.UpdateCurrentAnimationKeyframes(kfs);
+	panel.TriggerClass('static-hud-menu__entry--highlight');
 });

--- a/scripts/pages/settings/settings.ts
+++ b/scripts/pages/settings/settings.ts
@@ -158,11 +158,7 @@ export class SettingsHandler {
 		this.limitScrollCheck(1);
 
 		// Apply highlight anim
-		panel.AddClass('settings-group--highlight');
-
-		// I really hate this way of animating, but it ensures the --highlight class gets removed
-		const kfs = panel.CreateCopyOfCSSKeyframes('SettingsGroupHighlight');
-		panel.UpdateCurrentAnimationKeyframes(kfs);
+		panel.TriggerClass('settings-group--highlight');
 	}
 
 	// Set the shouldLimitScroll bool for a specific amount of time
@@ -349,9 +345,7 @@ export class SettingsHandler {
 			} else {
 				switchDelay = 0.05; // This should always be half the duration of settings-info--switch
 
-				this.panels.info.AddClass('settings-info--switch');
-				const kfs = this.panels.info.CreateCopyOfCSSKeyframes('BlurFadeInOut');
-				this.panels.info.UpdateCurrentAnimationKeyframes(kfs);
+				this.panels.info.TriggerClass('settings-info--switch');
 			}
 
 			// Delay changing the properties even we've just played the switch animation,


### PR DESCRIPTION
Closes https://github.com/momentum-mod/game/issues/2419

Calling `UpdateCurrentAnimationKeyframes` call cause an infinite loop in a `CUtlMap::Find`. I have no idea how, was a huge pain to debug, and `UpdateCurrentAnimationKeyframes` really be used anyway, `TriggerClass` is the proper way to ensure an anim fires.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
