### PR TITLE
feat: Add ahop sprint hud

### DIFF
--- a/layout/hud/ahop-sprint.xml
+++ b/layout/hud/ahop-sprint.xml
@@ -1,0 +1,16 @@
+<root>
+	<styles>
+		<include src="file://{resources}/styles/main.scss" />
+	</styles>
+	
+	<scripts>
+		<include type="module" src="file://{scripts}/hud/ahop-sprint.ts" />
+	</scripts>
+
+	<MomHudAhopSprint class="h-align-center v-align-center">
+		<Panel id="AhopSprint">
+			<Panel id="AhopSprintLeft"/>
+			<Panel id="AhopSprintRight"/>
+		</Panel>
+	</MomHudAhopSprint>
+</root>

--- a/layout/hud/hud.xml
+++ b/layout/hud/hud.xml
@@ -18,6 +18,7 @@
 		<!-- Center of screen HUD laid out vertically top-to-bottom -->
 		<Panel id="HudCenter" hittest="false" hittestchildren="false">
 			<MomHudSafeguardIndicator />
+			<MomHudAhopSprint />
 			<MomHudJumpTiming />
 		</Panel>
 

--- a/layout/pages/settings/gameplay.xml
+++ b/layout/pages/settings/gameplay.xml
@@ -215,6 +215,40 @@
 
 			<Panel class="settings-page__spacer" />
 
+			<Panel id="AhopSubSection" class="settings-group">
+				<Panel class="settings-group__header">
+					<Label class="settings-group__title" text="#Settings_Ahop_Title" tags="ahop, sprint" />
+					<Panel class="flow-right h-align-right">
+						<Button class="button mr-3" onactivate="SettingsPage.showImportExportDialogue('Settings_Ahop_Title', 'AhopSubSection')">
+							<Label class="button__text" text="#Settings_ImportExport_ImportExport" />
+						</Button>
+						<TooltipPanel class="settings-group__reset" tooltip="#Settings_General_Reset">
+							<Button class="button" onactivate="SettingsPage.resetSettings('AhopSubSection');">
+								<Image class="button__icon" src="file://{images}/reset.svg" />
+							</Button>
+						</TooltipPanel>
+					</Panel>
+				</Panel>
+
+				<SettingsEnum text="#Settings_Ahop_Sprint_Enable" convar="mom_hud_ahop_sprint_enable" infomessage="#Settings_Ahop_Sprint_Enable_Info" tags="ahop, sprint">
+						<RadioButton group="sprintenable" text="#Common_Off" value="0" />
+						<RadioButton group="sprintenable" text="#Common_On" value="1" />
+				</SettingsEnum>
+
+				<ConVarEnabler convar="mom_hud_ahop_sprint_enable" class="flow-down">
+					<SettingsSlider text="#Settings_Ahop_Sprint_Distance" min="10" max="200" value="40" convar="mom_hud_ahop_distance" displayprecision="0" infomessage="#Settings_Ahop_Sprint_Distance_Info" tags="distance, separation, width" />
+					<SettingsSlider text="#Settings_Ahop_Sprint_Size" min="10" max="200" convar="mom_hud_ahop_size" displayprecision="0" infomessage="#Settings_Ahop_Sprint_Distance_Info" tags="size, height" />
+					<SettingsSlider text="#Settings_Ahop_Sprint_Thickness" min="1" max="20" convar="mom_hud_ahop_thickness" displayprecision="1" infomessage="#Settings_Ahop_Sprint_Thickness_Info" tags="thickness, width" />
+					<SettingsSlider text="#Settings_Ahop_Sprint_Rotation" min="-90" max="90" convar="mom_hud_ahop_rotation" displayprecision="1" infomessage="#Settings_Ahop_Sprint_Rotation_Info" tags="rotation" />
+					<SettingsSlider text="#Settings_Ahop_Sprint_Arc_Length" min="10" max="360" convar="mom_hud_ahop_arclength" displayprecision="1" infomessage="#Settings_Ahop_Sprint_Arc_Length_Info" tags="arc, length" />
+					<ConVarColorDisplay text="#Settings_Ahop_Sprint_AvailableColor" convar="mom_hud_ahop_available_color" infomessage="#Settings_Ahop_Sprint_AvailableColor_Info" tags="sprint, available" />
+					<ConVarColorDisplay text="#Settings_Ahop_Sprint_ActiveColor" convar="mom_hud_ahop_active_color" infomessage="#Settings_Ahop_Sprint_ActiveColor_Info" tags="sprint, active" />
+					<ConVarColorDisplay text="#Settings_Ahop_Sprint_BlockedColor" convar="mom_hud_ahop_blocked_color" infomessage="#Settings_Ahop_Sprint_BlockedColor_Info" tags="sprint, blocked" />
+					<ConVarColorDisplay text="#Settings_Ahop_Sprint_DisabledColor" convar="mom_hud_ahop_disabled_color" infomessage="#Settings_Ahop_Sprint_DisabledColor_Info" tags="sprint, disabled" />
+				</ConVarEnabler>
+
+			</Panel>
+
 			<Panel id="RocketJumpSubSection" class="settings-group">
 				<Panel class="settings-group__header">
 					<Label class="settings-group__title" text="#Settings_RJ_Title" tags="rj,rocketjump,soldier" />

