### PR TITLE
Jump timing HUD improvements + perf percent HUD

### DIFF
--- a/layout/hud/jump-timing.xml
+++ b/layout/hud/jump-timing.xml
@@ -8,17 +8,20 @@
 	</scripts>
 	
 	<MomHudJumpTiming class="bhopjump__component">
-		<ConVarEnabler id="JumpTimingContainer" class="bhopjump__container" convar="mom_hud_jump_timing" togglevisibility="true">
-			<ConVarEnabler convar="mom_hud_jump_timing_text" class="bhopjump__text-wrapper" togglevisibility="true">
-				<Label id="JumpEarlyLabel" class="bhopjump__text-wrapper--early" text="0" />
-			</ConVarEnabler>
-			<Panel class="bhopjump__bar-wrapper" alternateTicks="false">
-				<ProgressBar id="JumpEarlyBar" class="bhopjump__early" min="0" max="1" />
-				<ProgressBar id="JumpLateBar" class="bhopjump__late" min="0" max="1" />
+		<ConVarEnabler id="JumpTimingContainer" class="bhopjump__outer-container" convar="mom_hud_jump_timing" togglevisibility="true">
+			<Panel class="bhopjump__bar-container">
+				<ConVarEnabler convar="mom_hud_jump_timing_text" class="bhopjump__text-wrapper" togglevisibility="true">
+					<Label id="JumpEarlyLabel" class="bhopjump__text-wrapper--early" text="0" />
+				</ConVarEnabler>
+				<Panel class="bhopjump__bar-wrapper" alternateTicks="false">
+					<ProgressBar id="JumpEarlyBar" class="bhopjump__early" min="0" max="1" />
+					<ProgressBar id="JumpLateBar" class="bhopjump__late" min="0" max="1" />
+				</Panel>
+				<ConVarEnabler convar="mom_hud_jump_timing_text" class="bhopjump__text-wrapper" togglevisibility="true">
+					<Label id="JumpLateLabel" class="bhopjump__text-wrapper--late" text="0" />
+				</ConVarEnabler>
 			</Panel>
-			<ConVarEnabler convar="mom_hud_jump_timing_text" class="bhopjump__text-wrapper" togglevisibility="true">
-				<Label id="JumpLateLabel" class="bhopjump__text-wrapper--late" text="0" />
-			</ConVarEnabler>
+			<Label id="JumpPerfPercentLabel" class="bhopjump__perf-percent" text="#JumpTiming_Label_PerfPercent" />
 		</ConVarEnabler>
 	</MomHudJumpTiming>
 </root>

--- a/layout/hud/jump-timing.xml
+++ b/layout/hud/jump-timing.xml
@@ -13,9 +13,17 @@
 				<ConVarEnabler convar="mom_hud_jump_timing_text" class="bhopjump__text-wrapper" togglevisibility="true">
 					<Label id="JumpEarlyLabel" class="bhopjump__text-wrapper--early" text="0" />
 				</ConVarEnabler>
-				<Panel class="bhopjump__bar-wrapper" alternateTicks="false">
-					<ProgressBar id="JumpEarlyBar" class="bhopjump__early" min="0" max="1" />
-					<ProgressBar id="JumpLateBar" class="bhopjump__late" min="0" max="1" />
+				<Panel class="bhopjump__bar-tick-container">
+					<Panel id="BufferedJumpZones" class="bhopjump__bar-wrapper">
+						<Panel id="JumpEarlyZone" class="bhopjump__zone" />
+						<Panel id="JumpPerfectZone" class="bhopjump__zone" />
+						<Panel id="JumpLateZone" class="bhopjump__zone" />
+					</Panel>
+					<Panel id="ScrollZones" class="bhopjump__bar-wrapper">
+						<Panel id="ScrollLateZone1" class="bhopjump__zone" />
+						<Panel id="ScrollLateZone2" class="bhopjump__zone" />
+					</Panel>
+					<Panel id="JumpTickMarker" class="bhopjump__tick-marker" />
 				</Panel>
 				<ConVarEnabler convar="mom_hud_jump_timing_text" class="bhopjump__text-wrapper" togglevisibility="true">
 					<Label id="JumpLateLabel" class="bhopjump__text-wrapper--late" text="0" />

