### PR TITLE
fix: Prevent controls in the zoning and HUD customizer menus from taking keyboard focus

### DIFF
--- a/layout/hud/customizer.xml
+++ b/layout/hud/customizer.xml
@@ -94,7 +94,7 @@
 
 	<!-- Outer panel (full width) has no hittest, hittestchildren is controlled by C++ -->
 	<HudCustomizer class="hud-customizer" hittest="false">
-		<Panel id="CustomizerSettings" class="hud-customizer-settings" acceptsinput="true" acceptsfocus="true" tabindex="auto">
+		<Panel id="CustomizerSettings" class="hud-customizer-settings" acceptsinput="true" acceptsfocus="true" tabindex="0">
 			<Panel id="CustomizerSettingsHeader" class="hud-customizer-settings__header" draggable="true" hittest="true" hittestchildren="true">
 				<Label class="hud-customizer-settings__header__title" text="#HudCustomizer_Menu" />
 				<Image class="hud-customizer-settings__header__close" onactivate="HudCustomizerHandler.toggle(false)" src="file://{images}/close.svg" />

--- a/layout/pages/zoning/zoning.xml
+++ b/layout/pages/zoning/zoning.xml
@@ -22,7 +22,7 @@
 
 	</snippets>
 
-	<ZoneMenu class="zoning" acceptsinput="true" acceptsfocus="true" tabindex="auto">
+	<ZoneMenu class="zoning" acceptsinput="true" acceptsfocus="true" tabindex="0">
 		<Panel class="w-full">
 			<Label class="zoning__title" text="#Zoning_Menu" />
 			<Button class="button button--red h-align-right" onactivate="GameInterfaceAPI.ConsoleCommand('mom_zoning_enable 0');">


### PR DESCRIPTION
Panels in the HUD "window" by default do not try take keyboard focus when clicked. These menus were using tabindex="auto" as a hack to override this default and allow them to take focus by clicking to take away focus from a text entry. The issue is "auto" also propagates to all children, assigning them tab indexes and allowing them to take focus by clicking.

We don't want things like dropdowns opening with the enter key after being clicked once, checkboxes toggling with space after being clicked once, or the tab key invisibly cycling focus, especially when those inputs would otherwise pass through to other handlers. These problems are exacerbated in cases where the panel's configuration causes it to keep keyboard focus even when hidden (a problem that has also been fixed for these menus, via C++ changes).

Instead, set an explicit numerical tabindex to keep the focus-by-clicking behavior but without propagating anything to children.