--- a/layout/pages/settings/settings.xml
+++ b/layout/pages/settings/settings.xml
@@ -104,7 +104,7 @@
 
 						<RadioButton id="GameplayRadio" class="settings-nav__item" group="SettingsNav" onactivate="SettingsHandler.navigateToTab('GameplaySettings')">
 							<Label class="settings-nav__item-label" text="#Settings_Gameplay" />
-							<Panel class="settings-nav__subsection settings-nav__subsection--8 settings-nav__subsection--hidden">
+							<Panel class="settings-nav__subsection settings-nav__subsection--9 settings-nav__subsection--hidden">
 								<RadioButton id="GameplayGeneralRadio" class="settings-nav__subitem" group="SettingsSubNav" onactivate="SettingsHandler.navigateToSubsection('GameplaySettings', 'GameplayGeneralSubSection')">
 									<Label class="settings-nav__subitem-label" text="#Settings_Gameplay" />
 								</RadioButton>
@@ -117,6 +117,9 @@
 								<!-- TODO: Rename -->
 								<RadioButton id="ZonesRadio" class="settings-nav__subitem" group="SettingsSubNav" onactivate="SettingsHandler.navigateToSubsection('GameplaySettings', 'ZonesSubSection')">
 									<Label class="settings-nav__subitem-label" text="#Settings_Zones_Title" />
+								</RadioButton>
+								<RadioButton id="AhopRadio" class="settings-nav__subitem" group="SettingsSubNav" onactivate="SettingsHandler.navigateToSubsection('GameplaySettings', 'AhopSubSection')">
+									<Label class="settings-nav__subitem-label" text="#Settings_Ahop_Title" />
 								</RadioButton>
 								<RadioButton id="RocketJumpRadio" class="settings-nav__subitem" group="SettingsSubNav" onactivate="SettingsHandler.navigateToSubsection('GameplaySettings', 'RocketJumpSubSection')">
 									<Label class="settings-nav__subitem-label" text="#Settings_RJ_Title" />

