### PR TITLE
Fix timer status JS exception entering cancel zones

### DIFF
--- a/scripts/hud/status.ts
+++ b/scripts/hud/status.ts
@@ -134,8 +134,19 @@ class HudStatusHandler {
 
 		// Use the subsegment count as the checkpoint number if checkpoints aren't ordered
 		const splits = MomentumTimerAPI.GetObservedTimerRunSplits();
-		const segment = splits.segments[majorNum - 1];
-		const checkpointNum = segment.checkpointsOrdered ? minorNum : segment.subsegments.length;
+
+		let checkpointNum: number;
+		const segment = splits.segments?.[majorNum - 1];
+		if (segment) {
+			checkpointNum = segment.checkpointsOrdered ? minorNum : segment.subsegments.length;
+		} else {
+			// If a start zone and cancel zone are very close together, it's possible that OnObservedTimerStateChange
+			// fires multiple times in one tick, first for timer starting, then for cancelling. But the splits networked
+			// to the client are the same for both, i.e. no segments, because the timer disabling cleared them.
+			// If that happens, just let checkpointNum be 1 -- the only time this should ever happen is if we just left
+			// a start zone.
+			checkpointNum = 1;
+		}
 
 		// state is TimerState.RUNNING
 		let str = '';


### PR DESCRIPTION
Closes momentum-mod/game/issues/2661

Fix for  a rare case of leaving a start zone and entering a cancel zone on same tick e.g. here:
<img width="2560" height="1440" alt="Momentum_Mod_-_DX1126,03,26,075057" src="https://github.com/user-attachments/assets/43a23e32-d525-4f18-80fb-6c41bc9ba396" />

There's maybe some other cases where a similar error could happen in `common/timer.ts` but I'm not sure and honestly don't have the brainpower at the moment to dive into the logic there.

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

