### PR TITLE
Use download only Panorama API

### DIFF
--- a/scripts/common/maps.ts
+++ b/scripts/common/maps.ts
@@ -11,7 +11,7 @@ import { TrackType } from './web/enums/track-type.enum';
 export function handlePlayMap(mapData: MapCacheAPI.MapData, gamemodeOverride: Gamemode = null) {
 	if (!mapData.mapFileExists) {
 		// Need to download
-		$.DispatchEvent('MapSelector_TryPlayMap', mapData.staticData.id);
+		$.DispatchEvent('MapSelector_DownloadMap', mapData.staticData.id);
 		return;
 	}
 

--- a/scripts/pages/map-selector/map-entry.ts
+++ b/scripts/pages/map-selector/map-entry.ts
@@ -95,7 +95,7 @@ class MapEntryHandler {
 					label: $.Localize('#Action_DownloadMap'),
 					icon: 'file://{images}/play.svg',
 					style: 'icon-color-mid-blue',
-					jsCallback: () => $.DispatchEvent('MapSelector_TryPlayMap', mapID)
+					jsCallback: () => $.DispatchEvent('MapSelector_DownloadMap', mapID)
 				});
 			}
 		}

--- a/scripts/types-mom/events.d.ts
+++ b/scripts/types-mom/events.d.ts
@@ -27,6 +27,9 @@ interface GlobalEventNameMap {
 		gamemode: import('common/web/enums/gamemode.enum').Gamemode
 	) => void;
 
+	/** Downloads the given mapID's BSP + online zones only, without playing it once the download finishes. */
+	MapSelector_DownloadMap: (mapID: number) => void;
+
 	/** Toggles adding/removing a map to/from favorites */
 	MapSelector_ToggleMapFavorite: (mapID: number, isAdding: boolean) => void;
 


### PR DESCRIPTION
This will download the bsp/zones only and doesn't trigger autoplay.

### Checks

-   [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not
        break**
-   [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
        e.g. `feat: Add foo`, `chore: Update bar`, etc...
-   [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
-   [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code
        review
-   [ ] All changes requested in review have been `fixup`ed into my original commits.
-   [ ] Fully tokenized all my strings (no hardcoded English strings!!) and supplied
        [bulk JSON strings](https://docs.momentum-mod.org/guide/localization/#bulk-adding-terms) below