--- a/scripts/common/settings.ts
+++ b/scripts/common/settings.ts
@@ -42,6 +42,7 @@ export const SettingsTabs = {
 			PaintSubSection: 'PaintRadio',
 			SafeguardsSubSection: 'SafeguardsRadio',
 			ZonesSubSection: 'ZonesRadio',
+			AhopSubSection: 'AhopRadio',
 			RocketJumpSubSection: 'RocketJumpRadio',
 			StickyJumpSubSection: 'StickyJumpRadio',
 			ConcSubSection: 'ConcRadio',

--- a/scripts/hud/ahop-sprint.ts
+++ b/scripts/hud/ahop-sprint.ts
@@ -1,0 +1,171 @@
+import { PanelHandler } from 'util/module-helpers';
+import { Gamemode } from 'common/web/enums/gamemode.enum';
+//import { RegisterEventForGamemodes } from 'util/register-for-gamemodes';
+import { RegisterHUDPanelForGamemode } from '../util/register-for-gamemodes';
+import { Button } from 'common/buttons';
+
+@PanelHandler()
+class AhopSprint {
+	readonly panels = {
+		sprint: $<Panel>('#AhopSprint'),
+		sprintLeft: $<Panel>('#AhopSprintLeft'),
+		sprintRight: $<Panel>('#AhopSprintRight')
+	};
+
+	sprintWasActive = false;
+	sprintInactive = false;
+
+	distance: number;
+	size: number;
+	thickness: number;
+	rotation: number;
+	arcLength: number;
+
+	//How does this magic type work? Cgaz uses it but I can't figure it out
+	activeColor: rgbaColor;
+	disabledColor: rgbaColor;
+	blockedColor: rgbaColor;
+	availableColor: rgbaColor;
+
+	constructor() {
+		RegisterHUDPanelForGamemode({
+			onLoad: () => this.onLoad(),
+			gamemodes: [Gamemode.AHOP],
+			handledEvents: [
+				{
+					event: 'HudProcessInput',
+					panel: $.GetContextPanel(),
+					callback: () => this.onUpdate()
+				}
+			]
+		});
+		$.Msg('WTF???');
+		//$.RegisterForUnhandledEvent('OnAhopHUDSettingsChange', () => this.updateSettings());
+	}
+
+	updateSettings() {
+		this.distance = 68;
+		this.size = 56;
+		this.thickness = 2.5;
+		this.rotation = 0;
+		this.arcLength = 120;
+
+		this.activeColor = '#7aee7a';
+		this.disabledColor = '#7e7e7e';
+		this.blockedColor = '#ff6a6a';
+		this.availableColor = '#1896d3';
+
+		//this.distance = GameInterfaceAPI.GetSettingFloat('mom_hud_ahop_distance');
+		//this.size = GameInterfaceAPI.GetSettingFloat('mom_hud_ahop_size');
+		//this.rotation = GameInterfaceAPI.GetSettingFloat('mom_hud_ahop_rotation');
+		//this.thickness = GameInterfaceAPI.GetSettingFloat('mom_hud_ahop_thickness');
+		//this.arcLength = GameInterfaceAPI.GetSettingFloat('mom_hud_ahop_arclength');
+
+		// === TODO: CGAZ COLORS RETURN A NUMBER, I HAVE NO IDEA HOW rgbaColor TYPE WORKS, IT'S NOT DEFINED PROPERLY AND VSC DOESN'T RECOGNIZE IT ===
+		// === CGAZ USES EVENTS FOR EVERY SETTING, IS THAT SOMETHING THAT NEEDS TO BE DONE HERE? ===
+		//this.activeColor = GameInterfaceAPI.GetSettingString('mom_hud_ahop_active_color')
+		//this.disabledColor = GameInterfaceAPI.GetSettingString('mom_hud_ahop_disabled_color')
+		//this.blockedColor = GameInterfaceAPI.GetSettingString('mom_hud_ahop_blocked_color')
+		//this.availableColor = GameInterfaceAPI.GetSettingString('mom_hud_ahop_available_color')
+
+		this.updateStyles();
+	}
+
+	updateStyles() {
+		this.panels.sprint.style.width = this.distance + 'px';
+
+		this.panels.sprint.style.height = Math.max(this.distance, this.size) + 'px';
+
+		Object.values(this.panels).forEach((panel, index) => {
+			if (index === 0) return;
+
+			panel.style.width = Math.min(this.distance, this.size) + 'px';
+			panel.style.height = this.size + 'px';
+			panel.style.borderWidth = this.thickness + 'px';
+			panel.style.borderStyle = 'solid';
+		});
+
+		this.updateArcLength();
+		this.panels.sprint.style.transform = 'rotateZ(' + this.rotation + 'deg)';
+	}
+
+	updateArcLength() {
+		const leftStart = Math.ceil(270 + this.arcLength / 2);
+		const rightStart = Math.ceil(90 + this.arcLength / 2);
+		const clipLength = 360 - this.arcLength;
+
+		this.panels.sprintLeft.style.clip = 'radial(50% 50%,' + leftStart + 'deg,' + clipLength + 'deg)';
+		this.panels.sprintRight.style.clip = 'radial(50% 50%,' + rightStart + 'deg,' + clipLength + 'deg)';
+	}
+
+	onLoad() {
+		Object.values(this.panels).forEach((panel, index) => {
+			panel.style.align = 'center center';
+			panel.style.borderRadius = '50%';
+		});
+
+		this.panels.sprintLeft.style.horizontalAlign = 'left';
+		this.panels.sprintRight.style.horizontalAlign = 'right';
+
+		this.updateSettings();
+		$.Msg('WTF');
+	}
+
+	onUpdate() {
+		// === TODO: REWRITE ALL OF THIS AFTER MOVEMENT API IS ADDED ===
+		const buttons = MomentumInputAPI.GetButtons().physicalButtons;
+
+		const walkPressed = !!(buttons & Button.WALK);
+		const speedPressed = !!(buttons & Button.SPEED);
+		const duckPressed = !!(buttons & Button.DUCK);
+
+		const isDucking = MomentumPlayerAPI.IsDucking();
+		//const isWalking = MomentumPlayerAPI.IsWalking();
+		// const IsSprinting = MomentumPlayerAPI.IsSprinting();
+
+		// $.Msg(isWalking);
+		const isVaulting = isDucking && !duckPressed;
+
+		//Disable sprint if manually ducking or vaulting without sprint active
+		//Doesn't handle manually pressing duck during vaulting which doesn't deactivate sprint
+		if ((isDucking && duckPressed) || (isVaulting && !this.sprintWasActive)) {
+			if (!speedPressed) this.setSprintState(this.disabledColor);
+			else {
+				this.setSprintState(this.blockedColor);
+				this.sprintInactive = true;
+			}
+			this.sprintWasActive = false;
+			return;
+		}
+
+		//Doesn't handle toggle_walk, should be fixed with MomentumPlayerAPI.IsWalking
+		if (walkPressed && !this.sprintWasActive) {
+			this.setSprintState(this.disabledColor);
+			this.sprintWasActive = false;
+		}
+
+		//Jumping on flat ground then landing doesn't allow for sprinting if sprint is pressed on the same tick as landing
+		//This is probably the correct behavior and will be fixed by MomentumPlayerAPI.IsSprinting but could be an engine bug
+		//I have no idea if it's consistant with hl2
+		if (speedPressed) {
+			if ((walkPressed && !this.sprintWasActive) || this.sprintInactive) {
+				this.setSprintState(this.blockedColor);
+				this.sprintInactive = true;
+			} else {
+				this.setSprintState(this.activeColor);
+				this.sprintWasActive = true;
+			}
+			return;
+		} else {
+			this.sprintWasActive = false;
+			this.sprintInactive = false;
+
+			if (!walkPressed) this.setSprintState(this.availableColor);
+		}
+	}
+
+	setSprintState(color) {
+		this.panels.sprintLeft.style.borderColor = color;
+		this.panels.sprintRight.style.borderColor = color;
+	}
+}

--- a/scripts/util/panel-registration.ts
+++ b/scripts/util/panel-registration.ts
@@ -26,6 +26,7 @@ declare interface PanelTagNameMap {
 	MomHudStrafeTrainer: MomHudStrafeTrainer;
 	MomHudPowerupTimer: MomHudPowerupTimer;
 	MomHudSafeguardIndicator: MomHudSafeguardIndicator;
+	MomHudAhopSprint: MomHudAhopSprint;
 	ToastContainer: ToastContainer;
 	ToastGeneric: ToastGeneric;
 	Gallery: Gallery;
@@ -83,3 +84,6 @@ UiToolkitAPI.RegisterHUDPanel2d('MomHudPowerupTimer', 'file://{resources}/layout
 
 declare interface MomHudSafeguardIndicator extends AbstractHudPanel<'MomHudSafeguardIndicator'> {}
 UiToolkitAPI.RegisterHUDPanel2d('MomHudSafeguardIndicator', 'file://{resources}/layout/hud/safeguard-indicator.xml');
+
+declare interface MomHudAhopSprint extends AbstractHudPanel<'MomHudAhopSprint'> {}
+UiToolkitAPI.RegisterHUDPanel2d('MomHudAhopSprint', 'file://{resources}/layout/hud/ahop-sprint.xml');


### PR DESCRIPTION
Closes momentum-mod/game/issues/2430

Ahop Sprint HUD visualizes player's sprint state

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### API
In a meeting we discussed whether or not `MomentumPlayerAPI.IsDucking` tracks player state or just keyboard input.
After checking I'm sure it tracks only the player state.

In ahop ducking on the ground is not instant, .IsDucking doesn't react until player is fully ducked even with the key pressed:
https://github.com/user-attachments/assets/26ee04a4-f4d0-4211-b58e-d313280cd324

Following should be added to the API to make the logic of this HUD much cleaner (and without bugs):
`MomentumPlayerAPI.IsWalking()`
`MomentumPlayerAPI.IsSprinting()`


### Cvars
List of cvars for customization
#### Shape
`mom_hud_ahop_enable`:
    - min: 0
    - max: 1
    - default: 1
`mom_hud_ahop_distance`:
    - min: 10
    - max: No reason to cap this, above a certain value it will be full screen width
    - default: 68
`mom_hud_ahop_size`:
    - min: 10
    - max: No reason to cap this, above a certain value it will be full screen height
    - default: 56
`mom_hud_ahop_rotation`:
    - min: -90
    - max: 90
    - default: 0
`mom_hud_ahop_thickness`:
    - min: 0.1
    - max: thickness will depend on size, will be capped in settings to a reasonable value but cvar should be uncapped imo
    - default: 2.5
 `mom_hud_ahop_arclength`:
     - min: 1 ( visibility depends on size )
     - max: 360;
     - default: 120;

 #### Colors
I don't know how colors are defined in code, providing defaults in hex and rgba.
All colors are defined in config.scss ( $blue, $green, $red, $disabled )
`mom_hud_ahop_active_color`:
    - hex: #7aee7a
    - rgba: rgba(122, 238, 122, 1)
`mom_hud_ahop_disabled_color`:
    - hex: #7e7e7e
    - rgba: rgba(126, 126, 126, 1)
`mom_hud_ahop_blocked_color`:
    - hex: #ff6a6a
    - rgba: rgba(255, 106, 106, 1)
`mom_hud_ahop_available_color`:
    - hex: #1896d3
    - rgba: rgba(24, 150, 211, 1)

### Events
Cgaz uses one event per setting for updates, I'm not sure if that is necessary in this case.
Seems like `OnAhopHUDSettingsChange` event that fires whenever one of the cvars above is changed would be sufficient.

### Networking
Is there anything I need to do for the HUD to be properly networked?


### POEditor JSON Strings

```json
[
        {
        "term": "Settings_Ahop_Title",
        "definition": "Ahop"
    },
       {
        "term": "Settings_Ahop_Sprint_Enable",
        "definition": "Display Ahop Sprint HUD"
    },
       {
        "term": "Settings_Ahop_Sprint_Enable_Info",
        "definition": "Provides an on-screen indicator of player's sprint status"
    },
       {
        "term": "Settings_Ahop_Sprint_Distance",
        "definition": "Distance"
    },
       {
        "term": "Settings_Ahop_Sprint_Distance_Info",
        "definition": "Distance between the indicators"
    },
       {
        "term": "Settings_Ahop_Sprint_Size",
        "definition": "Size"
    },
       {
        "term": "Settings_Ahop_Sprint_Distance_Info",
        "definition": "Size of the indicators"
    },
       {
        "term": "Settings_Ahop_Sprint_Thickness",
        "definition": "Thickness"
    },
       {
        "term": "Settings_Ahop_Sprint_Thickness_Info",
        "definition": "Thickness of the indicators"
    },
       {
        "term": "Settings_Ahop_Sprint_Rotation",
        "definition": "Rotation"
    },
       {
        "term": "Settings_Ahop_Sprint_Rotation_Info",
        "definition": "Rotation of the indicators around the center of the screen.\n Positive Value - Clockwise Rotation\n Negative Value - Counterclockwise Rotation"
    },
       {
        "term": "Settings_Ahop_Sprint_Arc_Length",
        "definition": "Arc Length"
    },
       {
        "term": "Settings_Ahop_Sprint_Arc_Length_Info",
        "definition": "Visible portion of a circle on which the indicator resides"
    },
       {
        "term": "Settings_Ahop_Sprint_AvailableColor",
        "definition": "Available Color"
    },
       {
        "term": "Settings_Ahop_Sprint_AvailableColor_Info",
        "definition": "Color of the indicators when sprint is not activated or blocked by crouching/walking"
    },
       {
        "term": "Settings_Ahop_Sprint_ActiveColor",
        "definition": "Active Color"
    },
       {
        "term": "Settings_Ahop_Sprint_ActiveColor_Info",
        "definition": "Color of the indicators when sprint is active"
    },
       {
        "term": "Settings_Ahop_Sprint_BlockedColor",
        "definition": "Blocked Color"
    },
       {
        "term": "Settings_Ahop_Sprint_BlockedColor_Info",
        "definition": "Color of the indicators when sprint is pressed, but it's unavailable due to crouching or walking"
    },
       {
        "term": "Settings_Ahop_Sprint_DisabledColor",
        "definition": "Disabled Color"
    },
       {
        "term": "Settings_Ahop_Sprint_DisabledColor_Info",
        "definition": "Color of the indicators when sprint is unavailable due to crouching or walking"
    },
]
```
