### PR TITLE
fix: open zoning UI from tab menu

### DIFF
--- a/layout/hud/tab-menu.xml
+++ b/layout/hud/tab-menu.xml
@@ -56,7 +56,7 @@
 			
 			<Panel id="TabMenuFooter" class="hud-tab-menu__footer">
 				<ConVarEnabler convar="sv_cheats" class="h-full" togglevisibility="true">
-					<ToggleButton id="ZoningToggle" class="hud-tab-menu__footer-button" convar="mom_zone_edit" />
+					<ToggleButton id="ZoningToggle" class="hud-tab-menu__footer-button" convar="mom_zoning_enable" />
 				</ConVarEnabler>
 				<Label class="hud-tab-menu__enable-cursor-tip" text="#HudTabMenu_EnableCursorTip"/> 
 			</Panel>


### PR DESCRIPTION
Recent change broke opening zoning UI from the tab menu. This PR undoes the change that broke it.