--- a/scripts/hud/jump-timing.ts
+++ b/scripts/hud/jump-timing.ts
@@ -6,20 +6,26 @@ import { GamemodeCategories } from 'common/web/maps/gamemodes.map';
 
 const Colors = {
 	RED: [255, 0, 0, 255] as RgbaTuple,
-	ORANGE: [255, 165, 0, 255] as RgbaTuple
+	GREEN: [0, 255, 0, 255] as RgbaTuple,
+	DARK_RED: [80, 0, 0, 255] as RgbaTuple,
+	DARK_GREEN: [0, 80, 0, 255] as RgbaTuple
 };
 
 @PanelHandler()
 class JumpTimingHandler {
 	readonly panels = {
 		container: $<Panel>('#JumpTimingContainer'),
-		earlyBar: $<ProgressBar>('#JumpEarlyBar'),
-		lateBar: $<ProgressBar>('#JumpLateBar'),
 		earlyLabel: $<Label>('#JumpEarlyLabel'),
 		lateLabel: $<Label>('#JumpLateLabel'),
-		earlyBarProgress: $<Panel>('#JumpEarlyBar_Left'),
-		lateBarProgress: $<Panel>('#JumpLateBar_Left'),
-		perfPercentLabel: $<Label>('#JumpPerfPercentLabel')
+		bufferedJumpZones: $<Panel>('#BufferedJumpZones'),
+		scrollZones: $<Panel>('#ScrollZones'),
+		earlyTimingZone: $<Panel>('#JumpEarlyZone'),
+		perfectTimingZone: $<Panel>('#JumpPerfectZone'),
+		lateTimingZone: $<Panel>('#JumpLateZone'),
+		scrollLateZone1: $<Panel>('#ScrollLateZone1'),
+		scrollLateZone2: $<Panel>('#ScrollLateZone2'),
+		perfPercentLabel: $<Label>('#JumpPerfPercentLabel'),
+		tickMarker: $<Panel>('#JumpTickMarker')
 	};
 
 	perfWindow: number;
@@ -53,6 +59,8 @@ class JumpTimingHandler {
 		});
 
 		this.panels.container.visible = false;
