### PR TITLE
fix(customizer): disable the ability to toggle showpos hud

### DIFF
--- a/scripts/hud/show-pos.ts
+++ b/scripts/hud/show-pos.ts
@@ -7,6 +7,7 @@ class HudShowPosHandler {
 	constructor() {
 		registerHUDCustomizerComponent($.GetContextPanel(), {
 			name: $.Localize('#Customizer_Show_Pos_Name'),
+			canDisable: false,
 			resizeX: true,
 			resizeY: false,
 			dynamicStyles: {


### PR DESCRIPTION
Disables the toggle in customizer, it will be only controlled by cl_showpos.

hud_default.kv3 change is **not necessary** for this change, `canDisable: false` ignores the `enabled` value in the config.