### PR TITLE
Expand brightness slider range

### DIFF
--- a/layout/pages/settings/video.xml
+++ b/layout/pages/settings/video.xml
@@ -54,7 +54,7 @@
 					<Label text="#Settings_Video_ColorMode_TV" value="1" id="tvmode1" />
 				</SettingsEnumDropDown>
 
-				<SettingsSlider id="brightness" text="#Settings_Video_Brightness" min="0.7" max="1.3" percentage="true" invert="false" value100percent="1.0" convar="mat_brightness" infomessage="#Settings_Video_Brightness_Info" hasdocspage="false" />
+				<SettingsSlider id="brightness" text="#Settings_Video_Brightness" min="0.5" max="3" percentage="true" invert="false" value100percent="1.0" convar="mat_brightness" infomessage="#Settings_Video_Brightness_Info" hasdocspage="false" />
 
 				<SettingsEnumDropDown text="#Settings_Video_AspectRatio" onuserinputsubmit="SettingsPage.videoSettingsOnUserInputSubmit()" id="AspectRatioEnum" oninputsubmit="AspectRatioSelectionChanged()">
 					<Label text="#Settings_Video_AspectRatio_Normal" value="0" id="aspectratio0" />


### PR DESCRIPTION
This just expands the settings menu brightness slider range since it was pretty limited before and I had one person complaining about poor brightness, which a value above the slider limit fixed. The UI allows manually typing a value outside the range, but most players will probably not figure that out.
