### PR TITLE
Enable strafe trainer on HL1 Bhop and Climb 1.6

### DIFF
--- a/scripts/hud/strafe-trainer.ts
+++ b/scripts/hud/strafe-trainer.ts
@@ -77,7 +77,14 @@ class StrafeTrainer {
 
 	constructor() {
 		RegisterHUDPanelForGamemode({
-			gamemodes: [Gamemode.BHOP, Gamemode.SURF, Gamemode.CLIMB_KZT, Gamemode.CLIMB_MOM],
+			gamemodes: [
+				Gamemode.SURF,
+				Gamemode.BHOP,
+				Gamemode.BHOP_HL1,
+				Gamemode.CLIMB_MOM,
+				Gamemode.CLIMB_KZT,
+				Gamemode.CLIMB_16
+			],
 			onLoad: () => this.onLoad(),
 			events: [
 				{ event: 'OnJumpStarted', callback: () => this.onJump() },


### PR DESCRIPTION
### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
