### PR TITLE
fix: Find track leaderboards on modes that don't have Normal style

### DIFF
--- a/scripts/common/leaderboard.ts
+++ b/scripts/common/leaderboard.ts
@@ -1,5 +1,7 @@
 import type { Leaderboard, MMap } from './web/types/models/models';
 import { TrackType } from './web/enums/track-type.enum';
+import { Style } from './web/enums/style.enum';
+import { GamemodeDefaultUIStyle } from './web/maps/gamemode-styles.map';
 
 export enum LeaderboardListType {
 	LOCAL = 0,
@@ -38,8 +40,12 @@ export function getTrack(
 	gamemode: Gamemode,
 	trackType: TrackType = TrackType.MAIN,
 	trackNum: number = 1,
-	style: number = 0
+	style?: Style
 ): Leaderboard | undefined {
+	if (style === undefined) {
+		style = GamemodeDefaultUIStyle.get(gamemode);
+	}
+
 	return mapData.leaderboards.find(
 		(leaderboard) =>
 			leaderboard.gamemode === gamemode &&


### PR DESCRIPTION
This fixes an issue where the tier does not display in the climb map selector entries.

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

