### PR TITLE
fix: muting not working in lobbies

### DIFF
--- a/scripts/pages/drawer/lobby.ts
+++ b/scripts/pages/drawer/lobby.ts
@@ -341,7 +341,7 @@ class LobbyHandler {
 					icon: 'file://{images}/volume-' + (isMuted ? 'high' : 'mute') + '.svg',
 					style: 'icon-color-' + (isMuted ? 'green' : 'red'),
 					jsCallback: () => {
-						ChatAPI.ChangeMuteState(+memberSteamID, !isMuted);
+						ChatAPI.ChangeMuteState(memberSteamID, !isMuted);
 						if (isMuted) {
 							memberData.isMuted = false;
 						}

--- a/scripts/types-mom/apis.d.ts
+++ b/scripts/types-mom/apis.d.ts
@@ -198,9 +198,9 @@ declare namespace MomentumReplayAPI {
 }
 
 declare namespace ChatAPI {
-	function ChangeMuteState(steamID: number, mute: boolean): void;
+	function ChangeMuteState(steamID: steamID, mute: boolean): void;
 
-	function BIsUserMuted(steamID: number): boolean;
+	function BIsUserMuted(steamID: steamID): boolean;
 }
 
 declare namespace SteamLobbyAPI {

--- a/scripts/types-mom/panels.d.ts
+++ b/scripts/types-mom/panels.d.ts
@@ -136,7 +136,7 @@ interface MomHudDFJump extends AbstractHudPanel<'MomHudDFJump'> {}
 interface MomHudJumpTiming extends AbstractHudPanel<'MomHudJumpTiming'> {}
 
 interface PlayerListPlayer extends AbstractPanel<'PlayerListPlayer'> {
-	readonly steamId: number;
+	readonly steamId: steamID;
 	readonly isSelf: boolean;
 	readonly connected: boolean;
 	readonly spectating: boolean;


### PR DESCRIPTION
Closes momentum-mod/game/issues/2456

This cast to number loses precision for steamIDs which exceed 2^53. Should always be string here, my fault for not doing the ChatAPI.ChangeMuteState definition wrong.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "",
		"definition": "",
	    "context": ""
	}
]
```
