### PR TITLE
Fix obvious text clipping issues with other languages

### DIFF
--- a/styles/config.scss
+++ b/styles/config.scss
@@ -371,7 +371,7 @@ $dropdown-button-color: $font-default-color !default;
 $dropdown-button-color-disabled: $font-disabled-color !default;
 $dropdown-button-text-shadow: $button-text-shadow;
 
-$dropdown-button-padding: 4px 12px !default;
+$dropdown-button-padding: 2px 12px !default;
 $dropdown-button-icon-width: 24px !default;
 
 $dropdown-menu-background: $gray-100 !default;

--- a/styles/pages/main-menu.scss
+++ b/styles/pages/main-menu.scss
@@ -499,7 +499,6 @@ $drawer-width: 768px;
 
 	&__header {
 		width: 100%;
-		height: 31px;
 		background-color: rgba(0, 0, 0, 0.4);
 		border-bottom: 1px solid rgba(0, 0, 0, 0.15);
 		padding: 2px 4px 1px 8px;

--- a/styles/pages/settings/settings.scss
+++ b/styles/pages/settings/settings.scss
@@ -310,7 +310,6 @@ $page-width: 1920px - $rightnav-width;
 	&__header {
 		flow-children: right;
 		width: 100%;
-		height: 64px;
 
 		padding-left: 8px;
 		margin-top: -10px;


### PR DESCRIPTION
This addresses the most obvious issues involving non-English languages, including:

- The "News" title being cutoff
- The settings headers being cutoff
- The dropdown offsetting the label vertically down

Obvious being defined as "I can see this within 5 minutes"

More information (including a comparison table) and more testing tomorrow

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [x] All changes requested in review have been `fixup`ed into my original commits.

