### PR TITLE
Maintain scroll position after updating selection

### DIFF
--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -126,7 +126,7 @@
 						<Panel class="w-full">
 							<Panel class="w-fit-children h-align-left flow-right">
 								<Label class="zoning__property-label not-global-region" text="#Zoning_Region" />
-								<DropDown id="RegionSelect" class="dropdown zoning__dropdown not-global-region" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.populateRegionProperties()">
+								<DropDown id="RegionSelect" class="dropdown zoning__dropdown not-global-region" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.onRegionDropdownChanged()">
 									<!-- Populated in js -->
 								</DropDown>
 								<Label id="RegionCountLabel" class="zoning__property-label not-global-region" text="/ ?" />
@@ -205,6 +205,11 @@
 											<!-- Populated in js -->
 										</DropDown>
 									</Panel>
+									<Panel class="zoning__property">
+										<Button class="button button--gray zoning__property-button" onactivate="ZoneMenuHandler.previewTeleDest()">
+											<Label class="button__text" text="#Zoning_PreviewDestination" />
+										</Button>
+									</Panel>
 								</Panel>
 								<Panel id="RegionTPDest_Custom_Properties" class="w-full col">
 									<Panel class="zoning__property">
@@ -226,6 +231,11 @@
 											</Button>
 											<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="4" textmode="numeric" ontextentrychange="ZoneMenuHandler?.setRegionTeleDestOrientation?.()" />
 										</Panel>
+									</Panel>
+									<Panel class="zoning__property">
+										<Button class="button button--gray zoning__property-button" onactivate="ZoneMenuHandler.previewTeleDest()">
+											<Label class="button__text" text="#Zoning_PreviewDestination" />
+										</Button>
 									</Panel>
 								</Panel>
 							</Panel>

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -74,7 +74,7 @@
 				<Panel class="zoning__menu-separator">
 					<Panel id="MapMaxVelocity" class="zoning__property">
 						<Label class="zoning__property-label" text="#Zoning_MaxVelocity" />
-						<TextEntry id="MaxVelocity" class="textentry zoning__textentry" textmode="numeric" text="" ontextentrysubmit="ZoneMenuHandler.setMaxVelocity()" />
+						<TextEntry id="MaxVelocity" class="textentry zoning__textentry" textmode="numeric" text="" ontextentrychange="ZoneMenuHandler?.setMaxVelocity?.()" />
 					</Panel>
 					<Panel id="StagesEndAtStageStarts" class="zoning__property">
 						<Label class="zoning__property-label" text="#Zoning_StagesEndAtStageStarts" />
@@ -108,7 +108,7 @@
 					</Panel>
 					<Panel id="Name" class="zoning__property">
 						<Label class="zoning__property-label" text="#Zoning_Name" />
-						<TextEntry id="SegmentName" class="textentry zoning__textentry" maxchars="255" text="" ontextentrysubmit="ZoneMenuHandler.setSegmentName()" />
+						<TextEntry id="SegmentName" class="textentry zoning__textentry" maxchars="255" text="" ontextentrychange="ZoneMenuHandler?.setSegmentName?.()" />
 					</Panel>
 				</Panel>
 			</Panel>
@@ -116,7 +116,7 @@
 				<Panel class="zoning__menu-separator">
 					<Panel id="Filter" class="zoning__property not-global-region">
 						<Label class="zoning__property-label" text="#Zoning_Filter" />
-						<DropDown id="FilterSelect" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler.updateZoneFilter()">
+						<DropDown id="FilterSelect" class="dropdown zoning__dropdown" menuclass="dropdown-menu" onuserinputsubmit="ZoneMenuHandler?.updateZoneFilter?.()">
 							<Label text="#Zoning_Filter_None" value="0" />
 							<!-- Populated in js -->
 						</DropDown>
@@ -154,7 +154,7 @@
 								<Button id='SetHeightButton' class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickHeight()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetHeightButton', '#Zoning_SetHeight_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 									<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 								</Button>
-								<TextEntry id="RegionHeight" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionHeight()" />
+								<TextEntry id="RegionHeight" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrychange="ZoneMenuHandler?.setRegionHeight?.()" />
 							</Panel>
 						</Panel>
 						<Panel id="RegionSafeHeightSection" class="not-global-region w-full col">
@@ -178,7 +178,7 @@
 									<Button id='SetSafeHeightButton' class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickSafeHeight()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetSafeHeightButton', '#Zoning_SetSafeHeight_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 										<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 									</Button>
-									<TextEntry id="RegionSafeHeight" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionSafeHeight()" />
+									<TextEntry id="RegionSafeHeight" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrychange="ZoneMenuHandler?.setRegionSafeHeight?.()" />
 								</Panel>
 							</Panel>
 						</Panel>
@@ -213,9 +213,9 @@
 											<Button id="SetTeleDestPosButton" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestPos()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetTeleDestPosButton', '#Zoning_SetTeleDestPos_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 												<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 											</Button>
