### PR TITLE
feat: add overbounce global regions to zoning UI

### DIFF
--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -63,7 +63,8 @@ export enum ItemType {
 export enum GlobalRegionType {
 	TYPES_LIST = 0,
 	ALLOW_BHOP = 1,
-	CANCEL_TIMER = 2
+	CANCEL_TIMER = 2,
+	OVERBOUNCE = 3
 }
 
 interface GlobalRegionSelection {
@@ -451,7 +452,8 @@ class ZoneMenuHandler {
 		if (this.selectedZone.globalRegion != null) {
 			const types = [
 				['#Zoning_AllowBhopZone', GlobalRegionType.ALLOW_BHOP, 'allowBhop'] as const,
-				['#Zoning_CancelZone', GlobalRegionType.CANCEL_TIMER, 'cancel'] as const
+				['#Zoning_CancelZone', GlobalRegionType.CANCEL_TIMER, 'cancel'] as const,
+				['#Zoning_OverbounceZone', GlobalRegionType.OVERBOUNCE, 'overbounce'] as const
 			];
 
 			this.mapZoneData.globalRegions = this.mapZoneData.globalRegions || {};
@@ -1483,6 +1485,13 @@ class ZoneMenuHandler {
 			renderRegions.push({
 				region: region,
 				renderMode: RegionRenderMode.CANCEL,
+				editing: region === this.selectedRegion
+			});
+		}
+		for (const region of this.mapZoneData.globalRegions?.overbounce ?? []) {
+			renderRegions.push({
+				region: region,
+				renderMode: RegionRenderMode.OVERBOUNCE,
 				editing: region === this.selectedRegion
 			});
 		}


### PR DESCRIPTION
Closes momentum-mod/game/issues/2447

This pull request adds UI for creating overbounce zones as global regions. This is already implemented in the engine, an needed to be added to the in-game zoning tool.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "Zoning_OverbounceZone",
		"definition": "Allow Overbounces",
	    "context": "OB defrag technique, zoning UI"
	}
]
```
