### PR TITLE
MomTV Defrag HUD

### DIFF
--- a/scripts/hud/cgaz.ts
+++ b/scripts/hud/cgaz.ts
@@ -524,7 +524,6 @@ class CgazHandler {
 		const speedSquared = speed * speed;
 		const dropSpeedSquared = dropSpeed * dropSpeed;
 
-		const velDir = MomMath.normal2D(velocity, 0.001);
 		const velAngle = Math.atan2(velocity.y, velocity.x);
 		const wishDir = lastMoveData.wishdir;
 		const wishAngle = MomMath.sumOfSquares2D(wishDir) > 0.001 ? Math.atan2(wishDir.y, wishDir.x) : 0;
@@ -537,7 +536,7 @@ class CgazHandler {
 		const forwardMove = Math.round(MomMath.dot2D(viewDir, wishDir));
 		const rightMove = Math.round(MomMath.cross2D(viewDir, wishDir));
 
-		const bIsFalling = lastMoveData.moveStatus === 0;
+		const bIsFalling = lastMoveData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.AIR;
 		const bHasAirControl = phyMode && MomMath.approxEquals(wishAngle, viewAngle, 0.01) && bIsFalling;
 		const bSnapShift =
 			!MomMath.approxEquals(Math.abs(forwardMove), Math.abs(rightMove), 0.01) && !(phyMode && bIsFalling);

--- a/scripts/hud/cgaz.ts
+++ b/scripts/hud/cgaz.ts
@@ -1130,13 +1130,9 @@ class CgazHandler {
 			Math.round(MomMath.magnitude2D(wishDir)) * (1 << Math.round(2 * Math.pow(cross, 2))) +
 			(Math.round(cross) > 0 ? 1 : 0);
 
-		const angleOffset = MomMath.remapAngle(velAngle - wishAngle);
-		const targetOffset = MomMath.remapAngle(velAngle - viewAngle);
-		const inputAngle = MomMath.remapAngle(viewAngle - wishAngle) * MomMath.sumOfSquares2D(wishDir);
 		const velocity = MomentumPlayerAPI.GetVelocity();
 		const gainZonesMap = new Map();
 		const phyMode = DefragAPI.GetDFPhysicsMode();
-		const lastMoveData = MomentumMovementAPI.GetLastMoveData();
 
 		let speedGain = 0;
 		let gainMax = -this.primeAccel;

--- a/scripts/hud/cgaz.ts
+++ b/scripts/hud/cgaz.ts
@@ -487,7 +487,8 @@ class CgazHandler {
 		const [realAccelerate, realMaxSpeed] = this.calcAccelAndMaxSpeed(hudData, velocity);
 		const realFriction = this.calcFriction(hudData, speed);
 
-		const maxSpeed = this.accelScaleEnable ? hudData.wishSpeed : realMaxSpeed;
+		const wishSpeed = MomMath.magnitude2D(hudData.wishVel);
+		const maxSpeed = this.accelScaleEnable ? wishSpeed : realMaxSpeed;
 		const accel = realAccelerate;
 		const maxAccel = accel * maxSpeed * tickInterval;
 
@@ -531,7 +532,7 @@ class CgazHandler {
 		const dropSpeedSquared = dropSpeed * dropSpeed;
 
 		const velAngle = Math.atan2(velocity.y, velocity.x);
-		const wishDir = hudData.wishDir;
+		const wishDir = MomMath.normalizeVector(hudData.wishVel);
 		const wishAngle = MomMath.sumOfSquares2D(wishDir) > 0.001 ? Math.atan2(wishDir.y, wishDir.x) : 0;
 		const viewAngle = (MomentumPlayerAPI.GetAngles().y * Math.PI) / 180;
 		const viewDir = {
@@ -706,8 +707,7 @@ class CgazHandler {
 					this.primeTruenessMode & TruenessMode.CPM_TURN || phyMode === DefragAPI.DefragPhysics.VQ3
 				);
 
-				const primeMaxSpeed =
-					this.primeTruenessMode & TruenessMode.PROJECTED ? hudData.wishSpeed : realMaxSpeed;
+				const primeMaxSpeed = this.primeTruenessMode & TruenessMode.PROJECTED ? wishSpeed : realMaxSpeed;
 				const primeMaxAccel = realAccelerate * maxSpeed * tickInterval;
 				const primeSightSpeed = useSnapAccel ? MAX_GROUND_SPEED : primeMaxSpeed;
 				const primeSightAccel = useSnapAccel ? this.snapAccel : primeMaxAccel;
@@ -905,7 +905,7 @@ class CgazHandler {
 							vel2Ddir = MomMath.normalizeVector2D(vel2Ddir);
 							if (
 								airDecelerate >= 0 &&
-								MomMath.rad2deg(Math.acos(MomMath.dot2D(vel2Ddir, hudData.wishDir))) >
+								MomMath.rad2deg(Math.acos(MomMath.dot2D(vel2Ddir, hudData.wishVel))) >
 									airDecelerateAngle
 							) {
 								accelerate = airDecelerate;

--- a/scripts/hud/cgaz.ts
+++ b/scripts/hud/cgaz.ts
@@ -1,5 +1,5 @@
 import { PanelHandler } from 'util/module-helpers';
-import { GamemodeCategories, GamemodeCategory } from 'common/web_dontmodifyme';
+import { GamemodeCategories, GamemodeCategory, Gamemode } from 'common/web_dontmodifyme';
 import * as MomMath from 'util/math';
 import { enhanceAlpha, rgbaStringLerp, rgbaStringToRgb } from 'util/colors';
 import { RegisterHUDPanelForGamemode } from '../util/register-for-gamemodes';
@@ -10,6 +10,8 @@ const DEFAULT_ACCEL = 2.56;
 const DEFAULT_SPEED = 320;
 const HASTE_ACCEL = 3.328; // (max speed) * (air accel = 1) * (tick interval) * (haste factor)
 const HASTE_SPEED = 416;
+const HASTE_FACTOR = 1.3;
+const AIR_MAX_WISHSPEED = 30;
 
 enum TruenessMode {
 	GROUND = 1 << 0, // show ground zones
@@ -476,14 +478,20 @@ class CgazHandler {
 		this.hFov = Math.atan((this.vFovTangent * this.screenX) / this.screenY);
 
 		const phyMode = DefragAPI.GetDFPhysicsMode();
-		const lastMoveData = MomentumMovementAPI.GetLastMoveData();
-
+		const hudData = MomentumMovementAPI.GetHudData();
 		const tickInterval = MomentumMovementAPI.GetTickInterval();
-		const maxSpeed = this.accelScaleEnable ? lastMoveData.wishspeed : lastMoveData.maxspeed;
-		const accel = lastMoveData.acceleration;
+
+		const velocity = MomentumPlayerAPI.GetVelocity();
+		const speed = MomMath.magnitude2D(velocity);
+
+		const [realAccelerate, realMaxSpeed] = this.calcAccelAndMaxSpeed(hudData, velocity);
+		const realFriction = this.calcFriction(hudData, speed);
+
+		const maxSpeed = this.accelScaleEnable ? hudData.wishSpeed : realMaxSpeed;
+		const accel = realAccelerate;
 		const maxAccel = accel * maxSpeed * tickInterval;
 
-		if (lastMoveData.hasteTime) {
+		if (hudData.hasteTime) {
 			if (this.snapAccel !== HASTE_ACCEL) {
 				this.snapAccel = HASTE_ACCEL;
 				MAX_GROUND_SPEED = HASTE_SPEED;
@@ -517,15 +525,13 @@ class CgazHandler {
 			this.onSnapConfigChange();
 		}
 
-		const velocity = MomentumPlayerAPI.GetVelocity();
-		const speed = MomMath.magnitude2D(velocity);
 		const stopSpeed = Math.max(speed, MomentumMovementAPI.GetStopspeed());
-		const dropSpeed = Math.max(speed - stopSpeed * lastMoveData.friction * tickInterval, 0);
+		const dropSpeed = Math.max(speed - stopSpeed * realFriction * tickInterval, 0);
 		const speedSquared = speed * speed;
 		const dropSpeedSquared = dropSpeed * dropSpeed;
 
 		const velAngle = Math.atan2(velocity.y, velocity.x);
-		const wishDir = lastMoveData.wishdir;
+		const wishDir = hudData.wishDir;
 		const wishAngle = MomMath.sumOfSquares2D(wishDir) > 0.001 ? Math.atan2(wishDir.y, wishDir.x) : 0;
 		const viewAngle = (MomentumPlayerAPI.GetAngles().y * Math.PI) / 180;
 		const viewDir = {
@@ -536,7 +542,7 @@ class CgazHandler {
 		const forwardMove = Math.round(MomMath.dot2D(viewDir, wishDir));
 		const rightMove = Math.round(MomMath.cross2D(viewDir, wishDir));
 
-		const bIsFalling = lastMoveData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.AIR;
+		const bIsFalling = hudData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.AIR;
 		const bHasAirControl = phyMode && MomMath.approxEquals(wishAngle, viewAngle, 0.01) && bIsFalling;
 		const bSnapShift =
 			!MomMath.approxEquals(Math.abs(forwardMove), Math.abs(rightMove), 0.01) && !(phyMode && bIsFalling);
@@ -699,9 +705,10 @@ class CgazHandler {
 				const useSnapAccel = !(
 					this.primeTruenessMode & TruenessMode.CPM_TURN || phyMode === DefragAPI.DefragPhysics.VQ3
 				);
+
 				const primeMaxSpeed =
-					this.primeTruenessMode & TruenessMode.PROJECTED ? lastMoveData.wishspeed : lastMoveData.maxspeed;
-				const primeMaxAccel = lastMoveData.acceleration * maxSpeed * tickInterval;
+					this.primeTruenessMode & TruenessMode.PROJECTED ? hudData.wishSpeed : realMaxSpeed;
+				const primeMaxAccel = realAccelerate * maxSpeed * tickInterval;
 				const primeSightSpeed = useSnapAccel ? MAX_GROUND_SPEED : primeMaxSpeed;
 				const primeSightAccel = useSnapAccel ? this.snapAccel : primeMaxAccel;
 
@@ -872,6 +879,84 @@ class CgazHandler {
 			this.windicatorArrow.visible = false;
 			this.windicatorZone.style.width = '0px';
 		}
+	}
+
+	calcAccelAndMaxSpeed(hudData: MomentumMovementAPI.HudData, velocity: vec3): [float, float] {
+		let accelerate: float;
+		let maxSpeed: float;
+		const hasteFactor = hudData.hasteTime > 0 ? HASTE_FACTOR : 1.0;
+		switch (hudData.moveStatus) {
+			case MomentumMovementAPI.PlayerMoveStatus.AIR: {
+				switch (GameModeAPI.GetCurrentGameMode()) {
+					case Gamemode.DEFRAG_VQ3:
+						accelerate = GameInterfaceAPI.GetSettingFloat('sv_airaccelerate');
+						maxSpeed = GameInterfaceAPI.GetSettingFloat('sv_maxspeed') * hasteFactor;
+						break;
+					case Gamemode.DEFRAG_CPM:
+						if (hudData.moveFlags & MomentumMovementAPI.PlayerMoveFlags.AIRSTRAFING) {
+							accelerate = GameInterfaceAPI.GetSettingFloat('mom_mv_df_airstrafeaccelerate');
+							maxSpeed = AIR_MAX_WISHSPEED;
+						} else {
+							maxSpeed = GameInterfaceAPI.GetSettingFloat('sv_maxspeed') * hasteFactor;
+
+							const airDecelerate = GameInterfaceAPI.GetSettingFloat('mom_mv_airdecelerate');
+							const airDecelerateAngle = GameInterfaceAPI.GetSettingFloat('mom_mv_airdecelerate_angle');
+							let vel2Ddir = { x: velocity.x, y: velocity.y };
+							vel2Ddir = MomMath.normalizeVector2D(vel2Ddir);
+							if (
+								airDecelerate >= 0 &&
+								MomMath.rad2deg(Math.acos(MomMath.dot2D(vel2Ddir, hudData.wishDir))) >
+									airDecelerateAngle
+							) {
+								accelerate = airDecelerate;
+							} else {
+								accelerate = GameInterfaceAPI.GetSettingFloat('sv_airaccelerate');
+							}
+						}
+						break;
+					case Gamemode.DEFRAG_VTG:
+						accelerate = GameInterfaceAPI.GetSettingFloat('sv_airaccelerate');
+						maxSpeed = AIR_MAX_WISHSPEED * hasteFactor;
+						break;
+				}
+				break;
+			}
+			case MomentumMovementAPI.PlayerMoveStatus.WALK:
+				accelerate =
+					hudData.moveFlags & MomentumMovementAPI.PlayerMoveFlags.SLICK
+						? GameInterfaceAPI.GetSettingFloat('mom_mv_df_slick_accelerate')
+						: GameInterfaceAPI.GetSettingFloat('sv_accelerate');
+				maxSpeed = GameInterfaceAPI.GetSettingFloat('sv_maxspeed') * hasteFactor;
+				break;
+			case MomentumMovementAPI.PlayerMoveStatus.WATER:
+				accelerate = GameInterfaceAPI.GetSettingFloat('sv_wateraccelerate');
+				maxSpeed = GameInterfaceAPI.GetSettingFloat('sv_maxspeed') * hasteFactor;
+				break;
+		}
+
+		return [accelerate, maxSpeed];
+	}
+
+	calcFriction(hudData: MomentumMovementAPI.HudData, speed: float): float {
+		if (
+			hudData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.AIR ||
+			hudData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.WATERJUMP ||
+			hudData.moveFlags & MomentumMovementAPI.PlayerMoveFlags.SLICK
+		) {
+			return 0;
+		}
+
+		const svFriction = GameInterfaceAPI.GetSettingFloat('sv_friction');
+
+		if (speed < 1) {
+			return svFriction;
+		}
+
+		if (hudData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.WATER) {
+			return GameInterfaceAPI.GetSettingFloat('sv_waterfriction');
+		}
+
+		return svFriction;
 	}
 
 	findSlowAngle(dropSpeed: number, dropSpeedSquared: number, speedSquared: number, maxSpeed: number) {

--- a/scripts/hud/ground-boost.ts
+++ b/scripts/hud/ground-boost.ts
@@ -82,7 +82,7 @@ class GroundboostHandler {
 		let bUpdateMeter = false;
 
 		// Only toggle visibility on if the player is grounded
-		if (lastMoveData.moveStatus === 1) {
+		if (lastMoveData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.WALK) {
 			if (timerFlags & TimerFlags.KNOCKBACK) {
 				// Knockback is what causes no-friction condition
 				// Crashland extends the timer to max duration

--- a/scripts/hud/ground-boost.ts
+++ b/scripts/hud/ground-boost.ts
@@ -73,16 +73,16 @@ class GroundboostHandler {
 	}
 
 	onHudUpdate() {
-		const lastMoveData = MomentumMovementAPI.GetLastMoveData();
-		let timer = lastMoveData.defragTimer;
-		const timerFlags = lastMoveData.defragTimerFlags;
+		const hudData = MomentumMovementAPI.GetHudData();
+		let timer = hudData.defragTimer;
+		const timerFlags = hudData.defragTimerFlags;
 		const curTime = MomentumMovementAPI.GetCurrentTime();
 		const speed = magnitude2D(MomentumPlayerAPI.GetVelocity());
 		const deltaSpeed = speed - this.startSpeed;
 		let bUpdateMeter = false;
 
 		// Only toggle visibility on if the player is grounded
-		if (lastMoveData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.WALK) {
+		if (hudData.moveStatus === MomentumMovementAPI.PlayerMoveStatus.WALK) {
 			if (timerFlags & TimerFlags.KNOCKBACK) {
 				// Knockback is what causes no-friction condition
 				// Crashland extends the timer to max duration

--- a/scripts/hud/powerup-timer.ts
+++ b/scripts/hud/powerup-timer.ts
@@ -27,7 +27,7 @@ class PowerupTimerHandler {
 	}
 
 	onUpdate() {
-		const { damageBoostTime, hasteTime, slickTime } = MomentumMovementAPI.GetLastMoveData();
+		const { damageBoostTime, hasteTime, slickTime } = MomentumMovementAPI.GetHudData();
 
 		this.updatePanel(this.panels.damageBoost, damageBoostTime);
 		this.updatePanel(this.panels.haste, hasteTime);

--- a/scripts/hud/strafe-trainer.ts
+++ b/scripts/hud/strafe-trainer.ts
@@ -127,7 +127,7 @@ class StrafeTrainer {
 		this.addToBuffer(this.gainRatioHistory, 0);
 		this.addToBuffer(this.yawRatioHistory, 0);
 
-		const bValidWishMove = MomMath.magnitude2D(hudData.wishDir) > 0.1;
+		const bValidWishMove = MomMath.magnitude2D(hudData.wishVel) > 0.1;
 		const strafeRight = (bValidWishMove ? 1 : 0) * lastTickStats.strafeRight;
 		const direction = this.dynamicEnable ? strafeRight : 1;
 		const flip = this.flipEnable ? -1 : 1;

--- a/scripts/hud/strafe-trainer.ts
+++ b/scripts/hud/strafe-trainer.ts
@@ -120,14 +120,14 @@ class StrafeTrainer {
 	}
 
 	onUpdate() {
-		const lastMoveData = MomentumMovementAPI.GetLastMoveData();
+		const hudData = MomentumMovementAPI.GetHudData();
 		const lastTickStats = MomentumMovementAPI.GetLastTickStats();
 
 		//zero buffers
 		this.addToBuffer(this.gainRatioHistory, 0);
 		this.addToBuffer(this.yawRatioHistory, 0);
 
-		const bValidWishMove = MomMath.magnitude2D(lastMoveData.wishdir) > 0.1;
+		const bValidWishMove = MomMath.magnitude2D(hudData.wishDir) > 0.1;
 		const strafeRight = (bValidWishMove ? 1 : 0) * lastTickStats.strafeRight;
 		const direction = this.dynamicEnable ? strafeRight : 1;
 		const flip = this.flipEnable ? -1 : 1;

--- a/scripts/types-mom/apis.d.ts
+++ b/scripts/types-mom/apis.d.ts
@@ -62,10 +62,9 @@ declare namespace MomentumMovementAPI {
 	}
 
 	interface HudData {
-		wishDir: vec3;
+		wishVel: vec3;
 		moveStatus: PlayerMoveStatus;
 		moveFlags: PlayerMoveFlags;
-		wishSpeed: float;
 		hasteTime: int32;
 		damageBoostTime: int32;
 		slickTime: int32;

--- a/scripts/types-mom/apis.d.ts
+++ b/scripts/types-mom/apis.d.ts
@@ -56,13 +56,16 @@ declare namespace MomentumMovementAPI {
 		WATERJUMP = 3
 	}
 
-	interface LastMove {
-		wishdir: vec3;
+	const enum PlayerMoveFlags {
+		AIRSTRAFING = 1 << 0,
+		SLICK = 1 << 1
+	}
+
+	interface HudData {
+		wishDir: vec3;
 		moveStatus: PlayerMoveStatus;
-		wishspeed: float;
-		acceleration: float;
-		maxspeed: float;
-		friction: float;
+		moveFlags: PlayerMoveFlags;
+		wishSpeed: float;
 		hasteTime: int32;
 		damageBoostTime: int32;
 		slickTime: int32;
@@ -120,8 +123,8 @@ declare namespace MomentumMovementAPI {
 	/** Gets the player's movetype (eg. normal, on a ladder, noclip, etc) */
 	function GetMoveType(): MoveType;
 
-	/** Gets an object containing the last move data */
-	function GetLastMoveData(): LastMove;
+	/** Gets an object containing the HUD data */
+	function GetHudData(): HudData;
 
 	/* Gets an object containing stats from the last jump */
 	function GetLastJumpStats(): LastJump;

--- a/scripts/util/math.ts
+++ b/scripts/util/math.ts
@@ -6,6 +6,24 @@ export function magnitude2D(vec: vec2 | vec3): number {
 	return Math.sqrt(sumOfSquares2D(vec));
 }
 
+export function normalizeVector(vec: vec3): vec3 {
+	const mag = magnitude(vec);
+	if (mag === 0) {
+		return { x: 0, y: 0, z: 0 };
+	}
+
+	return { x: vec.x / mag, y: vec.y / mag, z: vec.z / mag };
+}
+
+export function normalizeVector2D(vec: vec2): vec2 {
+	const mag = magnitude2D(vec);
+	if (mag === 0) {
+		return { x: 0, y: 0 };
+	}
+
+	return { x: vec.x / mag, y: vec.y / mag };
+}
+
 // Note: Math.hypot performs additional bounds checking on V8 which which makes it considerably
 // slower than below implementations.
 export function sumOfSquares2D(vec: vec2 | vec3): number {


### PR DESCRIPTION
Save network bandwidth by re-computing `acceleration`, `maxspeed`, and `friction` using the player's state. `wishdir` and `wishspeed` were also combined to save bandwidth.

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