-											<TextEntry id="TeleX" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
-											<TextEntry id="TeleY" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
-											<TextEntry id="TeleZ" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+											<TextEntry id="TeleX" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrychange="ZoneMenuHandler?.setRegionTeleDestOrientation?.()" />
+											<TextEntry id="TeleY" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrychange="ZoneMenuHandler?.setRegionTeleDestOrientation?.()" />
+											<TextEntry id="TeleZ" class="textentry zoning__textentry" maxchars="9" textmode="numeric" ontextentrychange="ZoneMenuHandler?.setRegionTeleDestOrientation?.()" />
 										</Panel>
 									</Panel>
 									<Panel class="zoning__property">
@@ -224,7 +224,7 @@
 											<Button id="SetTeleDestYawButton" class="zoning__region-point-pick" onactivate="ZoneMenuHandler.pickTeleDestYaw()" onmouseover="UiToolkitAPI.ShowTextTooltip('SetTeleDestYawButton', '#Zoning_SetTeleDestYaw_Tooltip');" onmouseout="UiToolkitAPI.HideTextTooltip();">
 												<Image class="zoning__region-point-pick__icon" src="file://{images}/adjust.svg" />
 											</Button>
-											<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="4" textmode="numeric" ontextentrysubmit="ZoneMenuHandler.setRegionTeleDestOrientation()" />
+											<TextEntry id="TeleYaw" class="textentry zoning__textentry" maxchars="4" textmode="numeric" ontextentrychange="ZoneMenuHandler?.setRegionTeleDestOrientation?.()" />
 										</Panel>
 									</Panel>
 								</Panel>

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -261,7 +261,11 @@ class ZoneMenuHandler {
 			} else if (selectionWhenActivated.segment) {
 				region = selectionWhenActivated.segment.checkpoints[0].regions[0];
 			} else if (selectionWhenActivated.track) {
-				region = selectionWhenActivated.track.zones.segments[0].checkpoints[0].regions[0];
+				if (this.isDefragBonus(selectionWhenActivated.track)) {
+					region = this.mapZoneData.tracks?.main.zones.segments[0].checkpoints[0].regions[0];
+				} else {
+					region = selectionWhenActivated.track.zones.segments[0].checkpoints[0].regions[0];
+				}
 			} else if (selectionWhenActivated.globalRegion?.index >= 0) {
 				region = this.selectedZone.globalRegion.regions[this.selectedZone.globalRegion.index];
 			}

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -1005,6 +1005,12 @@ class ZoneMenuHandler {
 		this.panels.zoningMenu.moveToRegion(this.selectedRegion);
 	}
 
+	previewTeleDest() {
+		if (!this.selectedZone || !this.selectedRegion) return;
+
+		this.panels.zoningMenu.previewTeleDest(this.selectedRegion);
+	}
+
 	pickCorners() {
 		if (!this.selectedZone || !this.selectedRegion) return;
 		this.panels.zoningMenu.editRegion(PickType.CORNER);

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -1022,7 +1022,6 @@ class ZoneMenuHandler {
 
 		const height = Number.parseFloat(this.panels.regionHeight.text);
 		this.selectedRegion.height = Math.max(Number.isNaN(height) ? 0 : height, 1);
-		this.panels.regionHeight.text = this.selectedRegion.height.toFixed(2);
 
 		this.updateEditorRegions();
 	}

--- a/scripts/pages/zoning/zoning.ts
+++ b/scripts/pages/zoning/zoning.ts
@@ -1628,6 +1628,9 @@ class ZoneMenuHandler {
 		for (const bonus of this.mapZoneData.tracks.bonuses ?? []) {
 			regionCount += countTrackRegions(bonus);
 		}
+		for (const [regions] of Object.values(this.mapZoneData.globalRegions ?? {})) {
+			regionCount += regions?.length ?? 0;
+		}
 
 		return regionCount;
 	}

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -175,6 +175,8 @@ interface ZoneMenu extends AbstractPanel<'ZoneMenu'> {
 
 	moveToRegion(region: import('common/web_dontmodifyme').Region): void;
 
+	previewTeleDest(region: import('common/web_dontmodifyme').Region): void;
+
 	updateEditorRegions(editorRegions: ZoneEditorRegion[]): void;
 
 	validateRegionPolygon(

--- a/styles/pages/zoning/zoning.scss
+++ b/styles/pages/zoning/zoning.scss
@@ -218,6 +218,14 @@ $properties_inset: 24px;
 		horizontal-align: right;
 	}
 
+	&__property-button-teleport {
+		horizontal-align: right;
+
+		&:hover {
+			wash-color: $green;
+		}
+	}
+
 	&__region-property-container {
 		horizontal-align: right;
 		flow-children: right;


### PR DESCRIPTION
Closes momentum-mod/game/issues/2452

This pull request implements the following changes:
- keep scroll position of selection lists when new zoning object is selected
- include global regions when counting total regions (c++ validator also uses this behavior)
- don't require the user to submit changes to test entry fields
- ~~teleport to region when new zoning object is selected (don't require double click)~~ discarded change
- add a new button for previewing a teleport destination
- when teleporting to view a region, use the improved teleport (don't send the user to the TP destination)
- when the user teleports to a defrag bonus, use the main track's zones

Requires red MR for teleport features to be merged.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
