### PR TITLE
feat: Add volumetrics quality setting dropdown

### DIFF
--- a/layout/pages/settings/video.xml
+++ b/layout/pages/settings/video.xml
@@ -153,6 +153,14 @@
 					<Label text="#Settings_General_Disabled" value="0" id="colorcorrection0" />
 					<Label text="#Settings_General_Enabled" value="1" id="colorcorrection1" />
 				</SettingsEnumDropDown>
+				
+				<SettingsEnumDropDown text="#Settings_Render_VolumetricsQuality" onuserinputsubmit="SettingsPage.videoSettingsOnUserInputSubmit()" id="VolumetricsQualityLevel" infomessage="#Settings_Render_VolumetricsQuality_Info">
+					<Label text="#Settings_General_VeryLow" value="0" id="volumetricsqualitylevel0" />
+					<Label text="#Settings_General_Low" value="1" id="volumetricsqualitylevel1" />
+					<Label text="#Settings_General_Medium" value="2" id="volumetricsqualitylevel2" />
+					<Label text="#Settings_General_High" value="3" id="volumetricsqualitylevel3" />
+					<Label text="#Settings_General_Autodetect" value="9999999" id="volumetricqualitylevel4" />
+				</SettingsEnumDropDown>
 			</Panel>
 
 			<Panel class="settings-page__spacer" />


### PR DESCRIPTION
Adds a volumetrics quality setting dropdown to settings, for a future change to engine

### Checks

-   [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [x] All changes requested in review have been `fixup`ed into my original commits.
-   [x] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

### POEditor JSON Strings (if needed)

```json
[
	{
		"term": "Settings_Render_VolumetricsQuality",
		"definition": "Volumetrics Quality"
	},
	{
		"term": "Settings_Render_VolumetricsQuality_Info",
		"definition": "The Volumetrics Quality setting controls the resolution used to render volumetrics in the game. Higher settings increase the visual quality but can increase VRAM usage and degrade graphics performance."
	}
]
```