+		this.panels.scrollLateZone1.style.backgroundColor = tupleToRgbaString(Colors.RED);
+		this.panels.scrollLateZone2.style.backgroundColor = tupleToRgbaString(Colors.DARK_RED);
 	}
 
 	onMapInit() {
@@ -60,15 +68,29 @@ class JumpTimingHandler {
 	}
 
 	updateSettings() {
-		this.maxEarlyTiming = GameInterfaceAPI.GetSettingInt('mom_mv_buffered_jump_near_perf_window') + 1;
-		this.maxLateTiming = GameInterfaceAPI.GetSettingInt('mom_hud_late_jump_timing');
+		this.maxEarlyTiming = GameInterfaceAPI.GetSettingInt('mom_hud_jump_timing_early_range');
+		this.maxLateTiming = GameInterfaceAPI.GetSettingInt('mom_hud_jump_timing_late_range');
 		this.perfWindow = GameInterfaceAPI.GetSettingInt('mom_mv_buffered_jump_perf_window');
 		this.bufferedJumpingEnabled = GameInterfaceAPI.GetSettingInt('mom_mv_autohop_mode') === 2;
 		this.displayTime = GameInterfaceAPI.GetSettingFloat('mom_hud_jump_timing_display_time');
 
 		this.panels.earlyLabel.visible = this.bufferedJumpingEnabled;
-		this.panels.earlyBar.visible = this.bufferedJumpingEnabled;
-		this.panels.lateBar.style.width = this.bufferedJumpingEnabled ? '50%' : '100%';
+		this.panels.bufferedJumpZones.visible = this.bufferedJumpingEnabled;
+		this.panels.scrollZones.visible = !this.bufferedJumpingEnabled;
+
+		if (this.bufferedJumpingEnabled) {
+			const maxTimingWindow = this.maxEarlyTiming + this.maxLateTiming;
+			if (maxTimingWindow > 0) {
+				const earlyTimingZoneWidthPercent = ((this.maxEarlyTiming - this.perfWindow) / maxTimingWindow) * 100;
+				this.panels.earlyTimingZone.style.width = `${earlyTimingZoneWidthPercent}%`;
+
+				const perfZoneWidthPercent = (this.perfWindow / maxTimingWindow) * 100;
+				this.panels.perfectTimingZone.style.width = `${perfZoneWidthPercent}%`;
+
+				const lateTimingZoneWidthPercent = (this.maxLateTiming / maxTimingWindow) * 100;
+				this.panels.lateTimingZone.style.width = `${lateTimingZoneWidthPercent}%`;
+			}
+		}
 	}
 
 	updateVisibility() {
@@ -83,25 +105,54 @@ class JumpTimingHandler {
 
 		const clampedJumpTiming = Math.max(Math.min(jumpTiming, this.maxLateTiming), -this.maxEarlyTiming);
 
+		// Position tick marker based on jump timing
+		let tickPosition: number;
 		if (this.bufferedJumpingEnabled) {
-			const earlyTimingRatio =
-				clampedJumpTiming < 0
-					? Math.max(-clampedJumpTiming - this.perfWindow, 0) /
-						Math.max(this.maxEarlyTiming - this.perfWindow, 1)
-					: 0;
-			this.panels.earlyBar.value = earlyTimingRatio;
-			this.panels.earlyLabel.text = jumpTiming < 0 ? -jumpTiming : 0;
-
-			const earlyTimingColor = jumpTiming <= -this.maxEarlyTiming ? Colors.RED : Colors.ORANGE;
-			this.panels.earlyBarProgress.style.backgroundColor = tupleToRgbaString(earlyTimingColor);
+			const totalRange = this.maxEarlyTiming + this.maxLateTiming;
+			tickPosition = ((clampedJumpTiming + this.maxEarlyTiming) / totalRange) * 100;
+		} else {
+			// Scroll
+			tickPosition = (clampedJumpTiming / this.maxLateTiming) * 100;
 		}
 
-		const lateTimingRatio = clampedJumpTiming > 0 ? clampedJumpTiming / this.maxLateTiming : 0;
-		this.panels.lateBar.value = lateTimingRatio;
-		this.panels.lateLabel.text = jumpTiming > 0 ? jumpTiming : 0;
+		if (tickPosition < 100) {
+			this.panels.tickMarker.style.marginLeft = `${tickPosition}%`;
+			this.panels.tickMarker.style.horizontalAlign = 'left';
+		} else {
+			// Note: This is needed to prevent the tick from going past the full width of the bar
+			this.panels.tickMarker.style.marginLeft = '0%';
+			this.panels.tickMarker.style.horizontalAlign = 'right';
+		}
 
-		const lateTimingColor = Colors.RED;
-		this.panels.lateBarProgress.style.backgroundColor = tupleToRgbaString(lateTimingColor);
+		this.panels.tickMarker.visible = true;
+
+		// Update zones based on jump timing
+		if (this.bufferedJumpingEnabled) {
+			if (jumpTiming < -this.perfWindow) {
+				this.panels.earlyTimingZone.style.backgroundColor = tupleToRgbaString(Colors.RED);
+				this.panels.perfectTimingZone.style.backgroundColor = tupleToRgbaString(Colors.DARK_GREEN);
+				this.panels.lateTimingZone.style.backgroundColor = tupleToRgbaString(Colors.DARK_RED);
+			} else if (jumpTiming >= -this.perfWindow && jumpTiming <= 0) {
+				this.panels.earlyTimingZone.style.backgroundColor = tupleToRgbaString(Colors.DARK_RED);
+				this.panels.perfectTimingZone.style.backgroundColor = tupleToRgbaString(Colors.GREEN);
+				this.panels.lateTimingZone.style.backgroundColor = tupleToRgbaString(Colors.DARK_RED);
+			} else {
+				this.panels.earlyTimingZone.style.backgroundColor = tupleToRgbaString(Colors.DARK_RED);
+				this.panels.perfectTimingZone.style.backgroundColor = tupleToRgbaString(Colors.DARK_GREEN);
+				this.panels.lateTimingZone.style.backgroundColor = tupleToRgbaString(Colors.RED);
+			}
+		} else {
+			// Scroll
+			this.panels.scrollLateZone1.style.width = `${tickPosition}%`;
+			this.panels.scrollLateZone2.style.width = `${100 - tickPosition}%`;
+		}
+
+		// Update jump timing labels
+		if (this.bufferedJumpingEnabled) {
+			this.panels.earlyLabel.text = jumpTiming < 0 ? jumpTiming : 0;
+		}
+
+		this.panels.lateLabel.text = jumpTiming > 0 ? jumpTiming : 0;
 
 		// Display perfect jump percent
 		if (perfPercent < 0) {

--- a/scripts/hud/jump-timing.ts
+++ b/scripts/hud/jump-timing.ts
@@ -18,7 +18,8 @@ class JumpTimingHandler {
 		earlyLabel: $<Label>('#JumpEarlyLabel'),
 		lateLabel: $<Label>('#JumpLateLabel'),
 		earlyBarProgress: $<Panel>('#JumpEarlyBar_Left'),
-		lateBarProgress: $<Panel>('#JumpLateBar_Left')
+		lateBarProgress: $<Panel>('#JumpLateBar_Left'),
+		perfPercentLabel: $<Label>('#JumpPerfPercentLabel')
 	};
 
 	perfWindow: number;
@@ -46,7 +47,7 @@ class JumpTimingHandler {
 				{
 					event: 'JumpTimingDataUpdate',
 					panel: this.panels.container,
-					callback: (jumpTiming) => this.onJumpTimingUpdate(jumpTiming)
+					callback: (jumpTiming, perfPercent) => this.onJumpTimingUpdate(jumpTiming, perfPercent)
 				}
 			]
 		});
@@ -76,7 +77,10 @@ class JumpTimingHandler {
 		}
 	}
 
-	onJumpTimingUpdate(jumpTiming: number) {
+	onJumpTimingUpdate(jumpTiming: number, perfPercent: float) {
+		this.panels.container.visible = true;
+		this.displayStartTime = MomentumMovementAPI.GetCurrentTime();
+
 		const clampedJumpTiming = Math.max(Math.min(jumpTiming, this.maxLateTiming), -this.maxEarlyTiming);
 
 		if (this.bufferedJumpingEnabled) {
@@ -99,7 +103,12 @@ class JumpTimingHandler {
 		const lateTimingColor = Colors.RED;
 		this.panels.lateBarProgress.style.backgroundColor = tupleToRgbaString(lateTimingColor);
 
-		this.panels.container.visible = true;
-		this.displayStartTime = MomentumMovementAPI.GetCurrentTime();
+		// Display perfect jump percent
+		if (perfPercent < 0) {
+			this.panels.perfPercentLabel.visible = false;
+		} else {
+			this.panels.perfPercentLabel.visible = true;
+			this.panels.perfPercentLabel.SetDialogVariable('perf_percent', Math.round(perfPercent * 100).toString());
+		}
 	}
 }

--- a/scripts/hud/jump-timing.ts
+++ b/scripts/hud/jump-timing.ts
@@ -37,7 +37,10 @@ class JumpTimingHandler {
 
 	constructor() {
 		RegisterHUDPanelForGamemode({
-			gamemodes: GamemodeCategories.get(GamemodeCategory.BHOP), // TODO: Add stamina bhop game mode
+			gamemodes: [
+				...GamemodeCategories.get(GamemodeCategory.BHOP), // TODO: Add stamina bhop game mode
+				...GamemodeCategories.get(GamemodeCategory.CLIMB)
+			],
 			onLoad: () => this.onMapInit(),
 			events: [
 				{

--- a/styles/hud/jump-timing.scss
+++ b/styles/hud/jump-timing.scss
@@ -8,7 +8,15 @@
 		transform: translateY(34px);
 	}
 
-	&__container {
+	&__outer-container {
+		width: fit-children;
+		height: fit-children;
+		flow-children: down;
+		horizontal-align: center;
+		vertical-align: center;
+	}
+
+	&__bar-container {
 		width: fit-children;
 		height: $bhopjump-height;
 		flow-children: right;
@@ -69,5 +77,10 @@
 			horizontal-align: right;
 			padding-left: $bhopjump-padding;
 		}
+	}
+
+	&__perf-percent {
+		horizontal-align: center;
+		margin-top: 4px;
 	}
 }

--- a/styles/hud/jump-timing.scss
+++ b/styles/hud/jump-timing.scss
@@ -24,59 +24,51 @@
 		vertical-align: center;
 	}
 
-	&__bar-wrapper {
+	&__bar-tick-container {
 		width: $bhopjump-width;
-		height: $bhopjump-bar-height;
+		height: 20px;
 		vertical-align: center;
+	}
+
+	&__bar-wrapper {
+		width: 100%;
+		height: 16px;
 		border: 1px solid $white;
 		border-radius: 3px;
 		opacity: $bhopjump-opacity;
-	}
-
-	&__early {
-		width: 50%;
-		height: 100%;
-		horizontal-align: left;
-		vertical-align: center;
-		flow-children: left;
-		border-radius: 0px;
-		background-color: rgba(0, 0, 0, 0);
-
-		.ProgressBarRight {
-			background-color: $bhopjump-color-background;
-		}
-	}
-
-	&__late {
-		width: 50%;
-		height: 100%;
-		horizontal-align: right;
-		vertical-align: center;
 		flow-children: right;
-		border-radius: 0px;
-		background-color: rgba(0, 0, 0, 0);
-
-		.ProgressBarRight {
-			background-color: $bhopjump-color-background;
-		}
+		vertical-align: center;
 	}
 
 	&__text-wrapper {
-		width: fit-children;
+		width: 64px;
 		height: $bhopjump-height;
 		vertical-align: top;
 		font-size: $bhopjump-font-size;
 		font-weight: $bhopjump-font-weight;
 
 		&--early {
-			horizontal-align: left;
+			horizontal-align: right;
 			padding-right: $bhopjump-padding;
 		}
 
 		&--late {
-			horizontal-align: right;
+			horizontal-align: left;
 			padding-left: $bhopjump-padding;
 		}
+	}
+
+	&__zone {
+		height: 100%;
+		vertical-align: center;
+	}
+
+	&__tick-marker {
+		width: 2px;
+		height: 100%;
+		background-color: $white;
+		vertical-align: center;
+		visibility: collapse;
 	}
 
 	&__perf-percent {


### PR DESCRIPTION
This PR improves the appearance of the jump timing HUD and adds a text label for the perfect bhop percentage.

I didn't add a timing indicator for "near perf" buffered jumps (mom_mv_buffered_jump_near_perf_window) because I think they give too much of an advantage compared to scroll and probably won't be used in any official styles.

<img width="600" height="196" alt="image" src="https://github.com/user-attachments/assets/35c4c618-ffa5-4cca-8785-fd29feea9619" />

<img width="602" height="297" alt="image" src="https://github.com/user-attachments/assets/6e261011-85e5-46c2-a170-a49fd3f54b7c" />

poeditor: https://poeditor.com/projects/view_terms?search=JumpTiming_Label_PerfPercent&id=156379

This UI was inspired by the Stepmania judgement timing visualizer: https://user-images.githubusercontent.com/5017202/226025301-146101fe-c410-49ec-9c70-9eddb67a3fe3.png

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below
